### PR TITLE
Admin-terminer uppdatering

### DIFF
--- a/prisma/migrations/20260203111919_custom_dates_in_schema_item/migration.sql
+++ b/prisma/migrations/20260203111919_custom_dates_in_schema_item/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "schema_item" ADD COLUMN     "customEndDate" TIMESTAMP(3),
+ADD COLUMN     "customStartDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,8 +202,10 @@ model SchemaItem {
 
     weekday Weekday
 
-    timeStart DateTime // är DateTime rätt här?
-    timeEnd DateTime // -||- ?
+    timeStart DateTime 
+    timeEnd DateTime
+    customStartDate DateTime?
+    customEndDate DateTime?
 
     terminId String
     termin Termin @relation(fields: [terminId], references: [id], onDelete: Cascade)

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -9,8 +9,10 @@ export default function RootLayout({
   return (
     <SidebarProvider>
       <AppSidebar />
-      <div>
-        <SidebarTrigger />
+      <div className="flex-1 w-full min-w-0">
+        <div className="sticky top-2 z-40 px-2">
+          <SidebarTrigger className="size-9" />
+        </div>
         {children}
       </div>
     </SidebarProvider>

--- a/src/app/admin/termin/Schema.tsx
+++ b/src/app/admin/termin/Schema.tsx
@@ -1,37 +1,32 @@
-import type { ReactNode } from "react";
 import { Accordion } from "@/components/ui/accordion";
 import type { Course, Termin } from "@/generated/prisma/client";
-import { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
+import { getWeekdays } from "@/lib/tools";
+import AddCourseToSchemaForm from "./forms/AddCourseToSchemaForm";
 import SchemaDay from "./SchemaDay";
 
 interface SchemaProps {
   schemaItems: SchemaItemWithCourse[]; // Tar emot alla schemaItems (som har denna terminId) inkl kursdata.
   termin: Termin;
   allCourses: Course[];
-  actions?: ReactNode;
 }
 
 export default function Schema({
   schemaItems,
   termin,
   allCourses,
-  actions,
 }: SchemaProps) {
-  const weekdays = Object.keys(Weekday); // Hämta veckodagar från prismaschemats enum.
+  const weekdays = getWeekdays();
   return (
     <div className="border rounded-lg bg-muted/20">
       <div className="flex items-center justify-between px-4 py-3 border-b">
         <div>
           <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            Veckoschema
+            {schemaItems.length}st tillfällen.
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          {actions}
-          <div className="text-xs text-muted-foreground">
-            {schemaItems.length} kurstillfällen
-          </div>
+        <div className="gap-2">
+          <AddCourseToSchemaForm allCourses={allCourses} termin={termin} />
         </div>
       </div>
       <div className="p-2">
@@ -42,11 +37,9 @@ export default function Schema({
             {weekdays.map((day) => (
               <SchemaDay
                 allCourses={allCourses}
-                weekdays={weekdays}
                 termin={termin}
                 schemaItems={schemaItems}
-                weekday={day as Weekday}
-                weekdayIndex={weekdays.indexOf(day)}
+                weekday={day}
                 key={day}
               />
             ))}

--- a/src/app/admin/termin/Schema.tsx
+++ b/src/app/admin/termin/Schema.tsx
@@ -1,13 +1,15 @@
 import { Accordion } from "@/components/ui/accordion";
+import type { Termin } from "@/generated/prisma/client";
 import { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import SchemaDay from "./SchemaDay";
 
 interface SchemaProps {
   schemaItems: SchemaItemWithCourse[]; // Tar emot alla schemaItems (som har denna terminId) inkl kursdata.
+  termin: Termin;
 }
 
-export default function Schema({ schemaItems }: SchemaProps) {
+export default function Schema({ schemaItems, termin }: SchemaProps) {
   const weekdays = Object.keys(Weekday); // Hämta veckodagar från prismaschemats enum.
 
   return (
@@ -17,6 +19,7 @@ export default function Schema({ schemaItems }: SchemaProps) {
         : weekdays.map((day) => {
             return (
               <SchemaDay
+                termin={termin}
                 schemaItems={schemaItems}
                 weekday={day as Weekday}
                 weekdayIndex={weekdays.indexOf(day)}

--- a/src/app/admin/termin/Schema.tsx
+++ b/src/app/admin/termin/Schema.tsx
@@ -22,7 +22,7 @@ export default function Schema({
       <div className="flex items-center justify-between px-4 py-3 border-b">
         <div>
           <p className="text-xs uppercase tracking-wide text-muted-foreground">
-            {schemaItems.length}st tillfällen.
+            {schemaItems.length}st kurstillfällen i veckan.
           </p>
         </div>
         <div className="gap-2">

--- a/src/app/admin/termin/Schema.tsx
+++ b/src/app/admin/termin/Schema.tsx
@@ -1,5 +1,6 @@
+import type { ReactNode } from "react";
 import { Accordion } from "@/components/ui/accordion";
-import type { Termin } from "@/generated/prisma/client";
+import type { Course, Termin } from "@/generated/prisma/client";
 import { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import SchemaDay from "./SchemaDay";
@@ -7,26 +8,51 @@ import SchemaDay from "./SchemaDay";
 interface SchemaProps {
   schemaItems: SchemaItemWithCourse[]; // Tar emot alla schemaItems (som har denna terminId) inkl kursdata.
   termin: Termin;
+  allCourses: Course[];
+  actions?: ReactNode;
 }
 
-export default function Schema({ schemaItems, termin }: SchemaProps) {
+export default function Schema({
+  schemaItems,
+  termin,
+  allCourses,
+  actions,
+}: SchemaProps) {
   const weekdays = Object.keys(Weekday); // Hämta veckodagar från prismaschemats enum.
-
   return (
-    <Accordion type="single" className="p-2 border-2 rounded" collapsible>
-      {schemaItems.length === 0
-        ? "Inga kurser i veckoschemat."
-        : weekdays.map((day) => {
-            return (
+    <div className="border rounded-lg bg-muted/20">
+      <div className="flex items-center justify-between px-4 py-3 border-b">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Veckoschema
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {actions}
+          <div className="text-xs text-muted-foreground">
+            {schemaItems.length} kurstillfällen
+          </div>
+        </div>
+      </div>
+      <div className="p-2">
+        {schemaItems.length === 0 ? (
+          "Inga kurser i veckoschemat."
+        ) : (
+          <Accordion type="single" collapsible>
+            {weekdays.map((day) => (
               <SchemaDay
+                allCourses={allCourses}
+                weekdays={weekdays}
                 termin={termin}
                 schemaItems={schemaItems}
                 weekday={day as Weekday}
                 weekdayIndex={weekdays.indexOf(day)}
                 key={day}
-              ></SchemaDay>
-            );
-          })}
-    </Accordion>
+              />
+            ))}
+          </Accordion>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -1,4 +1,5 @@
 import { Calendar, Clock, ListChecks } from "lucide-react";
+import Link from "next/link";
 import {
   AccordionContent,
   AccordionItem,
@@ -77,14 +78,18 @@ export default function SchemaDay({
                   <div className="text-sm text-muted-foreground">
                     Plats: {itm.place || "Ej angiven"}
                   </div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8 p-0 cursor-pointer"
+                  <Link
+                    href={`/admin/lectures?schemaitem=${itm.id}&termin=${itm.terminId}&course=${itm.courseId}`}
                   >
-                    <ListChecks />
-                    Lektioner ({itm.Lessons.length}st)
-                  </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 p-0 cursor-pointer"
+                    >
+                      <ListChecks />
+                      Lektioner ({itm.Lessons.length}st)
+                    </Button>
+                  </Link>
                 </div>
                 <div className="flex items-center gap-2 md:flex-col md:items-end">
                   <EditCourseToSchemaForm

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -1,13 +1,14 @@
+import { AlertTriangle, Calendar, Clock, Layers } from "lucide-react";
 import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
-import type { Termin } from "@/generated/prisma/client";
+import type { Course, Termin } from "@/generated/prisma/client";
 import type { Weekday } from "@/generated/prisma/enums";
-import { getAllCourses, type SchemaItemWithCourse } from "@/lib/actions/admin";
+import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
-import { getCourseName, getWeekdays } from "@/lib/tools";
+import { getCourseName } from "@/lib/tools";
 import DeleteSchemaItemBtn from "./components/DeleteSchemaItemBtn";
 import EditCourseToSchemaForm from "./forms/EditCourseToSchemaForm";
 
@@ -16,6 +17,8 @@ interface Props {
   weekday: Weekday;
   weekdayIndex: number;
   termin: Termin;
+  allCourses: Course[];
+  weekdays: string[];
 }
 
 export const veckodagar = [
@@ -49,46 +52,86 @@ export const getVeckodag = (day: Weekday) => {
   }
 };
 
-export default async function SchemaDay({
+export default function SchemaDay({
   schemaItems,
   weekday,
   weekdayIndex,
   termin,
+  allCourses,
+  weekdays,
 }: Props) {
   if (schemaItems.filter((itm) => itm.weekday === weekday).length === 0)
     return null;
 
   return (
     <AccordionItem value={weekday}>
-      <AccordionTrigger>
-        {veckodagar[weekdayIndex]} (
-        {schemaItems.filter((itm) => itm.weekday === weekday).length})
+      <AccordionTrigger className="rounded-md px-3 py-2 hover:bg-muted/40">
+        <div className="flex w-full items-center justify-between pr-2">
+          <div className="text-left">
+            <p className="font-semibold">{veckodagar[weekdayIndex]}</p>
+            <p className="text-xs text-muted-foreground">
+              {schemaItems.filter((itm) => itm.weekday === weekday).length}{" "}
+              kurstillfällen
+            </p>
+          </div>
+          <div className="text-xs text-muted-foreground">Visa</div>
+        </div>
       </AccordionTrigger>
       {schemaItems
         .filter((itm) => itm.weekday === weekday)
         .sort((a, b) =>
           dbToFormTime(a.timeStart).localeCompare(dbToFormTime(b.timeStart)),
         )
-        .map(async (itm) => {
-          // const itmCourse = await getCourseById(itm.id);
-
+        .map((itm) => {
           return (
             <AccordionContent key={itm.id}>
-              <div className="bg-blue-500/10 border-blue-500/20 text-foreground border-2 p-2 rounded-lg flex justify-between">
-                <div>
-                  {dbToFormTime(itm.timeStart)} - {dbToFormTime(itm.timeEnd)}
-                  <br />
-                  <span className="font-bold">{getCourseName(itm.course)}</span>
-                  <br />
-                  <span className="font-bold">Plats: {itm.place}</span>
+              <div className="bg-muted/30 border-border text-foreground border p-3 rounded-lg flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {dbToFormTime(itm.timeStart)} -{" "}
+                      {dbToFormTime(itm.timeEnd)}
+                    </span>
+                    <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
+                      <Calendar className="h-3 w-3" />
+                      {itm.customStartDate
+                        ? itm.customStartDate.toLocaleDateString()
+                        : termin.startDate.toLocaleDateString()}
+                      {" - "}
+                      {itm.customEndDate
+                        ? itm.customEndDate.toLocaleDateString()
+                        : termin.endDate.toLocaleDateString()}
+                    </span>
+                    <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
+                      <Layers className="h-3 w-3" />
+                      {itm.Lessons.length} lektioner
+                    </span>
+                    {itm.Lessons.some((lesson) => lesson.cancelled) && (
+                      <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1 text-red-500 border-red-500/40">
+                        <AlertTriangle className="h-3 w-3" />
+                        {
+                          itm.Lessons.filter((lesson) => lesson.cancelled)
+                            .length
+                        }{" "}
+                        st inställda
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-base font-semibold">
+                    {getCourseName(itm.course)}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    Plats: {itm.place || "Ej angiven"}
+                  </div>
                 </div>
-                <div>
+                <div className="flex items-center gap-2 md:flex-col md:items-end">
                   <EditCourseToSchemaForm
-                    schemaItem={itm}
-                    allCourses={await getAllCourses()}
                     termin={termin}
-                    weekdays={getWeekdays()}
-                  ></EditCourseToSchemaForm>
+                    schemaItem={itm}
+                    allCourses={allCourses}
+                    weekdays={weekdays}
+                  />
                   <DeleteSchemaItemBtn itemId={itm.id} />
                 </div>
               </div>

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -8,73 +8,39 @@ import type { Course, Termin } from "@/generated/prisma/client";
 import type { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
-import { getCourseName } from "@/lib/tools";
+import { getCourseName, getVeckodag, getWeekdays } from "@/lib/tools";
 import DeleteSchemaItemBtn from "./components/DeleteSchemaItemBtn";
 import EditCourseToSchemaForm from "./forms/EditCourseToSchemaForm";
 
 interface Props {
   schemaItems: SchemaItemWithCourse[];
   weekday: Weekday;
-  weekdayIndex: number;
   termin: Termin;
   allCourses: Course[];
-  weekdays: string[];
 }
-
-export const veckodagar = [
-  "Måndag",
-  "Tisdag",
-  "Onsdag",
-  "Torsdag",
-  "Fredag",
-  "Lördag",
-  "Söndag",
-];
-
-export const getVeckodag = (day: Weekday) => {
-  switch (day) {
-    case "MONDAY":
-      return "Måndag";
-    case "TUESDAY":
-      return "Tisdag";
-    case "WEDNESDAY":
-      return "Onsdag";
-    case "THURSDAY":
-      return "Torsdag";
-    case "FRIDAY":
-      return "Fredag";
-    case "SATURDAY":
-      return "Lördag";
-    case "SUNDAY":
-      return "Söndag";
-    default:
-      return day; // Returnerar originalsträngen om ingen matchning hittas
-  }
-};
 
 export default function SchemaDay({
   schemaItems,
   weekday,
-  weekdayIndex,
   termin,
   allCourses,
-  weekdays,
 }: Props) {
   if (schemaItems.filter((itm) => itm.weekday === weekday).length === 0)
     return null;
+
+  const weekdays = getWeekdays();
 
   return (
     <AccordionItem value={weekday}>
       <AccordionTrigger className="rounded-md px-3 py-2 hover:bg-muted/40">
         <div className="flex w-full items-center justify-between pr-2">
           <div className="text-left">
-            <p className="font-semibold">{veckodagar[weekdayIndex]}</p>
+            <p className="font-semibold">{getVeckodag(weekday)}</p>
             <p className="text-xs text-muted-foreground">
-              {schemaItems.filter((itm) => itm.weekday === weekday).length}{" "}
+              {schemaItems.filter((itm) => itm.weekday === weekday).length}st{" "}
               kurstillfällen
             </p>
           </div>
-          <div className="text-xs text-muted-foreground">Visa</div>
         </div>
       </AccordionTrigger>
       {schemaItems
@@ -89,12 +55,12 @@ export default function SchemaDay({
                 <div className="space-y-2">
                   <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
-                      <Clock className="h-3 w-3" />
+                      <Clock className="h-3 w-3" />{" "}
                       {dbToFormTime(itm.timeStart)} -{" "}
                       {dbToFormTime(itm.timeEnd)}
                     </span>
                     <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
-                      <Calendar className="h-3 w-3" />
+                      <Calendar className="h-3 w-3" />{" "}
                       {itm.customStartDate
                         ? itm.customStartDate.toLocaleDateString()
                         : termin.startDate.toLocaleDateString()}

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -3,17 +3,19 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import type { Termin } from "@/generated/prisma/client";
 import type { Weekday } from "@/generated/prisma/enums";
-
-import type { SchemaItemWithCourse } from "@/lib/actions/admin";
+import { getAllCourses, type SchemaItemWithCourse } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
-import { getCourseName } from "@/lib/tools";
+import { getCourseName, getWeekdays } from "@/lib/tools";
 import DeleteSchemaItemBtn from "./components/DeleteSchemaItemBtn";
+import EditCourseToSchemaForm from "./forms/EditCourseToSchemaForm";
 
 interface Props {
   schemaItems: SchemaItemWithCourse[];
   weekday: Weekday;
   weekdayIndex: number;
+  termin: Termin;
 }
 
 export const veckodagar = [
@@ -51,6 +53,7 @@ export default async function SchemaDay({
   schemaItems,
   weekday,
   weekdayIndex,
+  termin,
 }: Props) {
   if (schemaItems.filter((itm) => itm.weekday === weekday).length === 0)
     return null;
@@ -80,6 +83,12 @@ export default async function SchemaDay({
                   <span className="font-bold">Plats: {itm.place}</span>
                 </div>
                 <div>
+                  <EditCourseToSchemaForm
+                    schemaItem={itm}
+                    allCourses={await getAllCourses()}
+                    termin={termin}
+                    weekdays={getWeekdays()}
+                  ></EditCourseToSchemaForm>
                   <DeleteSchemaItemBtn itemId={itm.id} />
                 </div>
               </div>

--- a/src/app/admin/termin/SchemaDay.tsx
+++ b/src/app/admin/termin/SchemaDay.tsx
@@ -1,9 +1,10 @@
-import { AlertTriangle, Calendar, Clock, Layers } from "lucide-react";
+import { Calendar, Clock, ListChecks } from "lucide-react";
 import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
 import type { Course, Termin } from "@/generated/prisma/client";
 import type { Weekday } from "@/generated/prisma/enums";
 import type { SchemaItemWithCourse } from "@/lib/actions/admin";
@@ -53,12 +54,7 @@ export default function SchemaDay({
             <AccordionContent key={itm.id}>
               <div className="bg-muted/30 border-border text-foreground border p-3 rounded-lg flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-2">
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                    <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
-                      <Clock className="h-3 w-3" />{" "}
-                      {dbToFormTime(itm.timeStart)} -{" "}
-                      {dbToFormTime(itm.timeEnd)}
-                    </span>
+                  <div className="flex flex-wrap items-center gap-2 text-xs">
                     <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
                       <Calendar className="h-3 w-3" />{" "}
                       {itm.customStartDate
@@ -70,19 +66,10 @@ export default function SchemaDay({
                         : termin.endDate.toLocaleDateString()}
                     </span>
                     <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1">
-                      <Layers className="h-3 w-3" />
-                      {itm.Lessons.length} lektioner
+                      <Clock className="h-3 w-3" />{" "}
+                      {dbToFormTime(itm.timeStart)} -{" "}
+                      {dbToFormTime(itm.timeEnd)}
                     </span>
-                    {itm.Lessons.some((lesson) => lesson.cancelled) && (
-                      <span className="rounded-full border px-2 py-0.5 inline-flex items-center gap-1 text-red-500 border-red-500/40">
-                        <AlertTriangle className="h-3 w-3" />
-                        {
-                          itm.Lessons.filter((lesson) => lesson.cancelled)
-                            .length
-                        }{" "}
-                        st inställda
-                      </span>
-                    )}
                   </div>
                   <div className="text-base font-semibold">
                     {getCourseName(itm.course)}
@@ -90,6 +77,14 @@ export default function SchemaDay({
                   <div className="text-sm text-muted-foreground">
                     Plats: {itm.place || "Ej angiven"}
                   </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 p-0 cursor-pointer"
+                  >
+                    <ListChecks />
+                    Lektioner ({itm.Lessons.length}st)
+                  </Button>
                 </div>
                 <div className="flex items-center gap-2 md:flex-col md:items-end">
                   <EditCourseToSchemaForm

--- a/src/app/admin/termin/TerminItem.tsx
+++ b/src/app/admin/termin/TerminItem.tsx
@@ -51,7 +51,6 @@ export default async function TerminItem({ termin }: Props) {
             </CardTitle>
 
             <div className="p-2 flex gap-2">
-              {/* fix: card-action istället? */}
               <AddCourseToSchemaForm
                 weekdays={Object.keys(Weekday)}
                 allCourses={allCourses}

--- a/src/app/admin/termin/TerminItem.tsx
+++ b/src/app/admin/termin/TerminItem.tsx
@@ -94,7 +94,7 @@ export default async function TerminItem({ termin }: Props) {
             <AccordionItem value="item-1">
               <AccordionTrigger>Veckoschema</AccordionTrigger>
               <AccordionContent>
-                <Schema schemaItems={schemaItems} />
+                <Schema schemaItems={schemaItems} termin={termin} />
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/src/app/admin/termin/TerminItem.tsx
+++ b/src/app/admin/termin/TerminItem.tsx
@@ -1,10 +1,4 @@
 import { Calendar } from "lucide-react";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { type Termin, Weekday } from "@/generated/prisma/client";
 import {
@@ -51,11 +45,6 @@ export default async function TerminItem({ termin }: Props) {
             </CardTitle>
 
             <div className="p-2 flex gap-2">
-              <AddCourseToSchemaForm
-                weekdays={Object.keys(Weekday)}
-                allCourses={allCourses}
-                termin={termin}
-              />
               <EditTerminForm termin={termin} />
               <DeleteTerminBtn terminId={termin.id} />
             </div>
@@ -90,14 +79,18 @@ export default async function TerminItem({ termin }: Props) {
           </div>
 
           <br />
-          <Accordion type="single" collapsible>
-            <AccordionItem value="item-1">
-              <AccordionTrigger>Veckoschema</AccordionTrigger>
-              <AccordionContent>
-                <Schema schemaItems={schemaItems} termin={termin} />
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
+          <Schema
+            actions={
+              <AddCourseToSchemaForm
+                weekdays={Object.keys(Weekday)}
+                allCourses={allCourses}
+                termin={termin}
+              />
+            }
+            allCourses={allCourses}
+            termin={termin}
+            schemaItems={schemaItems}
+          />
         </CardContent>
       </Card>
     </div>

--- a/src/app/admin/termin/TerminItem.tsx
+++ b/src/app/admin/termin/TerminItem.tsx
@@ -1,13 +1,20 @@
-import { Calendar } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { type Termin, Weekday } from "@/generated/prisma/client";
+import { Calendar, Calendar1Icon, CheckCircle2, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { TableCell, TableRow } from "@/components/ui/table";
+import type { Termin } from "@/generated/prisma/client";
 import {
   getAllCourses,
   getSchemaItems,
   type SchemaItemWithCourse,
 } from "@/lib/actions/admin";
 import DeleteTerminBtn from "./components/DeleteTerminBtn";
-import AddCourseToSchemaForm from "./forms/AddCourseToSchemaForm";
 import EditTerminForm from "./forms/EditTerminForm";
 import Schema from "./Schema";
 
@@ -17,82 +24,66 @@ interface Props {
 
 function isTerminActive(termin: Termin): boolean {
   const today = new Date();
-
-  const isAfterStart = today >= termin.startDate;
-
-  const isBeforeEnd = today <= termin.endDate;
-
-  return isAfterStart && isBeforeEnd;
+  return today >= termin.startDate && today <= termin.endDate;
 }
 
 export default async function TerminItem({ termin }: Props) {
   const schemaItems: SchemaItemWithCourse[] = await getSchemaItems(termin.id);
-
   const allCourses = await getAllCourses();
 
   return (
-    <div className="p-2 ">
-      <Card>
-        <CardHeader>
-          <div className="w-full lg:flex md:justify-between md:items-start">
-            <CardTitle>
-              <div>
-                {termin.name}{" "}
-                <span className="font-bold">
-                  {isTerminActive(termin) && "(AKTIV)"}
-                </span>
-              </div>
-            </CardTitle>
-
-            <div className="p-2 flex gap-2">
-              <EditTerminForm termin={termin} />
-              <DeleteTerminBtn terminId={termin.id} />
-            </div>
-          </div>
-        </CardHeader>
-
-        <CardContent>
-          <div className="grid grid-cols-2 gap-2 rounded ">
-            <div className="flex items-center gap-2">
-              <div className="flex flex-col items-center justify-center bg-muted/50 border rounded-md p-2 shadow-sm min-w-[100px]">
-                <span className="text-[10px] uppercase text-muted-foreground font-bold">
-                  <Calendar className="inline-block" /> Start
-                </span>
-                <span className="text-sm font-bold">
-                  {termin.startDate.toLocaleDateString()}
-                </span>
-              </div>
-              <div className="h-px w-4 bg-border" />{" "}
-              {/* En liten horisontell linje emellan */}
-              <div className="flex flex-col items-center justify-center bg-muted/50 border rounded-md p-2 shadow-sm min-w-[100px]">
-                <span className="text-[10px] uppercase text-muted-foreground font-bold">
-                  <Calendar className="inline-block" /> Slut
-                </span>
-                <span className="text-sm font-bold">
-                  {termin.endDate.toLocaleDateString()}
-                </span>
-              </div>
-            </div>
-            <div className="p-2 text-muted-foreground">
-              (statistik kommer...)
-            </div>
-          </div>
-
-          <br />
-          <Schema
-            actions={
-              <AddCourseToSchemaForm
-                weekdays={Object.keys(Weekday)}
+    <TableRow className="align-top">
+      <TableCell className="p-3">
+        <div className="font-semibold">
+          {termin.name}{" "}
+          {isTerminActive(termin) ? (
+            <span className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600">
+              <CheckCircle2 className="h-3 w-3" />
+              Aktiv
+            </span>
+          ) : (
+            <span className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              Inaktiv
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <Calendar className="h-4 w-4 text-muted-foreground" />
+          {termin.startDate.toLocaleDateString()} –{" "}
+          {termin.endDate.toLocaleDateString()}
+        </div>
+      </TableCell>
+      <TableCell className="p-3 text-right">
+        <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:justify-end">
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button
+                variant="secondary"
+                className="cursor-pointer h-8 w-8 p-0"
+              >
+                <Calendar1Icon />
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-h-[85vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>
+                  {termin.name}
+                  <br />
+                  veckoschema
+                </DialogTitle>
+              </DialogHeader>
+              <Schema
                 allCourses={allCourses}
                 termin={termin}
+                schemaItems={schemaItems}
               />
-            }
-            allCourses={allCourses}
-            termin={termin}
-            schemaItems={schemaItems}
-          />
-        </CardContent>
-      </Card>
-    </div>
+            </DialogContent>
+          </Dialog>
+          <EditTerminForm termin={termin} />
+          <DeleteTerminBtn terminId={termin.id} />
+        </div>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/src/app/admin/termin/components/DeleteSchemaItemBtn.tsx
+++ b/src/app/admin/termin/components/DeleteSchemaItemBtn.tsx
@@ -2,6 +2,7 @@
 
 // ev fix: Gör en generisk ta bort-knapp och passa funktionen som den ska köra.
 
+import { Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { delSchemaItem } from "@/lib/actions/admin";
@@ -53,8 +54,13 @@ export default function DeleteSchemaItemBtn({ itemId }: Props) {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant={"destructive"} className="cursor-pointer">
-          Ta bort
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+          <span className="sr-only">Ta bort kurstillfälle</span>
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/src/app/admin/termin/components/DeleteTerminBtn.tsx
+++ b/src/app/admin/termin/components/DeleteTerminBtn.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Trash2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { delTermin } from "@/lib/actions/admin";
@@ -45,8 +46,13 @@ export default function DeleteTerminBtn({ terminId }: Props) {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant={"destructive"} className="cursor-pointer">
-          Ta bort
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+          <span className="sr-only">Ta bort termin</span>
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>

--- a/src/app/admin/termin/components/HideOldCheckbox.tsx
+++ b/src/app/admin/termin/components/HideOldCheckbox.tsx
@@ -38,7 +38,7 @@ export function HideOldCheckbox() {
         id="hideCheck"
       />
       <label htmlFor="hideCheck" className="">
-        Dölj gamla
+        Dölj inaktiva
       </label>
     </div>
   );

--- a/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { PlusIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -46,9 +47,8 @@ import {
 } from "@/components/ui/select";
 import type { Course, Termin } from "@/generated/prisma/client";
 import { addCoursetoSchema } from "@/lib/actions/admin";
-import { getCourseName } from "@/lib/tools";
+import { getCourseName, getVeckodag, getWeekdays } from "@/lib/tools";
 import { adminAddCourseToSchemaSchema } from "@/validations/adminforms";
-import { veckodagar } from "../SchemaDay";
 
 const formSchema = adminAddCourseToSchemaSchema;
 type FormValues = z.infer<typeof adminAddCourseToSchemaSchema>;
@@ -56,14 +56,9 @@ type FormValues = z.infer<typeof adminAddCourseToSchemaSchema>;
 interface Props {
   termin: Termin;
   allCourses: Course[];
-  weekdays: string[];
 }
 
-export default function AddCourseToSchemaForm({
-  termin,
-  allCourses,
-  weekdays,
-}: Props) {
+export default function AddCourseToSchemaForm({ termin, allCourses }: Props) {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -106,6 +101,8 @@ export default function AddCourseToSchemaForm({
   const customEndBackupRef = useRef<string>("");
   const isBusy = form.formState.isSubmitting || form.formState.isValidating;
 
+  const weekdays = getWeekdays();
+
   useEffect(() => {
     if (!isOpen) {
       form.reset();
@@ -135,16 +132,15 @@ export default function AddCourseToSchemaForm({
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
         <Button variant="secondary" className="cursor-pointer mb-3">
-          Lägg till kurs
+          <PlusIcon /> Lägg till
         </Button>
       </DialogTrigger>
       <DialogContent className="overflow-y-auto max-h-[90vh]">
         <DialogHeader>
-          <DialogTitle>Lägg till kurstillfälle i veckoschemat</DialogTitle>
+          <DialogTitle>Lägg till kurstillfälle</DialogTitle>
           <DialogDescription>
             Ange vilken veckodag samt mellan vilka tider du vill lägga in
-            tillfället. Tillfället blir då{" "}
-            <span className="bold">bokningsbart</span> av kunder som köpt
+            tillfället. Tillfället blir då bokningsbart av kunder som köpt
             tillgång till kursen.
           </DialogDescription>
         </DialogHeader>
@@ -215,9 +211,9 @@ export default function AddCourseToSchemaForm({
                         <SelectContent>
                           <SelectGroup>
                             <SelectLabel>Välj dag</SelectLabel>
-                            {weekdays.map((c, i) => (
+                            {weekdays.map((c) => (
                               <SelectItem key={c} value={c}>
-                                {veckodagar[i]}
+                                {getVeckodag(c)}
                               </SelectItem>
                             ))}
                           </SelectGroup>

--- a/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
@@ -2,10 +2,11 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
+import Loader from "@/components/Loader";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -14,6 +15,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogClose,
@@ -67,22 +69,62 @@ export default function AddCourseToSchemaForm({
     defaultValues: {
       courseId: "",
       place: "",
+      customEndDate: termin.endDate.toISOString().split("T")[0],
+      customStartDate: termin.startDate.toISOString().split("T")[0],
       day: "MONDAY",
-      timeStart: "0",
-      timeEnd: "1",
+      timeStart: "01:00",
+      timeEnd: "02:00",
     },
   });
 
+  const terminStartValue = termin.startDate.toLocaleDateString("sv-SE");
+  const terminEndValue = termin.endDate.toLocaleDateString("sv-SE");
+
+  const formatDateToInput = (date: unknown) => {
+    if (!date) {
+      return "";
+    }
+
+    if (date instanceof Date) {
+      if (Number.isNaN(date.getTime())) {
+        return "";
+      }
+      return date.toISOString().split("T")[0];
+    }
+
+    if (typeof date === "string") {
+      return date;
+    }
+
+    return "";
+  };
+
   const [isOpen, setIsOpen] = useState(false);
+  const [useTerminStart, setUseTerminStart] = useState(true);
+  const [useTerminEnd, setUseTerminEnd] = useState(true);
+  const customStartBackupRef = useRef<string>("");
+  const customEndBackupRef = useRef<string>("");
+  const isBusy = form.formState.isSubmitting || form.formState.isValidating;
 
   useEffect(() => {
-    if (!isOpen) form.reset();
+    if (!isOpen) {
+      form.reset();
+
+      //
+      setUseTerminStart(true);
+      setUseTerminEnd(true);
+      customStartBackupRef.current = "";
+      customEndBackupRef.current = "";
+    }
   }, [isOpen, form]);
 
   const router = useRouter();
 
   async function onSubmit(values: FormValues) {
+    console.log(`Values sent:\n${values}`);
+
     const res = await addCoursetoSchema(termin.id, values);
+    console.log(`res:\n${JSON.stringify(res)}`);
     if (res.success) {
       toast.success(res.msg);
       setIsOpen(false);
@@ -226,6 +268,122 @@ export default function AddCourseToSchemaForm({
 
                 <FormField
                   control={form.control}
+                  name="customStartDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center justify-between gap-2">
+                        <FormLabel>Start datum</FormLabel>
+                        <label
+                          htmlFor="follow-termin-start"
+                          className="flex items-center gap-2 text-sm text-muted-foreground"
+                        >
+                          <Checkbox
+                            id="follow-termin-start"
+                            checked={useTerminStart}
+                            onCheckedChange={(checked) => {
+                              const isChecked = checked === true;
+                              setUseTerminStart(isChecked);
+                              if (isChecked) {
+                                customStartBackupRef.current =
+                                  form.getValues("customStartDate") ?? "";
+                                form.setValue(
+                                  "customStartDate",
+                                  terminStartValue,
+                                  {
+                                    shouldDirty: true,
+                                    shouldValidate: true,
+                                  },
+                                );
+                              } else if (customStartBackupRef.current) {
+                                form.setValue(
+                                  "customStartDate",
+                                  customStartBackupRef.current,
+                                  {
+                                    shouldDirty: true,
+                                    shouldValidate: true,
+                                  },
+                                );
+                              }
+                            }}
+                            className="w-5 h-5"
+                          />
+                          Följ termin
+                        </label>
+                      </div>
+
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={formatDateToInput(field.value)}
+                          onChange={field.onChange}
+                          disabled={useTerminStart}
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="customEndDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex items-center justify-between gap-2">
+                        <FormLabel>Slut datum</FormLabel>
+                        <label
+                          htmlFor="follow-termin-end"
+                          className="flex items-center gap-2 text-sm text-muted-foreground"
+                        >
+                          <Checkbox
+                            id="follow-termin-end"
+                            checked={useTerminEnd}
+                            onCheckedChange={(checked) => {
+                              const isChecked = checked === true;
+                              setUseTerminEnd(isChecked);
+                              if (isChecked) {
+                                customEndBackupRef.current =
+                                  form.getValues("customEndDate") ?? "";
+                                form.setValue("customEndDate", terminEndValue, {
+                                  shouldDirty: true,
+                                  shouldValidate: true,
+                                });
+                              } else if (customEndBackupRef.current) {
+                                form.setValue(
+                                  "customEndDate",
+                                  customEndBackupRef.current,
+                                  {
+                                    shouldDirty: true,
+                                    shouldValidate: true,
+                                  },
+                                );
+                              }
+                            }}
+                            className="w-5 h-5"
+                          />
+                          Följ termin
+                        </label>
+                      </div>
+
+                      <FormControl>
+                        <Input
+                          type="date"
+                          {...field}
+                          value={formatDateToInput(field.value)}
+                          onChange={field.onChange}
+                          disabled={useTerminEnd}
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
                   name="place"
                   render={({ field }) => (
                     <FormItem>
@@ -240,7 +398,8 @@ export default function AddCourseToSchemaForm({
                   )}
                 />
 
-                <Button type="submit" className="w-full">
+                {isBusy && <Loader />}
+                <Button type="submit" className="w-full" disabled={isBusy}>
                   Lägg till!
                 </Button>
               </form>

--- a/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
@@ -72,8 +72,8 @@ export default function AddCourseToSchemaForm({ termin, allCourses }: Props) {
     },
   });
 
-  const terminStartValue = termin.startDate.toLocaleDateString("sv-SE");
-  const terminEndValue = termin.endDate.toLocaleDateString("sv-SE");
+  const terminStartValue = termin.startDate.toISOString().split("T")[0];
+  const terminEndValue = termin.endDate.toISOString().split("T")[0];
 
   const formatDateToInput = (date: unknown) => {
     if (!date) {
@@ -99,6 +99,7 @@ export default function AddCourseToSchemaForm({ termin, allCourses }: Props) {
   const [useTerminEnd, setUseTerminEnd] = useState(true);
   const customStartBackupRef = useRef<string>("");
   const customEndBackupRef = useRef<string>("");
+
   const isBusy = form.formState.isSubmitting || form.formState.isValidating;
 
   const weekdays = getWeekdays();

--- a/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/AddCourseToSchemaForm.tsx
@@ -134,10 +134,7 @@ export default function AddCourseToSchemaForm({
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
-        <Button
-          variant={"default"}
-          className="bg-green-500 cursor-pointer mb-3"
-        >
+        <Button variant="secondary" className="cursor-pointer mb-3">
           Lägg till kurs
         </Button>
       </DialogTrigger>
@@ -396,7 +393,12 @@ export default function AddCourseToSchemaForm({
                 />
 
                 {isBusy && <Loader />}
-                <Button type="submit" className="w-full" disabled={isBusy}>
+                <Button
+                  type="submit"
+                  variant="secondary"
+                  className="w-full"
+                  disabled={isBusy}
+                >
                   Lägg till!
                 </Button>
               </form>

--- a/src/app/admin/termin/forms/AddTerminForm.tsx
+++ b/src/app/admin/termin/forms/AddTerminForm.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
+import Loader from "@/components/Loader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -89,6 +90,8 @@ export default function AddTerminForm() {
     return "";
   };
 
+  const isBusy = form.formState.isSubmitting || form.formState.isValidating;
+
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
@@ -168,9 +171,10 @@ export default function AddTerminForm() {
                   )}
                 />
 
-                <Button type="submit" className="w-full">
+                <Button type="submit" className="w-full" disabled={isBusy}>
                   Skapa
                 </Button>
+                {isBusy && <Loader />}
               </form>
             </Form>
           </CardContent>

--- a/src/app/admin/termin/forms/AddTerminForm.tsx
+++ b/src/app/admin/termin/forms/AddTerminForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { PlusIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -96,7 +97,7 @@ export default function AddTerminForm() {
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
         <Button variant="secondary" className="cursor-pointer">
-          Ny termin
+          <PlusIcon /> Ny termin
         </Button>
       </DialogTrigger>
 

--- a/src/app/admin/termin/forms/AddTerminForm.tsx
+++ b/src/app/admin/termin/forms/AddTerminForm.tsx
@@ -95,7 +95,7 @@ export default function AddTerminForm() {
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
-        <Button variant={"default"} className="bg-green-500 cursor-pointer">
+        <Button variant="secondary" className="cursor-pointer">
           Ny termin
         </Button>
       </DialogTrigger>
@@ -171,7 +171,12 @@ export default function AddTerminForm() {
                   )}
                 />
 
-                <Button type="submit" className="w-full" disabled={isBusy}>
+                <Button
+                  type="submit"
+                  variant="secondary"
+                  className="w-full"
+                  disabled={isBusy}
+                >
                   Skapa
                 </Button>
                 {isBusy && <Loader />}

--- a/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
@@ -48,9 +48,8 @@ import {
 import type { Course, SchemaItem, Termin } from "@/generated/prisma/client";
 import { editCourseInSchema } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
-import { getCourseName } from "@/lib/tools";
+import { getCourseName, getVeckodag, getWeekdays } from "@/lib/tools";
 import { adminAddCourseToSchemaSchema } from "@/validations/adminforms";
-import { veckodagar } from "../SchemaDay";
 
 const formSchema = adminAddCourseToSchemaSchema;
 type FormValues = z.infer<typeof adminAddCourseToSchemaSchema>;
@@ -65,7 +64,6 @@ interface Props {
 export default function EditCourseToSchemaForm({
   termin,
   allCourses,
-  weekdays,
   schemaItem,
 }: Props) {
   const form = useForm<FormValues>({
@@ -189,10 +187,12 @@ export default function EditCourseToSchemaForm({
     }
   }
 
+  const weekdays = getWeekdays();
+
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm" className="h-8 w-8 p-0 mb-3">
+        <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
           <Pencil className="h-4 w-4" />
           <span className="sr-only">Redigera kurstillfälle</span>
         </Button>
@@ -274,9 +274,9 @@ export default function EditCourseToSchemaForm({
                         <SelectContent>
                           <SelectGroup>
                             <SelectLabel>Välj dag</SelectLabel>
-                            {weekdays.map((c, i) => (
+                            {weekdays.map((c) => (
                               <SelectItem key={c} value={c}>
-                                {veckodagar[i]}
+                                {getVeckodag(c)}
                               </SelectItem>
                             ))}
                           </SelectGroup>

--- a/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Edit } from "lucide-react";
+import { Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -46,7 +46,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { Course, SchemaItem, Termin } from "@/generated/prisma/client";
-import { addCoursetoSchema } from "@/lib/actions/admin";
+import { editCourseInSchema } from "@/lib/actions/admin";
 import { dbToFormTime } from "@/lib/time-convert";
 import { getCourseName } from "@/lib/tools";
 import { adminAddCourseToSchemaSchema } from "@/validations/adminforms";
@@ -132,7 +132,19 @@ export default function EditCourseToSchemaForm({
 
   useEffect(() => {
     if (!isOpen) {
-      form.reset();
+      form.reset({
+        courseId: schemaItem.courseId,
+        place: schemaItem.place ?? "",
+        customEndDate:
+          schemaItem.customEndDate?.toISOString().split("T")[0] ??
+          termin.endDate.toISOString().split("T")[0],
+        customStartDate:
+          schemaItem.customStartDate?.toISOString().split("T")[0] ??
+          termin.startDate.toISOString().split("T")[0],
+        day: schemaItem.weekday,
+        timeStart: dbToFormTime(schemaItem.timeStart),
+        timeEnd: dbToFormTime(schemaItem.timeEnd),
+      });
 
       setUseTerminStart(
         !schemaItem.customStartDate ||
@@ -154,6 +166,11 @@ export default function EditCourseToSchemaForm({
     schemaItem.customStartDate,
     termin.endDate,
     termin.startDate,
+    schemaItem.courseId,
+    schemaItem.place,
+    schemaItem.timeEnd,
+    schemaItem.timeStart,
+    schemaItem.weekday,
   ]);
 
   const router = useRouter();
@@ -161,7 +178,7 @@ export default function EditCourseToSchemaForm({
   async function onSubmit(values: FormValues) {
     console.log(`Values sent:\n${values}`);
 
-    const res = await addCoursetoSchema(termin.id, values);
+    const res = await editCourseInSchema(termin.id, schemaItem.id, values);
     console.log(`res:\n${JSON.stringify(res)}`);
     if (res.success) {
       toast.success(res.msg);
@@ -175,8 +192,9 @@ export default function EditCourseToSchemaForm({
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
-        <Button variant={"default"} className="cursor-pointer mb-3">
-          <Edit />
+        <Button variant="ghost" size="sm" className="h-8 w-8 p-0 mb-3">
+          <Pencil className="h-4 w-4" />
+          <span className="sr-only">Redigera kurstillfälle</span>
         </Button>
       </DialogTrigger>
       <DialogContent className="overflow-y-auto max-h-[90vh]">
@@ -434,8 +452,13 @@ export default function EditCourseToSchemaForm({
                 />
 
                 {isBusy && <Loader />}
-                <Button type="submit" className="w-full" disabled={isBusy}>
-                  Lägg till!
+                <Button
+                  type="submit"
+                  variant="secondary"
+                  className="w-full"
+                  disabled={isBusy}
+                >
+                  Ändra
                 </Button>
               </form>
             </Form>

--- a/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
+++ b/src/app/admin/termin/forms/EditCourseToSchemaForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Edit } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -44,8 +45,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { Course, Termin } from "@/generated/prisma/client";
+import type { Course, SchemaItem, Termin } from "@/generated/prisma/client";
 import { addCoursetoSchema } from "@/lib/actions/admin";
+import { dbToFormTime } from "@/lib/time-convert";
 import { getCourseName } from "@/lib/tools";
 import { adminAddCourseToSchemaSchema } from "@/validations/adminforms";
 import { veckodagar } from "../SchemaDay";
@@ -57,28 +59,44 @@ interface Props {
   termin: Termin;
   allCourses: Course[];
   weekdays: string[];
+  schemaItem: SchemaItem;
 }
 
-export default function AddCourseToSchemaForm({
+export default function EditCourseToSchemaForm({
   termin,
   allCourses,
   weekdays,
+  schemaItem,
 }: Props) {
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      courseId: "",
-      place: "",
-      customEndDate: termin.endDate.toISOString().split("T")[0],
-      customStartDate: termin.startDate.toISOString().split("T")[0],
-      day: "MONDAY",
-      timeStart: "01:00",
-      timeEnd: "02:00",
+      courseId: schemaItem.courseId,
+      place: schemaItem.place ?? "",
+      customEndDate:
+        schemaItem.customEndDate?.toISOString().split("T")[0] ??
+        termin.endDate.toISOString().split("T")[0],
+      customStartDate:
+        schemaItem.customStartDate?.toISOString().split("T")[0] ??
+        termin.startDate.toISOString().split("T")[0],
+      day: schemaItem.weekday,
+      timeStart: dbToFormTime(schemaItem.timeStart),
+      timeEnd: dbToFormTime(schemaItem.timeEnd),
     },
   });
 
-  const terminStartValue = termin.startDate.toLocaleDateString("sv-SE");
-  const terminEndValue = termin.endDate.toLocaleDateString("sv-SE");
+  const terminStartValue = termin.startDate.toISOString().split("T")[0];
+  const terminEndValue = termin.endDate.toISOString().split("T")[0];
+
+  const sameDayUtc = useCallback(
+    (a?: Date | null, b?: Date | null) =>
+      !!a &&
+      !!b &&
+      a.getUTCFullYear() === b.getUTCFullYear() &&
+      a.getUTCMonth() === b.getUTCMonth() &&
+      a.getUTCDate() === b.getUTCDate(),
+    [],
+  );
 
   const formatDateToInput = (date: unknown) => {
     if (!date) {
@@ -100,8 +118,14 @@ export default function AddCourseToSchemaForm({
   };
 
   const [isOpen, setIsOpen] = useState(false);
-  const [useTerminStart, setUseTerminStart] = useState(true);
-  const [useTerminEnd, setUseTerminEnd] = useState(true);
+  const [useTerminStart, setUseTerminStart] = useState(
+    !schemaItem.customStartDate ||
+      sameDayUtc(schemaItem.customStartDate, termin.startDate),
+  );
+  const [useTerminEnd, setUseTerminEnd] = useState(
+    !schemaItem.customEndDate ||
+      sameDayUtc(schemaItem.customEndDate, termin.endDate),
+  );
   const customStartBackupRef = useRef<string>("");
   const customEndBackupRef = useRef<string>("");
   const isBusy = form.formState.isSubmitting || form.formState.isValidating;
@@ -110,18 +134,35 @@ export default function AddCourseToSchemaForm({
     if (!isOpen) {
       form.reset();
 
-      setUseTerminStart(true);
-      setUseTerminEnd(true);
+      setUseTerminStart(
+        !schemaItem.customStartDate ||
+          sameDayUtc(schemaItem.customStartDate, termin.startDate),
+      );
+      setUseTerminEnd(
+        !schemaItem.customEndDate ||
+          sameDayUtc(schemaItem.customEndDate, termin.endDate),
+      );
+
       customStartBackupRef.current = "";
       customEndBackupRef.current = "";
     }
-  }, [isOpen, form]);
+  }, [
+    isOpen,
+    form,
+    sameDayUtc,
+    schemaItem.customEndDate,
+    schemaItem.customStartDate,
+    termin.endDate,
+    termin.startDate,
+  ]);
 
   const router = useRouter();
 
   async function onSubmit(values: FormValues) {
-    const res = await addCoursetoSchema(termin.id, values);
+    console.log(`Values sent:\n${values}`);
 
+    const res = await addCoursetoSchema(termin.id, values);
+    console.log(`res:\n${JSON.stringify(res)}`);
     if (res.success) {
       toast.success(res.msg);
       setIsOpen(false);
@@ -134,11 +175,8 @@ export default function AddCourseToSchemaForm({
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
-        <Button
-          variant={"default"}
-          className="bg-green-500 cursor-pointer mb-3"
-        >
-          Lägg till kurs
+        <Button variant={"default"} className="cursor-pointer mb-3">
+          <Edit />
         </Button>
       </DialogTrigger>
       <DialogContent className="overflow-y-auto max-h-[90vh]">
@@ -154,7 +192,7 @@ export default function AddCourseToSchemaForm({
 
         <Card>
           <CardHeader>
-            <CardTitle>Nytt kurstillfälle i {termin.name}.</CardTitle>
+            <CardTitle>Ändra kurstillfälle i {termin.name}.</CardTitle>
             <CardDescription></CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/app/admin/termin/forms/EditTerminForm.tsx
+++ b/src/app/admin/termin/forms/EditTerminForm.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
+import Loader from "@/components/Loader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -104,12 +106,14 @@ export default function EditTerminForm({ termin }: Props) {
     // Fallback: Returnera tomt
     return "";
   };
+  const isBusy = form.formState.isSubmitting || form.formState.isValidating;
 
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
       <DialogTrigger asChild>
-        <Button variant={"default"} className="cursor-pointer">
-          Ändra termin
+        <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+          <Pencil className="h-4 w-4" />
+          <span className="sr-only">Redigera termin</span>
         </Button>
       </DialogTrigger>
 
@@ -184,8 +188,14 @@ export default function EditTerminForm({ termin }: Props) {
                   )}
                 />
 
-                <Button type="submit" className="w-full">
-                  Skapa
+                {isBusy && <Loader />}
+                <Button
+                  type="submit"
+                  variant="secondary"
+                  className="w-full"
+                  disabled={isBusy}
+                >
+                  Ändra
                 </Button>
               </form>
             </Form>

--- a/src/app/admin/termin/page.tsx
+++ b/src/app/admin/termin/page.tsx
@@ -48,7 +48,7 @@ export default async function Page({
           <TableHeader>
             <TableRow className="bg-muted/50 text-xs uppercase tracking-wide text-muted-foreground">
               <TableHead className="p-3 text-left">Namn</TableHead>
-              <TableHead className="p-3 text-right">Handlingar</TableHead>
+              <TableHead className="p-3 text-right">Åtgärder</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/src/app/admin/termin/page.tsx
+++ b/src/app/admin/termin/page.tsx
@@ -4,6 +4,16 @@ import { HideOldCheckbox } from "./components/HideOldCheckbox";
 import AddTerminForm from "./forms/AddTerminForm";
 import TerminItem from "./TerminItem";
 
+// 1. Gå igenom formuläret för att lägga till en termin, dvs jämför med profilsidor.
+
+// 2. Gå igenom formuläret för att lägga till en kurs i en termin, dvs jämför.
+
+// 3. Lägg till ett ändra-kurs i termin formulär.
+
+// 4. Lägg till snyggare detaljer i schemat.
+
+// 5. Lägg till statistik
+
 function isterminOld(termin: Termin): boolean {
   const today = new Date();
 
@@ -41,7 +51,7 @@ export default async function Page({
         {terminer
           .filter((t) => hide !== "yes" || !isterminOld(t))
           .map((t) => (
-            <TerminItem termin={t} key={t.id}></TerminItem>
+            <TerminItem termin={t} key={t.id} />
           ))}
       </div>
     </div>

--- a/src/app/admin/termin/page.tsx
+++ b/src/app/admin/termin/page.tsx
@@ -32,7 +32,7 @@ export default async function Page({
 
   return (
     <div>
-      <div className="w-full md:grid md:grid-cols-2 gap-2 p-2">
+      <div className="w-full md:grid md:grid-cols-1 gap-2 p-2">
         <div className="col-span-2 flex gap-2 items-center">
           <div>
             <span className="font-bold text-2xl">

--- a/src/app/admin/termin/page.tsx
+++ b/src/app/admin/termin/page.tsx
@@ -1,24 +1,15 @@
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import type { Termin } from "@/generated/prisma/client";
 import { getTerminer } from "@/lib/actions/admin";
 import { HideOldCheckbox } from "./components/HideOldCheckbox";
 import AddTerminForm from "./forms/AddTerminForm";
 import TerminItem from "./TerminItem";
-
-// 1. Gå igenom formuläret för att lägga till en termin, dvs jämför med profilsidor.
-
-// 2. Gå igenom formuläret för att lägga till en kurs i en termin, dvs jämför.
-
-// 3. Lägg till ett ändra-kurs i termin formulär.
-
-// 4. Lägg till snyggare detaljer i schemat.
-
-// 5. Lägg till statistik
-
-function isterminOld(termin: Termin): boolean {
-  const today = new Date();
-
-  return today > termin.endDate;
-}
 
 export default async function Page({
   searchParams,
@@ -27,33 +18,55 @@ export default async function Page({
 }) {
   const terminer = await getTerminer();
 
+  function isTerminActive(termin: Termin): boolean {
+    const today = new Date();
+    return today >= termin.startDate && today <= termin.endDate;
+  }
+
   const params = await searchParams;
   const hide = params.hide || "";
 
   return (
-    <div>
-      <div className="w-full md:grid md:grid-cols-1 gap-2 p-2">
-        <div className="col-span-2 flex gap-2 items-center">
-          <div>
-            <span className="font-bold text-2xl">
-              Terminer och veckoscheman
-            </span>
-          </div>
-
-          <div>
-            <HideOldCheckbox />
-          </div>
-
-          <div>
-            <AddTerminForm />
-          </div>
+    <div className=" w-full p-2">
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight">
+            Terminer och veckoscheman
+          </h1>
+          <p className="text-sm md:text-base text-muted-foreground leading-relaxed max-w-xl">
+            Skapa terminer och hantera veckoscheman för kurserna.
+          </p>
         </div>
-        {terminer
-          .filter((t) => hide !== "yes" || !isterminOld(t))
-          .map((t) => (
-            <TerminItem termin={t} key={t.id} />
-          ))}
+        <div className="flex items-center gap-3">
+          <HideOldCheckbox />
+          <AddTerminForm />
+        </div>
       </div>
+
+      <div className="border rounded-lg w-full mt-2">
+        <Table className="w-full text-sm ">
+          <TableHeader>
+            <TableRow className="bg-muted/50 text-xs uppercase tracking-wide text-muted-foreground">
+              <TableHead className="p-3 text-left">Namn</TableHead>
+              <TableHead className="p-3 text-right">Handlingar</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {terminer
+              .filter((t) => hide !== "yes" || isTerminActive(t))
+              .map((t) => (
+                <TerminItem termin={t} key={t.id} />
+              ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {terminer.filter((t) => hide !== "yes" || isTerminActive(t)).length ===
+        0 && (
+        <div className="text-center py-12 border rounded-lg bg-muted/20">
+          <p className="text-muted-foreground">Inga terminer hittades.</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -24,7 +24,7 @@ import {
   getProductSchema,
   getProductTermin,
 } from "@/lib/actions/server-actions";
-import { getVeckodag } from "../admin/termin/SchemaDay";
+import { getVeckodag } from "@/lib/tools";
 
 export default async function Page() {
   const products = await getAllProducts();

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,5 @@
+export default function Loader() {
+  return (
+    <div className="w-12 h-12 rounded-full border-3 border-blue-500 border-t-blue-300"></div>
+  );
+}

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,5 +1,7 @@
 export default function Loader() {
   return (
-    <div className="w-12 h-12 rounded-full border-3 border-blue-500 border-t-blue-300"></div>
+    <div className="flex justify-center">
+      <div className="w-12 h-12 rounded-full border-3 border-blue-500 border-t-blue-300"></div>
+    </div>
   );
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -180,32 +180,7 @@ export async function editTermin(
         },
       });
 
-      // 2. Hantera bokningar som hamnar utanför de nya datumen (Återbetalning).
-      const affectedBookings = await tx.booking.findMany({
-        where: {
-          lesson: {
-            terminId: id,
-            OR: [
-              { startTime: { lt: newStartDate } },
-              { startTime: { gt: newEndDate } },
-            ],
-          },
-        },
-        select: { id: true, purchaseItemId: true },
-      });
-
-      for (const booking of affectedBookings) {
-        if (!booking.purchaseItemId) continue;
-
-        // Ge tillbaka klipp via handleClips:
-        const clipResult = await handleClips(tx, booking.purchaseItemId, 1);
-
-        if (!clipResult.success) {
-          throw new Error(clipResult.msg || "Clip update failed.");
-        }
-      }
-
-      // 3. Hämta alla schemaItems för att synka lektioner
+      // 2. Hämta alla schemaItems för att synka lektioner
       const schemaItems = await tx.schemaItem.findMany({
         where: { terminId: id },
         include: {
@@ -214,17 +189,66 @@ export async function editTermin(
         },
       });
 
-      // 4. Städa bort lektioner som nu ligger utanför intervallet
-      // (Bokningarna raderas här pga Cascade Delete, klippen är redan återställda ovan).
-      await tx.lesson.deleteMany({
-        where: {
-          terminId: id,
-          OR: [
-            { startTime: { lt: newStartDate } },
-            { startTime: { gt: newEndDate } },
-          ],
-        },
-      });
+      // 3. Validera att custom-datum fortfarande ligger inom nya terminens datum
+      for (const item of schemaItems) {
+        if (
+          item.customStartDate &&
+          (item.customStartDate < newStartDate ||
+            item.customStartDate > newEndDate)
+        ) {
+          throw new Error(
+            "Startdatum för en kurs ligger utanför terminens nya datum.",
+          );
+        }
+
+        if (
+          item.customEndDate &&
+          (item.customEndDate < newStartDate || item.customEndDate > newEndDate)
+        ) {
+          throw new Error(
+            "Slutdatum för en kurs ligger utanför terminens nya datum.",
+          );
+        }
+      }
+
+      // 4. Hantera bokningar och lektioner som hamnar utanför de nya tidsramarna
+      for (const item of schemaItems) {
+        const validStart = item.customStartDate ?? newStartDate; //
+        const validEnd = item.customEndDate ?? newEndDate;
+
+        const affectedBookings = await tx.booking.findMany({
+          where: {
+            lesson: {
+              schemaItemId: item.id,
+              OR: [
+                { startTime: { lt: validStart } },
+                { startTime: { gt: validEnd } },
+              ],
+            },
+          },
+          select: { id: true, purchaseItemId: true },
+        });
+
+        for (const booking of affectedBookings) {
+          if (!booking.purchaseItemId) continue;
+
+          const clipResult = await handleClips(tx, booking.purchaseItemId, 1);
+          if (!clipResult.success) {
+            throw new Error(clipResult.msg || "Clip update failed.");
+          }
+        }
+
+        // Städa bort lektioner utanför intervallet för denna kurs
+        await tx.lesson.deleteMany({
+          where: {
+            schemaItemId: item.id,
+            OR: [
+              { startTime: { lt: validStart } },
+              { startTime: { gt: validEnd } },
+            ],
+          },
+        });
+      }
 
       // 5. Skapa nya lektioner för de datum som tillkommit
       const WEEKDAY_MAP: Record<string, number> = {
@@ -241,14 +265,16 @@ export async function editTermin(
 
       for (const item of schemaItems) {
         const targetDay = WEEKDAY_MAP[item.weekday];
-        const currentDate = new Date(newStartDate.getTime());
+        const actualStart = item.customStartDate ?? newStartDate;
+        const actualEnd = item.customEndDate ?? newEndDate;
+        const currentDate = new Date(actualStart.getTime());
 
         const startHours = item.timeStart.getHours();
         const startMinutes = item.timeStart.getMinutes();
         const endHours = item.timeEnd.getHours();
         const endMinutes = item.timeEnd.getMinutes();
 
-        while (currentDate <= newEndDate) {
+        while (currentDate <= actualEnd) {
           currentDate.setHours(0, 0, 0, 0);
 
           if (currentDate.getDay() === targetDay) {
@@ -296,7 +322,9 @@ export async function editTermin(
     };
   } catch (e) {
     console.error("Fel vid editTermin:", e);
-    return { success: false, msg: "Ett fel uppstod vid uppdatering." };
+    const msg =
+      e instanceof Error ? e.message : "Ett fel uppstod vid uppdatering.";
+    return { success: false, msg };
   }
 }
 
@@ -323,42 +351,65 @@ export async function addCoursetoSchema(
 
     if (!getCourse) throw new Error("Course was not found.");
 
-    const newSchemaItem = await prisma.schemaItem.create({
-      data: {
-        terminId,
-        place: validated.place,
-        courseId: validated.courseId,
-        maxBookings: getCourse?.maxBookings,
-        timeStart: formToDbDate(validated.timeStart),
-        timeEnd: formToDbDate(validated.timeEnd),
-        weekday: validated.day as Weekday,
-      },
-      include: { course: true, termin: true },
-    });
+    const result = await prisma.$transaction(async (tx) => {
+      const termin = await tx.termin.findUnique({ where: { id: terminId } });
+      if (!termin) throw new Error("No termin.");
 
-    // SKapa lessons!
-    const lessons = await createLessons(newSchemaItem.id);
+      const customStartDate = validated.customStartDate
+        ? new Date(validated.customStartDate)
+        : null;
+      const customEndDate = validated.customEndDate
+        ? new Date(validated.customEndDate)
+        : null;
 
-    if (!lessons.success) {
-      const del = await prisma.schemaItem.delete({
-        where: { id: newSchemaItem.id },
+      if (
+        customStartDate &&
+        (customStartDate < termin.startDate || customStartDate > termin.endDate)
+      ) {
+        throw new Error("Startdatum måste ligga inom terminens datum.");
+      }
+
+      if (
+        customEndDate &&
+        (customEndDate < termin.startDate || customEndDate > termin.endDate)
+      ) {
+        throw new Error("Slutdatum måste ligga inom terminens datum.");
+      }
+
+      const newSchemaItem = await tx.schemaItem.create({
+        data: {
+          terminId,
+          place: validated.place,
+          courseId: validated.courseId,
+          maxBookings: getCourse?.maxBookings,
+          timeStart: formToDbDate(validated.timeStart),
+          timeEnd: formToDbDate(validated.timeEnd),
+          customStartDate,
+          customEndDate,
+          weekday: validated.day as Weekday,
+        },
+        include: { course: true, termin: true },
       });
-      if (!del)
-        throw new Error(
-          "SchemaItem was created, but could not create lessons, and could not delete the schemaItem. Empty schemaItem can be in the db.",
-        );
 
-      throw new Error(
-        "Inga lektioner kunde skapas inom denna termin. Kontrollera startDate och endDate så de täcker bokningsbara dagar.",
-      );
-    }
+      const lessons = await createLessons(newSchemaItem.id, tx);
+
+      if (!lessons.success) {
+        throw new Error(
+          "Inga lektioner kunde skapas inom denna termin. Kontrollera startDate och endDate så de täcker bokningsbara dagar.",
+        );
+      }
+
+      return { newSchemaItem, lessonsMsg: lessons.msg };
+    });
 
     return {
       success: true,
-      msg: `Kursen ${newSchemaItem.course.name} lades till i terminen ${newSchemaItem.termin.name}. ${lessons.msg}`,
+      msg: `Kursen ${result.newSchemaItem.course.name} lades till i terminen ${result.newSchemaItem.termin.name}. ${result.lessonsMsg}`,
     };
   } catch (e) {
-    return { success: false, msg: JSON.stringify(e) };
+    console.error(e);
+    const msg = e instanceof Error ? e.message : JSON.stringify(e);
+    return { success: false, msg };
   }
 }
 
@@ -657,6 +708,7 @@ export async function editCourse(
  */
 async function createLessons(
   schemaItemId: string,
+  tx?: Prisma.TransactionClient,
 ): Promise<{ success: boolean; msg: string }> {
   const isAdmin = await isAdminRole();
   if (!isAdmin) return { success: false, msg: "No permission." };
@@ -666,7 +718,9 @@ async function createLessons(
 
     // Behöver vi validatera någonting här? ev. fix.
 
-    const schemaItm = await prisma.schemaItem.findUnique({
+    const db = tx ?? prisma;
+
+    const schemaItm = await db.schemaItem.findUnique({
       where: { id: schemaItemId },
       include: { termin: true, course: true },
     });
@@ -685,8 +739,8 @@ async function createLessons(
 
     const targetDay = WEEKDAY_MAP[schemaItm?.weekday]; // Få targetday som rätt nummer.
 
-    const startDate = schemaItm.termin.startDate;
-    const endDate = schemaItm.termin.endDate;
+    const startDate = schemaItm.customStartDate ?? schemaItm.termin.startDate;
+    const endDate = schemaItm.customEndDate ?? schemaItm.termin.endDate;
     const teacherId = schemaItm.course.teacherId;
 
     const lessonsToCreate = []; // Dessa lessions ska skapas.
@@ -735,19 +789,17 @@ async function createLessons(
       };
     }
 
-    // 1. Definiera de operationer som ska ingå i transaktionen
-    const creationOperation = prisma.lesson.createMany({
+    const result = await db.lesson.createMany({
       data: lessonsToCreate,
       skipDuplicates: true,
     });
-
-    const [result] = await prisma.$transaction([creationOperation]);
 
     return {
       success: true,
       msg: `Successfully created ${result.count} lessons.`,
     };
   } catch (e) {
+    console.error(e);
     return { success: false, msg: JSON.stringify(e) };
   }
 }

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -174,7 +174,11 @@ export async function editTermin(
     const newEndDate = new Date(validated.endDate);
 
     const result = await prisma.$transaction(async (tx) => {
-      // 1. Uppdatera själva terminen
+      // 1. Hämta nuvarande termin (för att avgöra "följ termin")
+      const currentTermin = await tx.termin.findUnique({ where: { id } });
+      if (!currentTermin) throw new Error("No termin.");
+
+      // 2. Uppdatera själva terminen
       const updatedTermin = await tx.termin.update({
         where: { id },
         data: {
@@ -193,33 +197,55 @@ export async function editTermin(
         },
       });
 
-      // 3. Validera att custom-datum fortfarande ligger inom nya terminens datum
-      for (const item of schemaItems) {
-        if (
-          item.customStartDate &&
-          (item.customStartDate < newStartDate ||
-            item.customStartDate > newEndDate)
-        ) {
-          throw new Error(
-            "Startdatum för en kurs ligger utanför terminens nya datum.",
-          );
-        }
+      // // 3. Validera att custom-datum fortfarande ligger inom nya terminens datum
 
-        if (
-          item.customEndDate &&
-          (item.customEndDate < newStartDate || item.customEndDate > newEndDate)
-        ) {
-          throw new Error(
-            "Slutdatum för en kurs ligger utanför terminens nya datum.",
-          );
-        }
-      }
+      // Vi har inte längre den gränsen. Behåller just nu ifall vi vill ändra tillbaka logiken.
+      // for (const item of schemaItems) {
+      //   if (
+      //     item.customStartDate &&
+      //     (item.customStartDate < newStartDate ||
+      //       item.customStartDate > newEndDate)
+      //   ) {
+      //     throw new Error(
+      //       "Startdatum för en kurs ligger utanför terminens nya datum.",
+      //     );
+      //   }
+
+      //   if (
+      //     item.customEndDate &&
+      //     (item.customEndDate < newStartDate || item.customEndDate > newEndDate)
+      //   ) {
+      //     throw new Error(
+      //       "Slutdatum för en kurs ligger utanför terminens nya datum.",
+      //     );
+      //   }
+      // }
+
+      const sameDayUtc = (a: Date, b: Date) =>
+        a.getUTCFullYear() === b.getUTCFullYear() &&
+        a.getUTCMonth() === b.getUTCMonth() &&
+        a.getUTCDate() === b.getUTCDate();
 
       // 4. Hantera bokningar och lektioner som hamnar utanför de nya tidsramarna
       for (const item of schemaItems) {
-        const validStart = item.customStartDate ?? newStartDate; //
-        const validEnd = item.customEndDate ?? newEndDate;
+        // Kollar om schemaItem följer terminens datum:
+        const followsStart =
+          !item.customStartDate ||
+          sameDayUtc(item.customStartDate, currentTermin.startDate);
+        const followsEnd =
+          !item.customEndDate ||
+          sameDayUtc(item.customEndDate, currentTermin.endDate);
 
+        // Beroende på det så ska vi bygga nya lektioner (eller ta bort). Om custom så kommer det bli orört
+        // (eftersom vi hämtar less than validStart och greater than validEnd)...
+        const validStart = followsStart
+          ? newStartDate
+          : (item.customStartDate ?? newStartDate);
+        const validEnd = followsEnd
+          ? newEndDate
+          : (item.customEndDate ?? newEndDate);
+
+        // Hämta de boknignar som ev berörs:
         const affectedBookings = await tx.booking.findMany({
           where: {
             lesson: {
@@ -234,7 +260,7 @@ export async function editTermin(
         });
 
         for (const booking of affectedBookings) {
-          if (!booking.purchaseItemId) continue;
+          if (!booking.purchaseItemId) continue; // Ska visserligen alltid finnas...
 
           const clipResult = await handleClips(tx, booking.purchaseItemId, 1);
           if (!clipResult.success) {
@@ -242,7 +268,7 @@ export async function editTermin(
           }
         }
 
-        // Städa bort lektioner utanför intervallet för denna kurs
+        // Städa bort lektioner utanför intervallet:
         await tx.lesson.deleteMany({
           where: {
             schemaItemId: item.id,
@@ -254,7 +280,7 @@ export async function editTermin(
         });
       }
 
-      // 5. Skapa nya lektioner för de datum som tillkommit
+      // 5. Skapa nya lektioner för de datum som ev tillkommit ()
       const WEEKDAY_MAP: Record<string, number> = {
         MONDAY: 1,
         TUESDAY: 2,
@@ -269,8 +295,19 @@ export async function editTermin(
 
       for (const item of schemaItems) {
         const targetDay = WEEKDAY_MAP[item.weekday];
-        const actualStart = item.customStartDate ?? newStartDate;
-        const actualEnd = item.customEndDate ?? newEndDate;
+        const followsStart =
+          !item.customStartDate ||
+          sameDayUtc(item.customStartDate, currentTermin.startDate);
+        const followsEnd =
+          !item.customEndDate ||
+          sameDayUtc(item.customEndDate, currentTermin.endDate);
+
+        const actualStart = followsStart
+          ? newStartDate
+          : (item.customStartDate ?? newStartDate);
+        const actualEnd = followsEnd
+          ? newEndDate
+          : (item.customEndDate ?? newEndDate);
         const currentDate = new Date(actualStart.getTime());
 
         const startHours = item.timeStart.getHours();
@@ -359,42 +396,12 @@ export async function addCoursetoSchema(
       const termin = await tx.termin.findUnique({ where: { id: terminId } });
       if (!termin) throw new Error("No termin.");
 
-      const customStartDate = validated.customStartDate
+      const finalStartDate = validated.customStartDate
         ? new Date(validated.customStartDate)
-        : null;
-      const customEndDate = validated.customEndDate
+        : termin.startDate;
+      const finalEndDate = validated.customEndDate
         ? new Date(validated.customEndDate)
-        : null;
-
-      const dateOnlyUtc = (d: Date) =>
-        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-      const isSameDateUtc = (a: Date, b: Date) =>
-        dateOnlyUtc(a) === dateOnlyUtc(b);
-
-      const finalCustomStartDate =
-        customStartDate && isSameDateUtc(customStartDate, termin.startDate)
-          ? null
-          : customStartDate;
-      const finalCustomEndDate =
-        customEndDate && isSameDateUtc(customEndDate, termin.endDate)
-          ? null
-          : customEndDate;
-
-      if (
-        finalCustomStartDate &&
-        (dateOnlyUtc(finalCustomStartDate) < dateOnlyUtc(termin.startDate) ||
-          dateOnlyUtc(finalCustomStartDate) > dateOnlyUtc(termin.endDate))
-      ) {
-        throw new Error("Startdatum måste ligga inom terminens datum.");
-      }
-
-      if (
-        finalCustomEndDate &&
-        (dateOnlyUtc(finalCustomEndDate) < dateOnlyUtc(termin.startDate) ||
-          dateOnlyUtc(finalCustomEndDate) > dateOnlyUtc(termin.endDate))
-      ) {
-        throw new Error("Slutdatum måste ligga inom terminens datum.");
-      }
+        : termin.endDate;
 
       const newSchemaItem = await tx.schemaItem.create({
         data: {
@@ -404,8 +411,8 @@ export async function addCoursetoSchema(
           maxBookings: getCourse?.maxBookings,
           timeStart: formToDbDate(validated.timeStart),
           timeEnd: formToDbDate(validated.timeEnd),
-          customStartDate: finalCustomStartDate,
-          customEndDate: finalCustomEndDate,
+          customStartDate: finalStartDate,
+          customEndDate: finalEndDate,
           weekday: validated.day as Weekday,
         },
         include: { course: true, termin: true },
@@ -457,42 +464,12 @@ export async function editCourseInSchema(
     const termin = await prisma.termin.findUnique({ where: { id: terminId } });
     if (!termin) throw new Error("No termin.");
 
-    const inputStartDate = validated.customStartDate
+    const finalStartDate = validated.customStartDate
       ? new Date(validated.customStartDate)
-      : null;
-    const inputEndDate = validated.customEndDate
+      : termin.startDate;
+    const finalEndDate = validated.customEndDate
       ? new Date(validated.customEndDate)
-      : null;
-
-    const dateOnlyUtc = (d: Date) =>
-      Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-    const isSameDateUtc = (a: Date, b: Date) =>
-      dateOnlyUtc(a) === dateOnlyUtc(b);
-
-    const finalStartDate =
-      inputStartDate && isSameDateUtc(inputStartDate, termin.startDate)
-        ? null
-        : inputStartDate;
-    const finalEndDate =
-      inputEndDate && isSameDateUtc(inputEndDate, termin.endDate)
-        ? null
-        : inputEndDate;
-
-    if (
-      finalStartDate &&
-      (dateOnlyUtc(finalStartDate) < dateOnlyUtc(termin.startDate) ||
-        dateOnlyUtc(finalStartDate) > dateOnlyUtc(termin.endDate))
-    ) {
-      throw new Error("Startdatum måste ligga inom terminens datum.");
-    }
-
-    if (
-      finalEndDate &&
-      (dateOnlyUtc(finalEndDate) < dateOnlyUtc(termin.startDate) ||
-        dateOnlyUtc(finalEndDate) > dateOnlyUtc(termin.endDate))
-    ) {
-      throw new Error("Slutdatum måste ligga inom terminens datum.");
-    }
+      : termin.endDate;
 
     const result = await prisma.$transaction(async (tx) => {
       const updatedSchemaItem = await tx.schemaItem.update({

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import type z from "zod";
 import type {
   Course,
+  Lesson,
   Prisma,
   Product,
   SchemaItem,
@@ -55,7 +56,10 @@ export async function getTerminer(): Promise<Termin[]> {
  * Needed in admin/termin to list all schemaitems, including course for building coursename (see GetCourseName in app/tools).
  *
  */
-export type SchemaItemWithCourse = SchemaItem & { course: Course };
+export type SchemaItemWithCourse = SchemaItem & {
+  course: Course;
+  Lessons: Lesson[];
+};
 
 /**
  * Gets schemaItems (with course) for a specific termin
@@ -71,7 +75,7 @@ export async function getSchemaItems(
 
   const schemaItems = await prisma.schemaItem.findMany({
     where: { terminId },
-    include: { course: true },
+    include: { course: true, Lessons: true },
   });
 
   return schemaItems;
@@ -362,16 +366,32 @@ export async function addCoursetoSchema(
         ? new Date(validated.customEndDate)
         : null;
 
+      const dateOnlyUtc = (d: Date) =>
+        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+      const isSameDateUtc = (a: Date, b: Date) =>
+        dateOnlyUtc(a) === dateOnlyUtc(b);
+
+      const finalCustomStartDate =
+        customStartDate && isSameDateUtc(customStartDate, termin.startDate)
+          ? null
+          : customStartDate;
+      const finalCustomEndDate =
+        customEndDate && isSameDateUtc(customEndDate, termin.endDate)
+          ? null
+          : customEndDate;
+
       if (
-        customStartDate &&
-        (customStartDate < termin.startDate || customStartDate > termin.endDate)
+        finalCustomStartDate &&
+        (dateOnlyUtc(finalCustomStartDate) < dateOnlyUtc(termin.startDate) ||
+          dateOnlyUtc(finalCustomStartDate) > dateOnlyUtc(termin.endDate))
       ) {
         throw new Error("Startdatum måste ligga inom terminens datum.");
       }
 
       if (
-        customEndDate &&
-        (customEndDate < termin.startDate || customEndDate > termin.endDate)
+        finalCustomEndDate &&
+        (dateOnlyUtc(finalCustomEndDate) < dateOnlyUtc(termin.startDate) ||
+          dateOnlyUtc(finalCustomEndDate) > dateOnlyUtc(termin.endDate))
       ) {
         throw new Error("Slutdatum måste ligga inom terminens datum.");
       }
@@ -384,8 +404,8 @@ export async function addCoursetoSchema(
           maxBookings: getCourse?.maxBookings,
           timeStart: formToDbDate(validated.timeStart),
           timeEnd: formToDbDate(validated.timeEnd),
-          customStartDate,
-          customEndDate,
+          customStartDate: finalCustomStartDate,
+          customEndDate: finalCustomEndDate,
           weekday: validated.day as Weekday,
         },
         include: { course: true, termin: true },
@@ -405,6 +425,113 @@ export async function addCoursetoSchema(
     return {
       success: true,
       msg: `Kursen ${result.newSchemaItem.course.name} lades till i terminen ${result.newSchemaItem.termin.name}. ${result.lessonsMsg}`,
+    };
+  } catch (e) {
+    console.error(e);
+    const msg = e instanceof Error ? e.message : JSON.stringify(e);
+    return { success: false, msg };
+  }
+}
+
+/**
+  Edit schemaitems and lessons when editing a course in a termin week schema.
+ * @auth Admin
+ */
+export async function editCourseInSchema(
+  terminId: string,
+  schemaItemId: string,
+  formData: z.infer<typeof adminAddCourseToSchemaSchema>,
+): Promise<{ success: boolean; msg: string }> {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, msg: "No permission." };
+
+  try {
+    const validated = await adminAddCourseToSchemaSchema.parseAsync(formData);
+
+    const getCourse = await prisma.course.findUnique({
+      where: { id: validated.courseId },
+    });
+
+    if (!getCourse) throw new Error("Course was not found.");
+
+    const termin = await prisma.termin.findUnique({ where: { id: terminId } });
+    if (!termin) throw new Error("No termin.");
+
+    const inputStartDate = validated.customStartDate
+      ? new Date(validated.customStartDate)
+      : null;
+    const inputEndDate = validated.customEndDate
+      ? new Date(validated.customEndDate)
+      : null;
+
+    const dateOnlyUtc = (d: Date) =>
+      Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+    const isSameDateUtc = (a: Date, b: Date) =>
+      dateOnlyUtc(a) === dateOnlyUtc(b);
+
+    const finalStartDate =
+      inputStartDate && isSameDateUtc(inputStartDate, termin.startDate)
+        ? null
+        : inputStartDate;
+    const finalEndDate =
+      inputEndDate && isSameDateUtc(inputEndDate, termin.endDate)
+        ? null
+        : inputEndDate;
+
+    if (
+      finalStartDate &&
+      (dateOnlyUtc(finalStartDate) < dateOnlyUtc(termin.startDate) ||
+        dateOnlyUtc(finalStartDate) > dateOnlyUtc(termin.endDate))
+    ) {
+      throw new Error("Startdatum måste ligga inom terminens datum.");
+    }
+
+    if (
+      finalEndDate &&
+      (dateOnlyUtc(finalEndDate) < dateOnlyUtc(termin.startDate) ||
+        dateOnlyUtc(finalEndDate) > dateOnlyUtc(termin.endDate))
+    ) {
+      throw new Error("Slutdatum måste ligga inom terminens datum.");
+    }
+
+    const result = await prisma.$transaction(async (tx) => {
+      const updatedSchemaItem = await tx.schemaItem.update({
+        where: { id: schemaItemId },
+        data: {
+          terminId,
+          place: validated.place,
+          courseId: validated.courseId,
+          maxBookings: getCourse?.maxBookings,
+          timeStart: formToDbDate(validated.timeStart),
+          timeEnd: formToDbDate(validated.timeEnd),
+          customStartDate: finalStartDate,
+          customEndDate: finalEndDate,
+          weekday: validated.day as Weekday,
+        },
+        include: { course: true, termin: true },
+      });
+
+      await tx.lesson.deleteMany({
+        where: { schemaItemId: updatedSchemaItem.id },
+      });
+
+      return updatedSchemaItem;
+    });
+
+    const lessons = await createLessons(schemaItemId);
+
+    if (!lessons.success) {
+      throw new Error(
+        "Kunde inte generera nya lektioner. Kontrollera dina datum.",
+      );
+    }
+
+    revalidatePath("/admin/termin");
+    revalidatePath("/admin/courses");
+
+    return {
+      success: true,
+      msg: `Kursen ${result.course.name} har uppdaterats i ${result.termin.name}. ${lessons.msg}`,
     };
   } catch (e) {
     console.error(e);

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,3 +1,5 @@
+import type { Weekday } from "@/generated/prisma/client";
+
 type CourseLike = {
   name: string;
   minAge: number | null;
@@ -35,3 +37,24 @@ export function getCourseName(course: CourseLike) {
 export function getWeekdays() {
   return [...WEEKDAYS];
 }
+
+export const getVeckodag = (day: Weekday) => {
+  switch (day) {
+    case "MONDAY":
+      return "Måndag";
+    case "TUESDAY":
+      return "Tisdag";
+    case "WEDNESDAY":
+      return "Onsdag";
+    case "THURSDAY":
+      return "Torsdag";
+    case "FRIDAY":
+      return "Fredag";
+    case "SATURDAY":
+      return "Lördag";
+    case "SUNDAY":
+      return "Söndag";
+    default:
+      return day; // Returnerar originalsträngen om ingen matchning hittas
+  }
+};

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,6 +1,22 @@
-import type { Course } from "@/generated/prisma/client";
+type CourseLike = {
+  name: string;
+  minAge: number | null;
+  maxAge: number | null;
+  adult: boolean;
+  level: string | null;
+};
 
-export function getCourseName(course: Course) {
+const WEEKDAYS = [
+  "MONDAY",
+  "TUESDAY",
+  "WEDNESDAY",
+  "THURSDAY",
+  "FRIDAY",
+  "SATURDAY",
+  "SUNDAY",
+] as const;
+
+export function getCourseName(course: CourseLike) {
   const ageRange =
     course.minAge && course.minAge > 0
       ? `${course.minAge}${
@@ -14,4 +30,8 @@ export function getCourseName(course: Course) {
   const levelInfo = course.level && ` - ${course.level}`;
 
   return `${course.name} ${ageRange} ${levelInfo}`;
+}
+
+export function getWeekdays() {
+  return [...WEEKDAYS];
 }

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -15,6 +15,15 @@ export const adminAddCourseToSchemaSchema = z
 
     timeEnd: z.string().min(1).regex(TIME_REGEX, "HH:MM."),
 
+    customStartDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Ange datum i formatet ÅÅÅÅ-MM-DD.")
+      .optional(),
+    customEndDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Ange datum i formatet ÅÅÅÅ-MM-DD.")
+      .optional(),
+
     day: z.enum(Object.values(Weekday) as [string, ...string[]]),
   })
   .refine(
@@ -25,6 +34,16 @@ export const adminAddCourseToSchemaSchema = z
     {
       message: "Sluttiden måste infalla efter starttiden.",
       path: ["timeEnd"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (!data.customEndDate || !data.customStartDate) return true;
+      return new Date(data.customEndDate) >= new Date(data.customStartDate);
+    },
+    {
+      message: "Slutdatumet måste vara samma eller senare än start datumet.",
+      path: ["customEndDate"],
     },
   );
 


### PR DESCRIPTION
Admin/termin omgjord till tabell‑layout med dialog för veckoschema.

Scheman visar custom‑datum och rikare metadata per schemaItem.

Lagt till edit‑formulär för schemaItems inkl custom‑datum.

Serverlogik uppdaterad för custom‑datum, edit av schemaItems och termin‑uppdateringar.

Renare UI och design.

Prisma: nya fält customStartDate/customEndDate + migration.