### PR TITLE
Pr 02 termin schema

### DIFF
--- a/prisma/migrations/20260107113207_add_custom_dates_to_schema_item/migration.sql
+++ b/prisma/migrations/20260107113207_add_custom_dates_to_schema_item/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "schema_item" ADD COLUMN     "customEndDate" TIMESTAMP(3),
+ADD COLUMN     "customStartDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -213,6 +213,9 @@ model SchemaItem {
 
     place String?
 
+    customStartDate DateTime? // Om kursens datum börjar senare / tidigare än terminens.
+    customEndDate   DateTime? // Om kursens datum börjar senare / tidigare än terminens.
+
     maxBookings Int // Man kan väl ha en standard ärvd från course, men låta lärarna ange olika för vissa veckodagar med. Även specifika lessons, samma princip.
 
     Lessons Lesson[]

--- a/src/app/admin/courses/forms/AddCourseForm.tsx
+++ b/src/app/admin/courses/forms/AddCourseForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Flag } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -113,13 +112,6 @@ export default function AddCourseForm({ teachers }: Props) {
       <DialogContent className="overflow-y-auto max-h-[90vh]">
         <DialogHeader>
           <DialogTitle>Skapa en ny kurs</DialogTitle>
-          <div className="w-full flex items-end bg-amber-200 text-black p-2 rounded">
-            <Flag className="w-16 h-16 text-red-600" />{" "}
-            <div className="font-bold">
-              Du sätts som lärare automatiskt, så om du inte är läraren vänligen
-              logga in som rätt lärare och skapa kursen.
-            </div>
-          </div>
         </DialogHeader>
 
         <Card>

--- a/src/app/admin/courses/forms/EditCourseForm.tsx
+++ b/src/app/admin/courses/forms/EditCourseForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Flag } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -123,14 +122,6 @@ export default function EditCourseForm({ course, teachers }: Props) {
       <DialogContent className="overflow-y-auto max-h-[90vh]">
         <DialogHeader>
           <DialogTitle>Skapa en ny kurs</DialogTitle>
-
-          <div className="w-full flex items-end bg-amber-200 text-black p-2 rounded">
-            <Flag className="w-16 h-16 text-red-600" />{" "}
-            <div className="font-bold">
-              Du sätts som lärare automatiskt, så om du inte är läraren vänligen
-              logga in som rätt lärare och skapa kursen.
-            </div>
-          </div>
         </DialogHeader>
 
         <Card>

--- a/src/app/admin/courses/forms/EditCourseForm.tsx
+++ b/src/app/admin/courses/forms/EditCourseForm.tsx
@@ -64,7 +64,7 @@ export default function EditCourseForm({ course, teachers }: Props) {
       level: course.level ?? "",
       adult: course.adult,
       teacherid: course.teacherId, // fix: gör så man kan välja lärare. (select)
-      maxCustomers: course.maxBookings,
+      maxCustomers: course.maxCustomer, // fixed bug.
     },
   });
 
@@ -83,6 +83,14 @@ export default function EditCourseForm({ course, teachers }: Props) {
       (form.watch("maxbookings") as string).trim()
     ) {
       values.maxbookings = 0;
+    }
+
+    if (
+      // fix: se över detta, kanske räcker med zod när vi fixat det.
+      (form.watch("maxCustomers") as number) <= 0 ||
+      (form.watch("maxCustomers") as string).trim()
+    ) {
+      values.maxCustomers = 0;
     }
 
     const res = await editCourse(course.id, values);

--- a/src/app/admin/termin/Schema.tsx
+++ b/src/app/admin/termin/Schema.tsx
@@ -1,13 +1,15 @@
 import { Accordion } from "@/components/ui/accordion";
