### PR TITLE
Pr 08 termin cleanup

### DIFF
--- a/prisma/migrations/20260116121009_removed_type_from_product_on_course/migration.sql
+++ b/prisma/migrations/20260116121009_removed_type_from_product_on_course/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `terminId` on the `product` table. All the data in the column will be lost.
+  - You are about to drop the column `type` on the `product_on_course` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "product" DROP CONSTRAINT "product_terminId_fkey";
+
+-- DropIndex
+DROP INDEX "product_terminId_idx";
+
+-- AlterTable
+ALTER TABLE "product" DROP COLUMN "terminId";
+
+-- AlterTable
+ALTER TABLE "product_on_course" DROP COLUMN "type";

--- a/prisma/migrations/20260116124419_removed_course_on_termin/migration.sql
+++ b/prisma/migrations/20260116124419_removed_course_on_termin/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `course_on_termin` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "course_on_termin" DROP CONSTRAINT "course_on_termin_courseId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "course_on_termin" DROP CONSTRAINT "course_on_termin_terminId_fkey";
+
+-- DropTable
+DROP TABLE "course_on_termin";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,9 +177,6 @@ model Termin {
 
   lessons Lesson[] // Vilka tillfällen är kopplade till terminen
 
-  // Denna verkar hittils iaf inte vara nödvändig: fix
-  courses CourseOnTermin[] // Så detta läggs till så fort man lägger in kursen i veckoschemat i en termin. Så håll koll på om man tar bort också. 
-
   createdAt DateTime  @default(now())
   updatedAt DateTime @updatedAt
 
@@ -250,8 +247,6 @@ model Course {
 
   purchaseItems PurchaseItem[]
 
-  terms CourseOnTermin[] // Vilka terminer kursen är inlagd på! Behövs denna?
-
   level String? 
 
   minAge Int?
@@ -263,19 +258,6 @@ model Course {
 
 }
 
-
-// Denna tabell kopplar alltså kurs till termin, du kan ha samma kurs på flera terminer.
-model CourseOnTermin {
-    courseId String
-    course   Course @relation(fields: [courseId], references: [id])
-    terminId String
-    termin   Termin @relation(fields: [terminId], references: [id])
-
-    // isActive Boolean @default(true)
-
-    @@id([courseId, terminId])
-    @@map("course_on_termin")
-}
 
 
 // Så här finns informationen om vilken/vilka kurser man kan boka med produkten, och i vilken termin (om specificerat). 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -338,7 +338,6 @@ model ProductOnCourse {
   product  Product @relation(fields: [productId], references: [id])
 
   lessonsIncluded Int //Hur många lektioner av denna kurs ingår i produkten?
-  type ProductType @default(COURSE) // Tror det är bra att ha den här med.
   unlimited Boolean @default(false) // fix: Lagt till denna för obegränsad tillgång till viss kurs.
 
   @@id([courseId, productId])

--- a/src/app/admin/AdminLessonCal.tsx
+++ b/src/app/admin/AdminLessonCal.tsx
@@ -234,7 +234,22 @@ export default function AdminLessonCal({
                       </div>
                       <Accordion type="single" collapsible className="mt-3">
                         <AccordionItem value={`lesson-${lesson.id}`}>
-                          <AccordionTrigger>Hantera</AccordionTrigger>
+                          <AccordionTrigger>
+                            {lesson.course.name}{" "}
+                            {startTime.toLocaleDateString("sv-SE", {
+                              day: "2-digit",
+                              month: "short",
+                            })}{" "}
+                            {startTime.toLocaleTimeString("sv-SE", {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            })}
+                            {" - "}
+                            {endTime.toLocaleTimeString("sv-SE", {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                            })}
+                          </AccordionTrigger>
                           <AccordionContent>
                             <LessonItemForm lesson={lesson} />
                           </AccordionContent>

--- a/src/app/admin/courses/page.tsx
+++ b/src/app/admin/courses/page.tsx
@@ -53,9 +53,12 @@ export default async function Page({
     <div className="p-4 md:p-6 space-y-6">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Kurser</h1>
-          <p className="text-muted-foreground">
-            Hantera kursdetaljer, produkter och lektioner.
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+            Kurser
+          </h1>
+          <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+            Skapa och uppdatera kurser, koppla produkter och hantera
+            lektionstillfällen.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/src/app/admin/omoss/page.tsx
+++ b/src/app/admin/omoss/page.tsx
@@ -1,3 +1,14 @@
 export default function Page() {
-  return <div>Hantera om oss sidan</div>;
+  return (
+    <div className="p-4 md:p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+          Om oss
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+          Redigera text, bilder och kontaktinfo på Om oss-sidan.
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -102,8 +102,15 @@ export default async function Page({
   }
 
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Ordrar</h1>
+    <div className="p-4 md:p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+          Ordrar
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+          Granska inkomna ordrar, godkänn betalning och följ status.
+        </p>
+      </div>
       <OrdersView
         orders={orders}
         defaultStatus={status}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -39,9 +39,12 @@ export default async function Page() {
   return (
     <div className="p-4 md:p-6 space-y-6">
       <div>
-        <h1 className="text-2xl font-bold">Admin - Översikt</h1>
-        <p className="text-muted-foreground">
-          Här ser du alla lektioner och kan hantera närvaro samt meddelanden.
+        <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+          Admin - Översikt
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+          Överblick av alla lektioner med snabb åtkomst till närvaro och
+          meddelanden.
         </p>
       </div>
 

--- a/src/app/admin/products/components/AddCoursesToProductForm.tsx
+++ b/src/app/admin/products/components/AddCoursesToProductForm.tsx
@@ -74,7 +74,7 @@ export default function AddCoursesToProductForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
       productId: productId,
-      lessonsIncluded: 0,
+      lessonsIncluded: isClip ? 0 : 1,
       unlimited: false,
       courseId: "",
     },
@@ -107,27 +107,48 @@ export default function AddCoursesToProductForm({
 
   useEffect(() => {
     // Prefilla om kursen redan finns kopplad till produkten.
+
     const checkIsInProd = async () => {
       const inProd = await isCourseInProduct(selCourse, productId);
+
       setIsInProd(inProd.found);
 
       if (inProd.found) {
-        form.setValue("lessonsIncluded", inProd.lessonsIncluded);
+        form.setValue(
+          "lessonsIncluded",
+          inProd.unlimited
+            ? 0
+            : isClip
+              ? 0
+              : Math.max(1, inProd.lessonsIncluded ?? 0),
+        );
         form.setValue("unlimited", inProd.unlimited);
       } else {
-        form.setValue("lessonsIncluded", 0);
+        form.setValue("lessonsIncluded", isClip ? 0 : 1);
         form.setValue("unlimited", false);
       }
     };
     checkIsInProd();
-  }, [selCourse, productId, form.setValue]);
+  }, [selCourse, productId, form.setValue, isClip]);
 
   useEffect(() => {
     if (!isOpen) form.reset();
   }, [isOpen, form]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const res = await addCourseToProduct(values);
+    //Kollar här ifall det är unlimited först, isåfall sätt antal tillfällen till 0, sen annars om det är ett klippkort, sätt det då också till 0, och annars minst 1 (ologisk att ha kurser i produkter utan minst 1 tillfälle att kunna boka.)
+    const sanitizedValues = {
+      ...values,
+      isClipcard: isClip,
+      lessonsIncluded:
+        values.unlimited === true
+          ? 0
+          : isClip
+            ? 0
+            : Math.max(1, values.lessonsIncluded ?? 0),
+    };
+
+    const res = await addCourseToProduct(sanitizedValues);
     if (res.success) {
       toast.success(res.msg);
       //   setIsOpen(false);
@@ -261,13 +282,14 @@ export default function AddCoursesToProductForm({
                         <FormControl>
                           <Input
                             type="number"
-                            min="0"
+                            min={form.watch("isClipcard") === true ? 0 : 1}
                             step="1"
                             {...field}
                             value={
-                              field.value === undefined
-                                ? ""
-                                : String(field.value)
+                              field.value === undefined ||
+                              form.watch("isClipcard") === true
+                                ? 0
+                                : Number(field.value)
                             }
                           />
                         </FormControl>
@@ -276,6 +298,14 @@ export default function AddCoursesToProductForm({
                       </FormItem>
                     )}
                   />
+                )}
+                {isClip && (
+                  <FormItem>
+                    <FormLabel>Antal tillfällen:</FormLabel>
+                    <div className="text-sm text-muted-foreground">
+                      (Klippkort)
+                    </div>
+                  </FormItem>
                 )}
 
                 <Button type="submit" variant={"secondary"} className="w-full">

--- a/src/app/admin/products/components/ProductFilters.tsx
+++ b/src/app/admin/products/components/ProductFilters.tsx
@@ -27,7 +27,7 @@ export default function ProductFilters({ terminer }: Props) {
   const pathname = usePathname();
   const { replace } = useRouter();
 
-  // URL:en är källan till sanningen för filter/sortering.
+  // Läs in vad som redan är satt:
   const currentType = searchParams.get("type") ?? "all";
   const currentTermin = searchParams.get("termin") ?? "all";
   const currentSort = searchParams.get("sort") ?? "name_asc";
@@ -35,11 +35,11 @@ export default function ProductFilters({ terminer }: Props) {
   const updateParam = useCallback(
     (key: string, value: string) => {
       const params = new URLSearchParams(searchParams);
-      // "all" => ta bort parametern för rena, delbara URL:er.
-      const nextValue = value === "all" ? "" : value;
-      const prevValue = params.get(key) ?? "";
-      if (prevValue === nextValue) return;
+      const nextValue = value === "all" ? "" : value; // All är ju inget filter, därmed "".
+      const prevValue = params.get(key) ?? ""; // Läs in förra värdet för att jämföra.
+      if (prevValue === nextValue) return; // Ingen ändring!
 
+      // nextValue och prevValue kan ju vara tomma (om all), så antingen set eller delete.
       if (nextValue) {
         params.set(key, nextValue);
       } else {

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -26,7 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { getAllProducts, getTermin, isAdminRole } from "@/lib/actions/admin";
+import { getAllProducts, getTerminer, isAdminRole } from "@/lib/actions/admin";
 import AddProductForm from "./components/AddProductForm";
 import ProductFilters from "./components/ProductFilters";
 import ProductItem from "./components/ProductItem";
@@ -74,16 +74,19 @@ export default async function Page({
       terminId: terminParam || undefined,
       sort,
     }),
-    getTermin(),
+    getTerminer(),
   ]);
 
   return (
     <div className="p-4 md:p-6 space-y-6">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight">Produkter</h1>
-          <p className="text-muted-foreground">
-            Hantera dina produkter och paket.
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+            Produkter
+          </h1>
+          <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+            Skapa, uppdatera och ta bort produkter samt koppla kurser, terminer
+            och priser.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -15,7 +15,9 @@ Tidigare:
 - Filter/sort hanterades klient-side med extra state.
 
 Resultat:
-- Snabbare första render, mindre klientlogik och färre onodiga requests.
+- Snabbare, mindre klientlogik och färre onodiga requests.
+
+Jag har också gjort om denna sida så istället för kort så är det en tabell, ser betydligt bättre ut och mer överskådligt för admin.
 
 */
 import { redirect } from "next/navigation";

--- a/src/app/admin/start/page.tsx
+++ b/src/app/admin/start/page.tsx
@@ -1,3 +1,14 @@
 export default function Page() {
-  return <div>Hantera startsidan</div>;
+  return (
+    <div className="p-4 md:p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+          Startsidan
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+          Uppdatera innehåll, kampanjer och layout för startsidan.
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/src/app/admin/students/page.tsx
+++ b/src/app/admin/students/page.tsx
@@ -72,8 +72,15 @@ export default async function StudentsPage(props: {
 
   return (
     <div className="p-4 space-y-6">
-      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
-        <h1 className="text-2xl font-bold">Deltagarlista & Elever</h1>
+      <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
+        <div>
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+            Deltagarlista & Elever
+          </h1>
+          <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+            Sök deltagare, se köp per termin och uppdatera kontaktuppgifter.
+          </p>
+        </div>
 
         <form className="flex flex-col sm:flex-row gap-2 w-full md:w-auto">
           <Input

--- a/src/app/admin/students/page.tsx
+++ b/src/app/admin/students/page.tsx
@@ -47,18 +47,32 @@ export default async function StudentsPage(props: {
       },
       purchases: {
         include: {
-          product: {
-            include: { termin: true },
-          },
+          product: true,
           PurchaseItems: {
             include: {
-              course: true,
+              course: {
+                include: {
+                  schemaItems: {
+                    include: { termin: true }, // Hämtar terminer via schemaItems.
+                  },
+                },
+              },
             },
           },
         },
         where: terminId
-          ? {
-              product: { terminId },
+          ? // Här måste vi istället hämta alla terminer som kursen finns i. (den kan finnas i flera.).
+            // terminId är borta i modellen product i prisma-schemat.
+            {
+              PurchaseItems: {
+                some: {
+                  course: {
+                    schemaItems: {
+                      some: { terminId },
+                    },
+                  },
+                },
+              },
             }
           : undefined,
       },
@@ -176,9 +190,30 @@ export default async function StudentsPage(props: {
                                   {item.course.name}
                                 </div>
                                 <div className="text-[10px] text-muted-foreground flex justify-between mt-1">
-                                  <span>
-                                    {pur.product.termin?.name || "Ingen termin"}
-                                  </span>
+                                  <div className="flex flex-wrap gap-1">
+                                    {
+                                      /* Här hämtas istället alla terminen som kursen finns i. */
+                                      Array.from(
+                                        new Set(
+                                          item.course.schemaItems
+                                            .map((s) => s.termin?.name)
+                                            .filter(Boolean),
+                                        ),
+                                      ).map((name) => (
+                                        <span
+                                          key={name}
+                                          className="rounded border border-border bg-muted/30 px-1.5 py-0.5 text-[10px] text-foreground"
+                                        >
+                                          {name}
+                                        </span>
+                                      ))
+                                    }
+                                    {item.course.schemaItems.length === 0 && (
+                                      <span className="text-[10px] text-muted-foreground">
+                                        Ingen termin
+                                      </span>
+                                    )}
+                                  </div>
                                   <span
                                     className={
                                       item.remainingCount > 0

--- a/src/app/admin/termin/page.tsx
+++ b/src/app/admin/termin/page.tsx
@@ -1,5 +1,5 @@
 import type { Termin } from "@/generated/prisma/client";
-import { getTermin } from "@/lib/actions/admin";
+import { getTerminer } from "@/lib/actions/admin";
 import { HideOldCheckbox } from "./components/HideOldCheckbox";
 import AddTerminForm from "./forms/AddTerminForm";
 import TerminItem from "./TerminItem";
@@ -15,7 +15,7 @@ export default async function Page({
 }: {
   searchParams: Promise<{ hide?: string }>;
 }) {
-  const terminer = await getTermin();
+  const terminer = await getTerminer();
 
   const params = await searchParams;
   const hide = params.hide || "";

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -1199,7 +1199,9 @@ export async function getAllProducts(options?: {
       courses: options?.terminId
         ? {
             some: {
-              course: { terms: { some: { terminId: options.terminId } } },
+              course: {
+                schemaItems: { some: { terminId: options.terminId } },
+              },
             },
           }
         : undefined,

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -42,7 +42,7 @@ export async function isAdminRole(): Promise<boolean> {
 }
 
 // Inser att det är svengelska. Men men.
-export async function getTermin(): Promise<Termin[]> {
+export async function getTerminer(): Promise<Termin[]> {
   const isAdmin = await isAdminRole();
   if (!isAdmin) return [];
 
@@ -58,11 +58,19 @@ export type SchemaItemWithCourse = SchemaItem & {
   Lessons: Lesson[];
 };
 
-// Tyo för att lista alla Lektioner inkl alla bokningar.
+// Typ för att lista alla Lektioner inkl alla bokningar.
 export type LessonWithBookings = Lesson & { bookings: Booking[] };
 
+// Lektion med kursdata för admin-översikt/kalender.
+// Used by: src/app/admin/page.tsx -> AdminLessonCal
 export type AdminLessonWithCourse = Lesson & { course: Course };
 
+// Bokning inkl deltagare (från köp) som används i admin närvaro-listor.
+// Used by:
+// - src/app/admin/courses/components/LessonAttendanceForm.tsx
+// - src/app/admin/courses/components/LessonBrowserData.tsx
+// - src/app/admin/courses/components/LessonItem.tsx
+// - src/app/admin/courses/components/LessonsBrowser.tsx
 export type BookingWithPurchaseParticipant = Prisma.BookingGetPayload<{
   include: {
     purchaseItem: {
@@ -77,10 +85,12 @@ export type BookingWithPurchaseParticipant = Prisma.BookingGetPayload<{
   };
 }>;
 
+// Denna används i admin/page för att fylla kalendern med lektioner. Inkludera course för att kunna visa vilken kurs det är, och sedan vidare kunna hantera närvaro och visa info.
 export async function getAdminLessons(): Promise<AdminLessonWithCourse[]> {
   const isAdmin = await isAdminRole();
   if (!isAdmin) return [];
 
+  // Hämtar alla lektioner med kursdata för admin-översikten.
   const lessons = await prisma.lesson.findMany({
     include: { course: true },
     orderBy: { startTime: "asc" },
@@ -110,6 +120,7 @@ export async function getSchemaItems(
   return schemaItems;
 }
 
+// Hämtar statistik i admin/termin för varje termin:
 export async function getTerminStats(terminId: string): Promise<{
   courseCount: number;
   productCount: number;
@@ -131,6 +142,7 @@ export async function getTerminStats(terminId: string): Promise<{
     return { courseCount: 0, productCount: 0, soldProductCount: 0 };
   }
 
+  // lärde mig nåt nytt här ;)
   const [productCount, soldProductCount] = await Promise.all([
     prisma.product.count({
       where: {
@@ -167,6 +179,8 @@ export async function getAllCourses(q: string = ""): Promise<Course[]> {
   return courses;
 }
 
+// Den används i LessonAttendanceForm.tsx för att hämta bokningar när man öppnar/uppdaterar närvaro...
+// Hämtar bokningar i en viss lektion, och visar vilken purchase och purcaseItem som använts, samt vem som är bokad (user eller particpant)
 export async function getBookingsFromLesson(
   lessonId: string,
 ): Promise<BookingWithPurchaseParticipant[]> {
@@ -257,6 +271,7 @@ export async function checkTerminDateChange(
   return { count: affectedBookings };
 }
 
+// så denna funktion är om man ändrar en temrin, vilket blix rätt komplext eftersom bokningar och lektioner rredan skapats och nu måste tas bort ev.
 export async function editTermin(
   id: string,
   formData: z.infer<typeof adminAddTerminSchema>,
@@ -309,11 +324,10 @@ export async function editTermin(
 
         // Återställ klipp/lektioner till kontot för de som drabbas
         for (const booking of affectedBookings) {
-          if (booking.purchaseItemId) {
-            await tx.purchaseItem.update({
-              where: { id: booking.purchaseItemId },
-              data: { remainingCount: { increment: 1 } },
-            });
+          if (!booking.purchaseItemId) continue;
+          const clipResult = await handleClips(tx, booking.purchaseItemId, 1);
+          if (!clipResult.success) {
+            throw new Error(clipResult.msg || "Clip update failed.");
           }
         }
 
@@ -345,7 +359,7 @@ export async function editTermin(
       for (const item of schemaItems) {
         const targetDay = WEEKDAY_MAP[item.weekday];
 
-        // Här används de nya datumen eller kursens egna specialdatum
+        // Här används de nya datumen eller kursens egna specialdatum.
         const actualStart = item.customStartDate || newStartDate;
         const actualEnd = item.customEndDate || newEndDate;
 
@@ -411,7 +425,6 @@ export async function editTermin(
     };
   }
 }
-// fix: klippkort
 
 /**
  * Lägger till en kurs i en termins schema och genererar automatiskt alla lektionstillfällen.
@@ -453,6 +466,8 @@ export async function addCoursetoSchema(
     if (!termin) throw new Error("No termin.");
     // fix: lägg in så den kopplar terminen till kursen också?
 
+    // Den funktionen jämför två datum bara på kalenderdag i UTC (år/månad/dag), och ignorerar tid på dygnet.
+    // Så om två datum ligger på samma UTC‑dag (oavsett klockslag) returnerar den true; annars false.
     const isSameDateUtc = (a: Date, b: Date) =>
       a.getUTCFullYear() === b.getUTCFullYear() &&
       a.getUTCMonth() === b.getUTCMonth() &&
@@ -552,6 +567,7 @@ export async function editCourseInSchema(
     const termin = await prisma.termin.findUnique({ where: { id: terminId } });
     if (!termin) throw new Error("No termin.");
 
+    // Jämför dagar oavsett tid (returner true om det är samma dagar)
     const isSameDateUtc = (a: Date, b: Date) =>
       a.getUTCFullYear() === b.getUTCFullYear() &&
       a.getUTCMonth() === b.getUTCMonth() &&
@@ -612,6 +628,7 @@ export async function editCourseInSchema(
     }
 
     revalidatePath("/admin/termin");
+    revalidatePath("/admin/courses");
 
     return {
       success: true,
@@ -769,6 +786,26 @@ export async function delCourse(
   if (!isAdmin) return { success: false, msg: "No permission." };
 
   try {
+    // Kolla först så det är okej att ta bort kursen! Om kunder har köpt tillgång till den blir det lite konstigt, och om något behöver ändras i kursen så kan de ju ändra istället..
+    // Ev fix: ha med isActive, både i kurs och kanske produkt också, istället för att ta bort kurser och produkter som inte längre är aktiva så kan man inaktivera de? För om du tar bort en kurs, försvinner de ju från gamla purchases också
+    const activePurchaseItem = await prisma.purchaseItem.findFirst({
+      where: {
+        courseId: id,
+        OR: [
+          { unlimited: true },
+          { remainingCount: { gt: 0 }, purchase: { type: { not: "CLIP" } } },
+          { purchase: { type: "CLIP", remainingCount: { gt: 0 } } },
+        ],
+      },
+      select: { id: true },
+    });
+    if (activePurchaseItem) {
+      return {
+        success: false,
+        msg: "Kursen kan inte raderas eftersom aktiva köp fortfarande har saldo.",
+      };
+    }
+
     // Hitta aktiva bokningar för denna kurs (för att återställa =))
     const bookings = await prisma.booking.findMany({
       where: {
@@ -938,14 +975,17 @@ async function createLessons(
   try {
     // Hämtar all data vi behöver.
 
-    // Behöver vi validatera någonting här? ev. fix.
-
+    // För säkerhets skull validerar vi här ocskå, även om funktionerna som anropar denna redan validerar också. Men blir säkrare:
     const schemaItm = await prisma.schemaItem.findUnique({
       where: { id: schemaItemId },
       include: { termin: true, course: true },
     });
 
     if (!schemaItm) throw new Error("schemaItm kunde inte hittas.");
+    if (!schemaItm.termin) throw new Error("Termin saknas på schemaItem.");
+    if (!schemaItm.course) throw new Error("Kurs saknas på schemaItem.");
+    if (!schemaItm.course.teacherId)
+      throw new Error("TeacherId saknas på kursen.");
 
     const WEEKDAY_MAP: Record<Weekday, number> = {
       MONDAY: 1,
@@ -965,6 +1005,11 @@ async function createLessons(
     const endDate = schemaItm.customEndDate
       ? schemaItm.customEndDate
       : schemaItm.termin.endDate;
+
+    if (startDate > endDate) {
+      throw new Error("Startdatum kan inte vara efter slutdatum.");
+    }
+
     const teacherId = schemaItm.course.teacherId;
 
     const lessonsToCreate = []; // Dessa lessions ska skapas.
@@ -974,6 +1019,14 @@ async function createLessons(
     const startMinutes = schemaItm.timeStart.getMinutes();
     const endHours = schemaItm.timeEnd.getHours();
     const endMinutes = schemaItm.timeEnd.getMinutes();
+
+    // Säkerställ att sluttid är efter starttid (på tidnivå).
+    if (
+      endHours < startHours ||
+      (endHours === startHours && endMinutes <= startMinutes)
+    ) {
+      throw new Error("Sluttid måste infalla efter starttid.");
+    }
 
     /// Så nu loopar vi igenom alla targetdays inom den perioden:
 
@@ -1107,7 +1160,7 @@ export async function editLessonItem(
 }
 
 /**
- * Hämtar samtliga produkter från databasen sorterade i alfabetisk ordning efter namn.
+ * Hämtar samtliga produkter från databasen enligt det filtret som skickas med.
  * * @returns En Promise som löser ut till en array av samtliga produkter.
  * Returnerar en tom array om den anropande användaren saknar administratörsbehörighet.
  * @auth Admin
@@ -1174,13 +1227,18 @@ export type ProdCourse = {
   lessonsIncluded: number;
 };
 
-// Så denna funktion körs om man skapar en produkt eller ändrar en produkt eller lägger in en kurs i en produkt, ändrar en kurs i en produkt eller tar bort en kurs ur en produkt.
-// Den kollar om det är ett klippkort, eller om den bara innehåller 1 kurs eller flera kurser, och avgör därefter produkttypen och ställer in det i produkten.
+// Så denna funktion körs om man skapar en produkt eller ändrar en produkt eller lägger in en kurs i en produkt, ändrar en
+//  kurs i en produkt eller tar bort en kurs ur en produkt.
+// Den kollar om det är ett klippkort, eller om den bara innehåller
+// 1 kurs eller flera kurser, och avgör därefter produkttypen och ställer in det i produkten.
 async function updateProductType(
   productId: string,
   options?: { isClip?: boolean; tx?: PrismaTx },
 ): Promise<"COURSE" | "PACK" | "CLIP"> {
-  const client = options?.tx ?? prisma; //
+  const client = options?.tx ?? prisma;
+  // utanför transaktion (t.ex. editProduct/addNewProduct) → då finns ingen tx, så den ska falla tillbaka till prisma
+  // inom transaktion (t.ex. addCourseToProduct/removeCourseInProduct) → då skickas tx för att hålla allt atomiskt.
+
   const product = await client.product.findUnique({
     where: { id: productId },
     select: {
@@ -1207,11 +1265,6 @@ async function updateProductType(
       data: { type: nextType },
     });
   }
-
-  await client.productOnCourse.updateMany({
-    where: { productId: product.id },
-    data: { type: nextType },
-  });
 
   return nextType;
 }
@@ -1313,7 +1366,6 @@ export async function createCourseProduct(
           courseId: course.id,
           unlimited: validated.unlimitedLessons ?? false,
           lessonsIncluded,
-          type: "COURSE",
         },
       });
 
@@ -1464,20 +1516,31 @@ export async function addCourseToProduct(
   try {
     const validated = await AdminProductCourseItemSchema.parseAsync(formData);
 
+    // Kolla om det redan finns en koppling:
     const isInProd = await isCourseInProduct(
       formData.courseId,
       formData.productId,
     );
 
     if (isInProd.found) {
+      // Koppling finns.
+
       await prisma.$transaction(async (tx) => {
+        // Hämta produkten
         const product = await tx.product.findUnique({
           where: { id: validated.productId },
-          select: { type: true },
+          select: { type: true }, // Ta med typ så vi kan avgöra hur vi lägger in kopplingen gällande tillfällen.
         });
+
         if (!product) throw new Error("Product not found.");
+
+        // Samma logik här, lika bra att kolla backend också :)
         const lessonsIncluded =
-          product.type === "CLIP" ? 0 : validated.lessonsIncluded;
+          product.type === "CLIP"
+            ? 0
+            : validated.unlimited === true
+              ? 0
+              : Math.max(1, validated.lessonsIncluded);
 
         await tx.productOnCourse.update({
           where: {
@@ -1501,18 +1564,23 @@ export async function addCourseToProduct(
       };
     } else {
       await prisma.$transaction(async (tx) => {
+        // Uppdatera produkttypen baserat på reglerna (se updateProductType)
         const productType = await updateProductType(validated.productId, {
           tx,
         });
 
+        // Skapa kopplingen och hantera lessons included (minst 1 om det inte är klippkort eller unlimited då ska det vara 0.)
         await tx.productOnCourse.create({
           data: {
             productId: validated.productId,
             courseId: validated.courseId,
             unlimited: validated.unlimited,
             lessonsIncluded:
-              productType === "CLIP" ? 0 : validated.lessonsIncluded,
-            type: productType,
+              productType === "CLIP"
+                ? 0
+                : validated.unlimited === true
+                  ? 0
+                  : Math.max(1, validated.lessonsIncluded),
           },
         });
       });
@@ -1650,9 +1718,7 @@ export async function countOrderItemsAndProductsCourse(
  * - purchases: Lista över genomförda köp med koppling till den köpta produkten.
  * - PurchaseItems: Specifika rader i varje köp som håller reda på:
  * - remainingCount: Hur många klipp/lektioner som finns kvar.
- * - lessonsIncluded: Det totala antalet lektioner som ingick vid köptillfället.
- * - course: Namnet på den specifika kursen som köpet avser.
- * * @usage Används främst i admin-vyn för att se en elevs saldo eller i användarens profil för att visa "X av Y lektioner kvar".
+ * * @usage Används främst i admin-vyn för att välja korrekt produkt vid admin-bokning.
  */
 export type UserPurchasesForCourse = Prisma.UserGetPayload<{
   select: {
@@ -1670,8 +1736,6 @@ export type UserPurchasesForCourse = Prisma.UserGetPayload<{
             id: true;
             remainingCount: true;
             unlimited: true;
-            lessonsIncluded: true; // Bra att ha för "X av Y" logik
-            course: { select: { name: true } }; // Hämtar namnet direkt
           };
         };
       };
@@ -1690,6 +1754,9 @@ export type UserPurchasesForCourse = Prisma.UserGetPayload<{
  * 1. Hittar användare som har MINST ett köp där `remainingCount > 0` för den valda kursen.
  * 2. Inuti sökresultatet (select) filtreras även inköpslistan så att endast de specifika
  * rader som faktiskt gäller den aktuella kursen och har saldo kvar visas.
+ * * @usedBy
+ * - src/app/admin/courses/components/LessonAttendanceForm.tsx
+ * - src/app/admin/courses/components/LessonBrowserData.tsx
  * @auth Admin
  */
 export async function getUsersWithPurchasedProductsWithCourseInIt(
@@ -1702,21 +1769,25 @@ export async function getUsersWithPurchasedProductsWithCourseInIt(
   const isAdmin = await isAdminRole();
   if (!isAdmin) return { success: false, msg: "No permission." };
   try {
+    // Hämtar användare och dess purchases och purchaseitems som innehåller kursen, samt till vilken deltagare det gäller.
+    // Och vi hämtar endast de användare som har minst ett köp med produkter som inte är slut.
+    // Detta för att admin skall kunna välja vilken (giltig) produkt som skall användas i en bokning de skapar åt en kund.
     const usersWithData = await prisma.user.findMany({
       where: {
         purchases: {
           some: {
+            // Hämta kunder som har purchaseItems som innehåller (bland annat) kursens id.
             PurchaseItems: {
               some: {
                 courseId,
                 OR: [
-                  { unlimited: true },
+                  { unlimited: true }, // Och har obegränsade tillfällen...
                   {
-                    purchase: { type: "CLIP", remainingCount: { gt: 0 } },
+                    purchase: { type: "CLIP", remainingCount: { gt: 0 } }, // Eller om de har klippkort med klipp kvar.
                   },
                   {
-                    remainingCount: { gt: 0 },
-                    purchase: { type: { not: "CLIP" } },
+                    remainingCount: { gt: 0 }, // Eller alla med klipp kvar
+                    purchase: { type: { not: "CLIP" } }, // men som inte är klippkort
                   },
                 ],
               },
@@ -1725,14 +1796,17 @@ export async function getUsersWithPurchasedProductsWithCourseInIt(
         },
       },
       select: {
+        // Här väljer vi det vi behöver.
         id: true,
         name: true,
 
         purchases: {
+          // Inte alla purchases utan endast de som kan användas för bokningen.
           where: {
             PurchaseItems: {
               some: {
                 courseId,
+                // Samma regler för produkttyp / klipp kvar:
                 OR: [
                   { unlimited: true },
                   {
@@ -1747,6 +1821,7 @@ export async function getUsersWithPurchasedProductsWithCourseInIt(
             },
           },
           select: {
+            // Och det här behöver vi för att hantera / visa rätt produkter och data:
             id: true,
             product: {
               select: { id: true, name: true },
@@ -1754,9 +1829,10 @@ export async function getUsersWithPurchasedProductsWithCourseInIt(
             participant: { select: { id: true, name: true } },
             type: true,
             remainingCount: true,
+
             PurchaseItems: {
               where: {
-                courseId,
+                courseId, // bara purchaseitems för denna kurs, och med samma regler för typ / klipp kvar:
                 OR: [
                   { unlimited: true },
                   {
@@ -1769,13 +1845,10 @@ export async function getUsersWithPurchasedProductsWithCourseInIt(
                 ],
               },
               select: {
+                // Detta är det vi behöver för purchsaseItems:
                 id: true,
                 remainingCount: true,
                 unlimited: true,
-                lessonsIncluded: true, // Lagt till för att matcha typen
-                course: {
-                  select: { name: true }, // Lagt till för att matcha typen
-                },
               },
             },
           },
@@ -1818,6 +1891,7 @@ export async function addUserInLesson(
   try {
     const validated = await AdminAddUserInLessonSchema.parseAsync(formData);
 
+    // Hämta purchasen.
     const purchase = await prisma.purchaseItem.findUnique({
       where: { id: validated.purchaseId },
       include: { purchase: true },
@@ -1826,6 +1900,7 @@ export async function addUserInLesson(
     if (!purchase)
       return { success: false, msg: "Could not find the purchase" };
 
+    // Kolla så vi kan använda purchasen (borde aldrig kunnat anropats då om den använde funktionen ovan, men lika bra att kolla här också.)
     if (!purchase.unlimited) {
       const remaining =
         purchase.purchase.type === "CLIP"
@@ -1836,6 +1911,7 @@ export async function addUserInLesson(
       }
     }
 
+    // Hämta prticipant info.
     const participantId = purchase.purchase.participantId;
     const duplicateClauses = participantId
       ? [{ purchaseItem: { purchase: { participantId } } }]
@@ -1845,10 +1921,14 @@ export async function addUserInLesson(
             purchaseItem: { purchase: { participantId: null } },
           },
         ];
+
+    // Kolla om bokningen redan finns:
+    // Om köpet har participantId → den letar efter bokningar med samma participant via purchaseItem.purchase.participantId.
+    // Annars (ingen participant) → den matchar på userId + participantId: null.
     const existingBooking = await prisma.booking.findFirst({
       where: {
         lessonId: validated.lessonId,
-        OR: duplicateClauses,
+        OR: duplicateClauses, //
       },
     });
 
@@ -1859,7 +1939,8 @@ export async function addUserInLesson(
       };
     }
 
-    // KOLLA STATUS OCH KAPACITET PÅ LEKTIONEN
+    // KOLLA STATUS OCH KAPACITET PÅ LEKTIONEN:
+    // Hämta lektionen :)
     const lesson = await prisma.lesson.findUnique({
       where: { id: validated.lessonId },
       select: { cancelled: true, maxBookings: true },
@@ -1876,6 +1957,7 @@ export async function addUserInLesson(
       };
     }
 
+    // Kolla så den inte är fullbokad eller cancelled:
     if (lesson?.maxBookings && lesson.maxBookings > 0) {
       const currentBookings = await prisma.booking.count({
         where: { lessonId: validated.lessonId, cancelled: false },
@@ -1886,12 +1968,14 @@ export async function addUserInLesson(
       }
     }
 
+    // All good, skapa bokningen :)
     await prisma.$transaction(async (tx) => {
       const txLesson = await tx.lesson.findUnique({
         where: { id: validated.lessonId },
         select: { cancelled: true, maxBookings: true },
       });
 
+      // kolla igen (race conditions är visserliggen väldigt osannolikt här)
       if (!txLesson) {
         throw new Error("Lektionen hittades inte.");
       }
@@ -1918,6 +2002,7 @@ export async function addUserInLesson(
         },
       });
 
+      // Vår nya funktion clipResult fixar klippen :)
       const clipResult = await handleClips(tx, validated.purchaseId, -1);
 
       if (!clipResult.success) {
@@ -1925,7 +2010,8 @@ export async function addUserInLesson(
       }
     });
 
-    revalidatePath("/admin/courses"); // Sökvägen där komponenten bor
+    revalidatePath("/admin/courses");
+    revalidatePath("/admin"); // Admin-översikten använder samma närvaro-flöde.
 
     return { success: true, msg: "Eleven blev tillagd i lektionen." };
   } catch (e) {
@@ -2008,6 +2094,7 @@ export async function removeUserFromLesson(
   }
 }
 
+// Behöver den här typen för att fortsätta en tx:
 export type PrismaTx = Prisma.TransactionClient;
 
 // // Okej, så nu den magiska funktionen handleClips då :)

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -153,16 +153,28 @@ export const adminCreateCourseProductSchema = z
     },
   );
 
-export const AdminProductCourseItemSchema = z.object({
-  productId: z.string().min(1),
-  isClipcard: z.coerce.boolean().optional(), // Denna logik kanske kan göras i koden, vi får se.
-  courseId: z.string().min(1, "Kurs-ID måste anges."),
-  unlimited: z.coerce.boolean().optional(),
-  lessonsIncluded: z.coerce
-    .number()
-    .int()
-    .nonnegative("Antalet tillfällen får inte vara negativt."),
-});
+export const AdminProductCourseItemSchema = z
+  .object({
+    productId: z.string().min(1),
+    isClipcard: z.coerce.boolean().optional(), // Denna logik kanske kan göras i koden, vi får se.
+    courseId: z.string().min(1, "Kurs-ID måste anges."),
+    unlimited: z.coerce.boolean().optional(),
+    lessonsIncluded: z.coerce
+      .number()
+      .int()
+      .nonnegative("Antalet tillfällen får inte vara negativt."),
+  })
+  .refine(
+    (data) =>
+      data.unlimited === true ||
+      data.isClipcard === true ||
+      data.lessonsIncluded >= 1,
+    {
+      message:
+        "Antal tillfällen måste vara minst 1 om inte obegränsat eller klippkort.",
+      path: ["lessonsIncluded"],
+    },
+  );
 
 export const AdminAddUserInLessonSchema = z.object({
   userId: z.string().min(1),


### PR DESCRIPTION
- Termin kopplas via SchemaItem (inte CourseOnTermin/product.terminId). Påverkar admin/students hur den hämtar terminer.

- Tar alltså bort CourseOnTermin och uppdaterar admin/students-logik.
- Accordion-label visar kurs + datum.

- Inkluderar migration.