+import type { Termin } from "@/generated/prisma/client";
 import { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import SchemaDay from "./SchemaDay";
 
 interface SchemaProps {
   schemaItems: SchemaItemWithCourse[]; // Tar emot alla schemaItems (som har denna terminId) inkl kursdata.
+  termin: Termin;
 }
 
-export default function Schema({ schemaItems }: SchemaProps) {
+export default function Schema({ schemaItems, termin }: SchemaProps) {
   const weekdays = Object.keys(Weekday); // Hämta veckodagar från prismaschemats enum.
 
   return (
@@ -17,6 +19,7 @@ export default function Schema({ schemaItems }: SchemaProps) {
         : weekdays.map((day) => {
             return (
               <SchemaDay
+                termin={termin}
                 schemaItems={schemaItems}
                 weekday={day as Weekday}
                 weekdayIndex={weekdays.indexOf(day)}

--- a/src/app/admin/termin/Schema.tsx
+++ b/src/app/admin/termin/Schema.tsx
@@ -1,5 +1,5 @@
 import { Accordion } from "@/components/ui/accordion";
-import type { Termin } from "@/generated/prisma/client";
+import type { Course, Termin } from "@/generated/prisma/client";
 import { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import SchemaDay from "./SchemaDay";
@@ -7,9 +7,14 @@ import SchemaDay from "./SchemaDay";
 interface SchemaProps {
   schemaItems: SchemaItemWithCourse[]; // Tar emot alla schemaItems (som har denna terminId) inkl kursdata.
   termin: Termin;
+  allCourses: Course[];
 }
 
-export default function Schema({ schemaItems, termin }: SchemaProps) {
+export default function Schema({
+  schemaItems,
+  termin,
+  allCourses,
+}: SchemaProps) {
   const weekdays = Object.keys(Weekday); // Hämta veckodagar från prismaschemats enum.
 
   return (
@@ -19,6 +24,8 @@ export default function Schema({ schemaItems, termin }: SchemaProps) {
         : weekdays.map((day) => {
             return (
               <SchemaDay
+                allCourses={allCourses}
+                weekdays={weekdays}
                 termin={termin}
                 schemaItems={schemaItems}
                 weekday={day as Weekday}

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -75,6 +75,11 @@ export default async function SchemaDay({
                 <div>
                   {dbToFormTime(itm.timeStart)} - {dbToFormTime(itm.timeEnd)}
                   <br />
+                  {itm.customStartDate &&
+                    itm.customStartDate.toLocaleDateString() +
+                      " - " +
+                      itm.customEndDate?.toLocaleDateString()}{" "}
+                  <br />
                   <span className="font-bold">{getCourseName(itm.course)}</span>
                   <br />
                   <span className="font-bold">Plats: {itm.place}</span>

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -3,8 +3,8 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import type { Termin } from "@/generated/prisma/client";
 import type { Weekday } from "@/generated/prisma/enums";
-
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
 import { getCourseName } from "@/lib/tools";
@@ -14,6 +14,7 @@ interface Props {
   schemaItems: SchemaItemWithCourse[];
   weekday: Weekday;
   weekdayIndex: number;
+  termin: Termin;
 }
 
 export const veckodagar = [
@@ -51,6 +52,7 @@ export default async function SchemaDay({
   schemaItems,
   weekday,
   weekdayIndex,
+  termin,
 }: Props) {
   if (schemaItems.filter((itm) => itm.weekday === weekday).length === 0)
     return null;
@@ -75,10 +77,13 @@ export default async function SchemaDay({
                 <div>
                   {dbToFormTime(itm.timeStart)} - {dbToFormTime(itm.timeEnd)}
                   <br />
-                  {itm.customStartDate &&
-                    itm.customStartDate.toLocaleDateString() +
-                      " - " +
-                      itm.customEndDate?.toLocaleDateString()}{" "}
+                  {itm.customStartDate
+                    ? itm.customStartDate.toLocaleDateString()
+                    : termin.startDate.toLocaleDateString()}
+                  -
+                  {itm.customEndDate
+                    ? itm.customEndDate.toLocaleDateString()
+                    : termin.endDate.toLocaleDateString()}
                   <br />
                   <span className="font-bold">{getCourseName(itm.course)}</span>
                   <br />

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -3,18 +3,21 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import type { Termin } from "@/generated/prisma/client";
+import type { Course, Termin } from "@/generated/prisma/client";
 import type { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
 import { getCourseName } from "@/lib/tools";
 import DeleteSchemaItemBtn from "./components/DeleteSchemaItemBtn";
+import EditCourseToSchemaForm from "./forms/EditCourseToSchemaForm";
 
 interface Props {
   schemaItems: SchemaItemWithCourse[];
   weekday: Weekday;
   weekdayIndex: number;
   termin: Termin;
+  allCourses: Course[];
+  weekdays: string[];
 }
 
 export const veckodagar = [
@@ -53,6 +56,8 @@ export default async function SchemaDay({
   weekday,
   weekdayIndex,
   termin,
+  allCourses,
+  weekdays,
 }: Props) {
   if (schemaItems.filter((itm) => itm.weekday === weekday).length === 0)
     return null;
@@ -90,6 +95,12 @@ export default async function SchemaDay({
                   <span className="font-bold">Plats: {itm.place}</span>
                 </div>
                 <div>
+                  <EditCourseToSchemaForm
+                    allCourses={allCourses}
+                    weekdays={weekdays}
+                    termin={termin}
+                    schemaItem={itm}
+                  />
                   <DeleteSchemaItemBtn itemId={itm.id} />
                 </div>
               </div>

--- a/src/app/admin/termin/TerminItem.tsx
+++ b/src/app/admin/termin/TerminItem.tsx
@@ -95,7 +95,11 @@ export default async function TerminItem({ termin }: Props) {
             <AccordionItem value="item-1">
               <AccordionTrigger>Veckoschema</AccordionTrigger>
               <AccordionContent>
-                <Schema termin={termin} schemaItems={schemaItems} />
+                <Schema
+                  allCourses={allCourses}
+                  termin={termin}
+                  schemaItems={schemaItems}
+                />
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/src/app/admin/termin/TerminItem.tsx
+++ b/src/app/admin/termin/TerminItem.tsx
@@ -95,7 +95,7 @@ export default async function TerminItem({ termin }: Props) {
             <AccordionItem value="item-1">
               <AccordionTrigger>Veckoschema</AccordionTrigger>
               <AccordionContent>
-                <Schema schemaItems={schemaItems} />
+                <Schema termin={termin} schemaItems={schemaItems} />
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
@@ -67,11 +67,33 @@ export default function AddCourseToSchemaForm({
     defaultValues: {
       courseId: "",
       place: "",
+      customEndDate: termin.endDate.toLocaleDateString(),
+      customStartDate: termin.startDate.toLocaleDateString(),
       day: "MONDAY",
       timeStart: "0",
       timeEnd: "1",
     },
   });
+
+  const formatDateToInput = (date: unknown) => {
+    if (!date) {
+      return "";
+    }
+
+    if (date instanceof Date) {
+      if (Number.isNaN(date.getTime())) {
+        return "";
+      }
+      return date.toISOString().split("T")[0];
+    }
+
+    if (typeof date === "string") {
+      return date;
+    }
+
+    // Fallback: Returnera tomt
+    return "";
+  };
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -82,6 +104,8 @@ export default function AddCourseToSchemaForm({
   const router = useRouter();
 
   async function onSubmit(values: FormValues) {
+    console.log(JSON.stringify(values));
+
     const res = await addCoursetoSchema(termin.id, values);
     if (res.success) {
       toast.success(res.msg);
@@ -217,6 +241,48 @@ export default function AddCourseToSchemaForm({
 
                       <FormControl>
                         <Input type="time" step="300" {...field} className="" />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customStartDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Start datum</FormLabel>
+
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={formatDateToInput(field.value)}
+                          onChange={field.onChange}
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customEndDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Slut datum</FormLabel>
+
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={formatDateToInput(field.value)}
+                          onChange={field.onChange}
+                        />
                       </FormControl>
 
                       <FormMessage />

--- a/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import type z from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Course, SchemaItem, Termin } from "@/generated/prisma/client";
+import { editCourseInSchema } from "@/lib/actions/admin";
+import { dbToFormTime } from "@/lib/time-convert";
+import { getCourseName } from "@/lib/tools";
+import { adminAddCourseToSchemaSchema } from "@/validations/adminforms";
+import { veckodagar } from "../SchemaDay";
+
+const formSchema = adminAddCourseToSchemaSchema;
+type FormValues = z.infer<typeof adminAddCourseToSchemaSchema>;
+
+interface Props {
+  termin: Termin;
+  allCourses: Course[];
+  weekdays: string[];
+  schemaItem: SchemaItem;
+}
+
+export default function EditCourseToSchemaForm({
+  termin,
+  allCourses,
+  weekdays,
+  schemaItem,
+}: Props) {
+  const getInitialValues = useCallback(
+    () => ({
+      courseId: schemaItem.courseId,
+      place: schemaItem.place ?? "",
+      customEndDate: schemaItem.customEndDate
+        ? schemaItem.customEndDate.toISOString().split("T")[0]
+        : termin.endDate.toISOString().split("T")[0],
+      customStartDate: schemaItem.customStartDate
+        ? schemaItem.customStartDate.toISOString().split("T")[0]
+        : termin.startDate.toISOString().split("T")[0],
+      day: schemaItem.weekday,
+      timeStart: dbToFormTime(schemaItem.timeStart),
+      timeEnd: dbToFormTime(schemaItem.timeEnd),
+    }),
+    [schemaItem, termin],
+  );
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: getInitialValues(),
+  });
+
+  //   const form = useForm<FormValues>({
+  //     resolver: zodResolver(formSchema),
+  //     defaultValues: {
+  //       courseId: schemaItem.courseId,
+  //       place: schemaItem.place ?? "",
+  //       customEndDate: schemaItem.customEndDate
+  //         ? schemaItem.customEndDate.toISOString().split("T")[0]
+  //         : termin.endDate.toISOString().split("T")[0],
+  //       customStartDate: schemaItem.customStartDate
+  //         ? schemaItem.customStartDate.toISOString().split("T")[0]
+  //         : termin.startDate.toISOString().split("T")[0],
+  //       day: schemaItem.weekday,
+  //       timeStart: dbToFormTime(schemaItem.timeStart),
+  //       timeEnd: dbToFormTime(schemaItem.timeEnd),
+  //     },
+  //   });
+
+  const formatDateToInput = (date: unknown) => {
+    if (!date) {
+      return "";
+    }
+
+    if (date instanceof Date) {
+      if (Number.isNaN(date.getTime())) {
+        return "";
+      }
+      return date.toISOString().split("T")[0];
+    }
+
+    if (typeof date === "string") {
+      return date;
+    }
+
+    // Fallback: Returnera tomt
+    return "";
+  };
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(getInitialValues());
+    }
+  }, [isOpen, form, getInitialValues]);
+
+  const router = useRouter();
+
+  async function onSubmit(values: FormValues) {
+    console.log(JSON.stringify(values));
+
+    const res = await editCourseInSchema(termin.id, schemaItem.id, values);
+    if (res.success) {
+      toast.success(res.msg);
+      setIsOpen(false);
+      router.refresh();
+    } else {
+      toast.error(res.msg);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
+      <DialogTrigger asChild>
+        <Button variant={"default"} className="bg-blue-500 cursor-pointer mb-3">
+          Ändra
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="overflow-y-auto max-h-[90vh]">
+        <DialogHeader>
+          <DialogTitle>Ändra kurstillfället i veckoschemat</DialogTitle>
+          <DialogDescription>
+            Ange vilken veckodag samt mellan vilka tider du vill lägga in
+            tillfället. Tillfället blir då{" "}
+            <span className="bold">bokningsbart</span> av kunder som köpt
+            tillgång till kursen.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Ändra kurstillfället i {termin.name}.</CardTitle>
+            <CardDescription></CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="space-y-2 p-2 rounded-xl"
+              >
+                <FormField
+                  control={form.control}
+                  name="courseId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Kurs</FormLabel>
+                      <Select
+                        defaultValue={field.value || ""}
+                        onValueChange={
+                          (value) =>
+                            field.onChange(value === "none" ? undefined : value) // kan ju ha med none ifall vi vill kunna göra så, why not. Dock är detta req så nja.
+                        }
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Välj kurs" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectGroup>
+                            <SelectLabel>Välj kurs</SelectLabel>
+                            {allCourses.map((c) => (
+                              <SelectItem key={c.id} value={c.id}>
+                                {getCourseName(c)}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="day"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Veckodag</FormLabel>
+                      <Select
+                        defaultValue={field.value || ""}
+                        onValueChange={
+                          (value) =>
+                            field.onChange(value === "none" ? undefined : value) // kan ju ha med none ifall vi vill kunna göra så, why not. Dock är detta req så nja.
+                        }
+                      >
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue placeholder="Välj kurs" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectGroup>
+                            <SelectLabel>Välj dag</SelectLabel>
+                            {weekdays.map((c, i) => (
+                              <SelectItem key={c} value={c}>
+                                {veckodagar[i]}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="timeStart"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Start-tid</FormLabel>
+
+                      <FormControl>
+                        <Input type="time" step="300" {...field} className="" />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="timeEnd"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Slut-tid</FormLabel>
+
+                      <FormControl>
+                        <Input type="time" step="300" {...field} className="" />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customStartDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Start datum</FormLabel>
+
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={formatDateToInput(field.value)}
+                          onChange={field.onChange}
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customEndDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Slut datum</FormLabel>
+
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={formatDateToInput(field.value)}
+                          onChange={field.onChange}
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="place"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Plats</FormLabel>
+
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <Button type="submit" className="w-full">
+                  Ändra
+                </Button>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+
+        <DialogFooter className="sm:justify-start">
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -434,6 +434,108 @@ export async function addCoursetoSchema(
 }
 
 /**
+ * Flyttar en kurs i en termins schema och genererar automatiskt alla lektionstillfällen (tar bort de gamla)
+ * * Funktionen utför följande steg:
+ * 1. Validerar indata och kontrollerar att kursen existerar.
+ * 2. Uppdaterar ett `SchemaItem` som fungerar som en veckomall för kursen.
+ * 3. Tar bort aööa öesspms. sedam anropar `createLessons` för att generera faktiska `Lesson`-poster för varje aktuell
+ * veckodag mellan terminens start- och slutdatum.
+ * 4. Om inga lektioner kan skapas (t.ex. om terminen är för kort) rullas skapandet
+ * av schemaposten tillbaka för att undvika inkonsistent data.
+ * * @param terminId - ID för den termin där kursen ska läggas till.
+ * @param schemaItemId - ID för det schemaItem som skall ändras.
+ * @param formData - Validerad data innehållande kurs-ID, plats, veckodag samt start- och sluttid.
+ * @returns Ett objekt med framgångsstatus och ett beskrivande meddelande om hur många lektioner som skapades.
+ * @auth Admin
+ */
+export async function editCourseInSchema(
+  terminId: string,
+  schemaItemId: string,
+  formData: z.infer<typeof adminAddCourseToSchemaSchema>,
+): Promise<{ success: boolean; msg: string }> {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, msg: "No permission." };
+
+  try {
+    const validated = await adminAddCourseToSchemaSchema.parseAsync(formData);
+    const getCourse = await prisma.course.findUnique({
+      where: { id: validated.courseId },
+    });
+    if (!getCourse) throw new Error("Course was not found.");
+
+    const termin = await prisma.termin.findUnique({ where: { id: terminId } });
+    if (!termin) throw new Error("No termin.");
+
+    // Datum-tvätt
+    const inputStartDate = validated.customStartDate
+      ? new Date(validated.customStartDate)
+      : null;
+    const inputEndDate = validated.customEndDate
+      ? new Date(validated.customEndDate)
+      : null;
+
+    const finalStartDate =
+      inputStartDate && inputStartDate.getTime() === termin.startDate.getTime()
+        ? null
+        : inputStartDate;
+    const finalEndDate =
+      inputEndDate && inputEndDate.getTime() === termin.endDate.getTime()
+        ? null
+        : inputEndDate;
+
+    // Kör allt i en transaktion så vi inte förstör något om createLessons misslyckas
+    const result = await prisma.$transaction(async (tx) => {
+      const updatedSchemaItem = await tx.schemaItem.update({
+        where: { id: schemaItemId },
+        data: {
+          terminId,
+          place: validated.place,
+          courseId: validated.courseId,
+          maxBookings: getCourse?.maxBookings,
+          timeStart: formToDbDate(validated.timeStart),
+          timeEnd: formToDbDate(validated.timeEnd),
+          customEndDate: finalEndDate,
+          customStartDate: finalStartDate,
+          weekday: validated.day as Weekday,
+        },
+        include: { course: true, termin: true },
+      });
+
+      // Ta bort gamla lektioner för detta schemaItem
+      await tx.lesson.deleteMany({
+        where: { schemaItemId: updatedSchemaItem.id },
+      });
+
+      return updatedSchemaItem;
+    });
+
+    // Skapa de nya lektionerna
+    const lessons = await createLessons(schemaItemId);
+
+    if (!lessons.success) {
+      // Istället för att radera schemaItem vid EDIT, kastar vi bara ett fel.
+      // Admin får behålla raden men måste fixa datumen.
+      throw new Error(
+        "Kunde inte generera nya lektioner. Kontrollera dina datum.",
+      );
+    }
+
+    revalidatePath("/admin/termin");
+
+    return {
+      success: true,
+      msg: `Kursen ${result.course.name} har uppdaterats i ${result.termin.name}. ${lessons.msg}`,
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      success: false,
+      msg: e instanceof Error ? e.message : "Ett okänt fel uppstod.",
+    };
+  }
+}
+
+/**
  * Tar bort ett SchemaItem från en termin.
  * * @important På grund av databasens konfiguration (Cascade Delete) kommer detta även
  * att radera samtliga lektionstillfällen (Lessons) och tillhörande bokningar.

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -356,6 +356,8 @@ export async function addCoursetoSchema(
   if (!isAdmin) return { success: false, msg: "No permission." };
 
   try {
+    console.log("Creating!");
+
     const validated = await adminAddCourseToSchemaSchema.parseAsync(formData);
 
     const getCourse = await prisma.course.findUnique({
@@ -364,6 +366,9 @@ export async function addCoursetoSchema(
 
     if (!getCourse) throw new Error("Course was not found.");
 
+    const termin = await prisma.termin.findUnique({ where: { id: terminId } });
+
+    if (!termin) throw new Error("No termin.");
     // fix: lägg in så den kopplar terminen till kursen också?
 
     const newSchemaItem = await prisma.schemaItem.create({
@@ -374,6 +379,12 @@ export async function addCoursetoSchema(
         maxBookings: getCourse?.maxBookings,
         timeStart: formToDbDate(validated.timeStart),
         timeEnd: formToDbDate(validated.timeEnd),
+        customEndDate: validated.customEndDate
+          ? new Date(validated.customEndDate)
+          : termin.endDate,
+        customStartDate: validated.customStartDate
+          ? new Date(validated.customStartDate)
+          : termin.startDate,
         weekday: validated.day as Weekday,
       },
       include: { course: true, termin: true },
@@ -401,6 +412,7 @@ export async function addCoursetoSchema(
       msg: `Kursen ${newSchemaItem.course.name} lades till i terminen ${newSchemaItem.termin.name}. ${lessons.msg}`,
     };
   } catch (e) {
+    console.error(e);
     return { success: false, msg: JSON.stringify(e) };
   }
 }
@@ -719,7 +731,7 @@ export async function editCourse(
 
 /**
  * Genererar fysiska lektionstillfällen baserat på SchemaItem.
- * * Funktionen itererar genom varje dag mellan terminens start- och slutdatum,
+ * * Funktionen itererar genom varje dag mellan terminens start- och slutdatum (eller customStart/EndDate i schemaItem om det är satt),
  * identifierar alla datum som matchar den angivna veckodagen och skapar
  * lektionsobjekt med korrekta tidsstämplar.
  * * @param schemaItemId - ID:t för den schemamall som ska användas som underlag.
@@ -757,8 +769,12 @@ async function createLessons(
 
     const targetDay = WEEKDAY_MAP[schemaItm?.weekday]; // Få targetday som rätt nummer.
 
-    const startDate = schemaItm.termin.startDate;
-    const endDate = schemaItm.termin.endDate;
+    const startDate = schemaItm.customStartDate
+      ? schemaItm.customStartDate
+      : schemaItm.termin.startDate;
+    const endDate = schemaItm.customEndDate
+      ? schemaItm.customEndDate
+      : schemaItm.termin.endDate;
     const teacherId = schemaItm.course.teacherId;
 
     const lessonsToCreate = []; // Dessa lessions ska skapas.
@@ -820,6 +836,7 @@ async function createLessons(
       msg: `Successfully created ${result.count} lessons.`,
     };
   } catch (e) {
+    console.error(e);
     return { success: false, msg: JSON.stringify(e) };
   }
 }

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -176,20 +176,6 @@ export async function checkTerminDateChange(
   return { count: affectedBookings };
 }
 
-/**
- * Uppdaterar en befintlig termin och synkroniserar alla tillhörande lektioner och bokningar.
- * * Funktionen körs som en Prisma-transaktion och utför följande steg:
- * 1. Uppdaterar terminens namn och datumintervall.
- * 2. Identifierar bokningar som hamnar utanför det nya intervallet och återställer
- * nyttjade lektionstillfällen (remainingCount) till elevernas köp.
- * 3. Raderar lektioner som hamnar utanför det nya intervallet (med tillhörande bokningar).
- * 4. Genererar automatiskt nya lektioner för eventuella nya datum som tillkommit i intervallet,
- * baserat på terminens befintliga SchemaItems (veckomallar).
- * * @param id - Det unika ID:t för terminen som ska redigeras.
- * @param formData - Validerad data från formuläret (namn, startdatum, slutdatum).
- * @returns Ett objekt med success-status och ett beskrivande meddelande till användaren.
- * @auth Admin
- */
 export async function editTermin(
   id: string,
   formData: z.infer<typeof adminAddTerminSchema>,
@@ -213,29 +199,7 @@ export async function editTermin(
         },
       });
 
-      // 2. Hantera bokningar som hamnar utanför de nya datumen (Återbetalning). fix: klippkortslogik!
-      const affectedBookings = await tx.booking.findMany({
-        where: {
-          lesson: {
-            terminId: id,
-            OR: [
-              { startTime: { lt: newStartDate } },
-              { startTime: { gt: newEndDate } },
-            ],
-          },
-        },
-        select: { id: true, purchaseItemId: true },
-      });
-
-      // Ge tillbaka klipp till alla drabbade elever. (fix klippkortslogik)
-      for (const booking of affectedBookings) {
-        await tx.purchaseItem.update({
-          where: { id: booking.purchaseItemId },
-          data: { remainingCount: { increment: 1 } },
-        });
-      }
-
-      // 3. Hämta alla schemaItems för att synka lektioner
+      // 2. Hämta alla schemaItems för att synka lektioner
       const schemaItems = await tx.schemaItem.findMany({
         where: { terminId: id },
         include: {
@@ -244,17 +208,45 @@ export async function editTermin(
         },
       });
 
-      // 4. Städa bort lektioner som nu ligger utanför intervallet
-      // (Bokningarna raderas här pga Cascade Delete, klippen är redan återställda ovan). fix: klippkort!
-      await tx.lesson.deleteMany({
-        where: {
-          terminId: id,
-          OR: [
-            { startTime: { lt: newStartDate } },
-            { startTime: { gt: newEndDate } },
-          ],
-        },
-      });
+      // 3. Hantera bokningar och klippkort som hamnar utanför de nya tidsramarna
+      for (const item of schemaItems) {
+        const validStart = item.customStartDate || newStartDate;
+        const validEnd = item.customEndDate || newEndDate;
+
+        const affectedBookings = await tx.booking.findMany({
+          where: {
+            lesson: {
+              schemaItemId: item.id,
+              OR: [
+                { startTime: { lt: validStart } },
+                { startTime: { gt: validEnd } },
+              ],
+            },
+          },
+          select: { id: true, purchaseItemId: true },
+        });
+
+        // Återställ klipp/lektioner till kontot för de som drabbas
+        for (const booking of affectedBookings) {
+          if (booking.purchaseItemId) {
+            await tx.purchaseItem.update({
+              where: { id: booking.purchaseItemId },
+              data: { remainingCount: { increment: 1 } },
+            });
+          }
+        }
+
+        // 4. Städa bort lektioner som nu ligger utanför intervallet för denna specifika kurs
+        await tx.lesson.deleteMany({
+          where: {
+            schemaItemId: item.id,
+            OR: [
+              { startTime: { lt: validStart } },
+              { startTime: { gt: validEnd } },
+            ],
+          },
+        });
+      }
 
       // 5. Skapa nya lektioner för de datum som tillkommit
       const WEEKDAY_MAP: Record<string, number> = {
@@ -271,21 +263,26 @@ export async function editTermin(
 
       for (const item of schemaItems) {
         const targetDay = WEEKDAY_MAP[item.weekday];
-        const currentDate = new Date(newStartDate.getTime());
+
+        // Här används de nya datumen eller kursens egna specialdatum
+        const actualStart = item.customStartDate || newStartDate;
+        const actualEnd = item.customEndDate || newEndDate;
+
+        const currentDate = new Date(actualStart.getTime());
 
         const startHours = item.timeStart.getHours();
         const startMinutes = item.timeStart.getMinutes();
         const endHours = item.timeEnd.getHours();
         const endMinutes = item.timeEnd.getMinutes();
 
-        while (currentDate <= newEndDate) {
+        while (currentDate <= actualEnd) {
           currentDate.setHours(0, 0, 0, 0);
 
           if (currentDate.getDay() === targetDay) {
             const combinedStartTime = new Date(currentDate.getTime());
             combinedStartTime.setHours(startHours, startMinutes, 0, 0);
 
-            // Kolla om lektionen redan finns (så vi inte skapar dubbletter)
+            // Undvik dubbletter: Kolla om lektionen redan finns för detta SchemaItem
             const exists = item.Lessons.some(
               (l) => l.startTime.getTime() === combinedStartTime.getTime(),
             );
@@ -319,14 +316,18 @@ export async function editTermin(
     });
 
     revalidatePath("/admin/courses");
+    revalidatePath("/admin/termin");
 
     return {
       success: true,
-      msg: `Terminen "${result.name}" har uppdaterats. Eventuella bokningar utanför perioden har raderats och bokningar har återställts till eleverna.`,
+      msg: `Terminen "${result.name}" har uppdaterats och lektionerna har synkroniserats.`,
     };
   } catch (e) {
     console.error("Fel vid editTermin:", e);
-    return { success: false, msg: "Ett fel uppstod vid uppdatering." };
+    return {
+      success: false,
+      msg: "Ett fel uppstod vid uppdatering av terminen.",
+    };
   }
 }
 // fix: klippkort
@@ -371,6 +372,25 @@ export async function addCoursetoSchema(
     if (!termin) throw new Error("No termin.");
     // fix: lägg in så den kopplar terminen till kursen också?
 
+    // Förbered datumen och kolla om de matchar terminen
+    const inputStartDate = validated.customStartDate
+      ? new Date(validated.customStartDate)
+      : null;
+    const inputEndDate = validated.customEndDate
+      ? new Date(validated.customEndDate)
+      : null;
+
+    // Om datumet finns och är exakt samma som terminens -> sätt till null
+    const finalStartDate =
+      inputStartDate && inputStartDate.getTime() === termin.startDate.getTime()
+        ? null
+        : inputStartDate;
+
+    const finalEndDate =
+      inputEndDate && inputEndDate.getTime() === termin.endDate.getTime()
+        ? null
+        : inputEndDate;
+
     const newSchemaItem = await prisma.schemaItem.create({
       data: {
         terminId,
@@ -379,12 +399,8 @@ export async function addCoursetoSchema(
         maxBookings: getCourse?.maxBookings,
         timeStart: formToDbDate(validated.timeStart),
         timeEnd: formToDbDate(validated.timeEnd),
-        customEndDate: validated.customEndDate
-          ? new Date(validated.customEndDate)
-          : termin.endDate,
-        customStartDate: validated.customStartDate
-          ? new Date(validated.customStartDate)
-          : termin.startDate,
+        customEndDate: finalEndDate,
+        customStartDate: finalStartDate,
         weekday: validated.day as Weekday,
       },
       include: { course: true, termin: true },

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -80,7 +80,8 @@ export async function adminGetOrder(orderId: string) {
 }
 
 // fix: klippkort.
-// kör denna när man accepterar ordern.
+// // kör denna när man accepterar ordern.
+// fix: Om det bara är 1 kurs, boka alla tillfällen.
 export async function createPurchaseFromOrder(orderId: string) {
   await requireAdmin();
 
@@ -157,6 +158,19 @@ export async function createPurchaseFromOrder(orderId: string) {
       await Promise.all(itemPromises);
       purchaseResults.push(purchase.id);
     }
+
+    // okej så vi bokar väl in automatiskt då:
+    const courseIds = order.orderItems.flatMap((oi) =>
+      oi.product.courses.map((pc) => pc.courseId),
+    );
+
+    const _lessons = await tx.lesson.findMany({
+      where: {
+        courseId: { in: courseIds },
+        // Valfritt: Boka bara in på framtida lektioner? Japp, inget annat makes sense för mig atm.
+        startTime: { gte: new Date() },
+      },
+    });
 
     return {
       success: true,

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -15,6 +15,9 @@ export const adminAddCourseToSchemaSchema = z
 
     timeEnd: z.string().min(1).regex(TIME_REGEX, "HH:MM."),
 
+    customStartDate: z.string().optional(),
+    customEndDate: z.string().optional(),
+
     day: z.enum(Object.values(Weekday) as [string, ...string[]]),
   })
   .refine(


### PR DESCRIPTION
- Bättre kontroll över schemaitems som startar/slutar utanför terminen.

- Custom start/end dates för schemaItem.
- Edit-form för schemaItem + UI-uppdateringar i termin-vyn.
- Små logikfixar i admin-actions.

- Inkluderar migration för schemaItem-datum.
