### PR TITLE
MaxCustomer-logik

### DIFF
--- a/prisma/migrations/20260218144552_added_cancelled_as_orderstatus/migration.sql
+++ b/prisma/migrations/20260218144552_added_cancelled_as_orderstatus/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "OrderStatus" ADD VALUE 'CANCELLED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -527,6 +527,7 @@ enum OrderStatus {
   AWAITING_APPROVAL
   PAID
   APPROVED
+  CANCELLED
 }
 
 // Audit trail for order status changes

--- a/src/app/admin/orders/OrdersView.tsx
+++ b/src/app/admin/orders/OrdersView.tsx
@@ -10,7 +10,8 @@ type OrderStatus =
   | "PENDING_PAYMENT"
   | "AWAITING_APPROVAL"
   | "APPROVED"
-  | "PAID";
+  | "PAID"
+  | "CANCELLED";
 
 type OrderLite = {
   id: string;
@@ -41,11 +42,13 @@ export default function OrdersView({
   defaultStatus,
   onApprove,
   onMarkPaid,
+  onCancel,
 }: {
   orders: OrderLite[];
   defaultStatus: string;
   onApprove: (formData: FormData) => void;
   onMarkPaid: (formData: FormData) => void;
+  onCancel: (formData: FormData) => void;
 }) {
   const sp = useSearchParams();
   const active = (sp.get("status")?.toUpperCase() || defaultStatus).toString();
@@ -126,6 +129,8 @@ export default function OrdersView({
         return "Godkänd";
       case "PAID":
         return "Betald";
+      case "CANCELLED":
+        return "Avbruten";
       default:
         return status;
     }
@@ -141,6 +146,8 @@ export default function OrdersView({
         return "bg-emerald-500/10 text-emerald-500";
       case "PAID":
         return "bg-blue-500/10 text-blue-500";
+      case "CANCELLED":
+        return "bg-rose-500/10 text-rose-500";
       default:
         return "bg-muted text-muted-foreground";
     }
@@ -316,6 +323,7 @@ export default function OrdersView({
                         "CREATED",
                         "PENDING_PAYMENT",
                         "AWAITING_APPROVAL",
+                        "PAID",
                       ].includes(o.status || "") && (
                         <form
                           action={onApprove}
@@ -346,6 +354,24 @@ export default function OrdersView({
                             pendingText="..."
                           >
                             Betald
+                          </SubmitButton>
+                        </form>
+                      )}
+                      {[
+                        "CREATED",
+                        "PENDING_PAYMENT",
+                        "AWAITING_APPROVAL",
+                      ].includes(o.status || "") && (
+                        <form
+                          action={onCancel}
+                          className="flex items-center gap-2"
+                        >
+                          <input type="hidden" name="orderId" value={o.id} />
+                          <SubmitButton
+                            className="px-3 py-1 bg-rose-600 hover:bg-rose-700 text-white rounded text-xs font-medium transition-colors"
+                            pendingText="..."
+                          >
+                            Avbryt
                           </SubmitButton>
                         </form>
                       )}

--- a/src/app/admin/orders/page.tsx
+++ b/src/app/admin/orders/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { isAdminRole } from "@/lib/actions/admin";
 import {
   approveOrder,
+  cancelOrder,
   createPurchaseFromOrder,
   markOrderPaid,
 } from "@/lib/actions/orders";
@@ -19,7 +20,8 @@ type OrderStatus =
   | "PENDING_PAYMENT"
   | "AWAITING_APPROVAL"
   | "APPROVED"
-  | "PAID";
+  | "PAID"
+  | "CANCELLED";
 
 type OrderLite = {
   id: string;
@@ -102,6 +104,14 @@ export default async function Page({
     revalidatePath("/admin/orders");
   }
 
+  async function onCancel(formData: FormData) {
+    "use server";
+    const orderId = String(formData.get("orderId"));
+    const note = formData.get("note")?.toString();
+    await cancelOrder(orderId, note);
+    revalidatePath("/admin/orders");
+  }
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Ordrar</h1>
@@ -110,6 +120,7 @@ export default async function Page({
         defaultStatus={status}
         onApprove={onApprove}
         onMarkPaid={onMarkPaid}
+        onCancel={onCancel}
       />
     </div>
   );

--- a/src/app/admin/orders/view/view-client.tsx
+++ b/src/app/admin/orders/view/view-client.tsx
@@ -11,7 +11,8 @@ type OrderStatus =
   | "PENDING_PAYMENT"
   | "AWAITING_APPROVAL"
   | "APPROVED"
-  | "PAID";
+  | "PAID"
+  | "CANCELLED";
 
 type OrderItemLite = {
   id: string;

--- a/src/app/admin/products/components/EditProductForm.tsx
+++ b/src/app/admin/products/components/EditProductForm.tsx
@@ -34,6 +34,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { editProduct } from "@/lib/actions/admin";
+import { getProductStats } from "@/lib/actions/purchase-actions";
 import { uploadImageFromBlob } from "@/lib/uploads";
 import { adminProductSchema } from "@/validations/adminforms";
 
@@ -127,11 +128,28 @@ export default function EditProductForm({
       }
     }
 
+    const stats = await getProductStats(productId);
+
     const payload = await formSchema.parseAsync({
       ...values,
       imageURL: finalImageURL,
       maxCustomers: values.unlimitedCustomers ? 0 : values.maxCustomers,
     });
+
+    if (!payload.unlimitedCustomers) {
+      if (!stats.success || stats.sold === null || stats.reserved === null) {
+        toast.error("Kunde inte verifiera platsstatistik. Försök igen.");
+        return;
+      }
+
+      const usedSpots = stats.sold + stats.reserved;
+      if (payload.maxCustomers < usedSpots) {
+        toast.error(
+          `Kan inte sätta max under redan upptagna platser (${usedSpots}).`,
+        );
+        return;
+      }
+    }
 
     const res = await editProduct(productId, payload);
     if (res.success) {

--- a/src/app/admin/products/components/ProductItem.tsx
+++ b/src/app/admin/products/components/ProductItem.tsx
@@ -47,7 +47,7 @@ export default async function ProductItem({ product }: Props) {
           : typeof productStats.spotsLeft === "number" &&
               Number.isFinite(productStats.spotsLeft)
             ? `${productStats.spotsLeft} kvar (${productStats.sold} skapade, ${productStats.reserved} reserverade)`
-            : "Obegränsat"}
+            : `∞ (${productStats.sold} skapade, ${productStats.reserved} reserverade)`}
       </TableCell>
       <TableCell className="text-right">
         <div className="flex justify-end gap-2">

--- a/src/app/admin/products/components/ProductItem.tsx
+++ b/src/app/admin/products/components/ProductItem.tsx
@@ -1,6 +1,7 @@
 import { TableCell, TableRow } from "@/components/ui/table";
 import type { Product } from "@/generated/prisma/client";
 import { getAllCourses, type ProdCourse } from "@/lib/actions/admin";
+import { getProductStats } from "@/lib/actions/purchase-actions";
 import prisma from "@/lib/prisma";
 import AddCoursesToProductForm from "./AddCoursesToProductForm";
 import DeleteProductBtn from "./DelProductBtn";
@@ -12,6 +13,7 @@ interface Props {
 
 export default async function ProductItem({ product }: Props) {
   const allCourses = await getAllCourses();
+  const productStats = await getProductStats(product.id);
   const prodCourse: ProdCourse[] = await prisma.productOnCourse.findMany({
     where: { productId: product.id },
     include: { course: true },
@@ -38,6 +40,14 @@ export default async function ProductItem({ product }: Props) {
           clipCount={product.totalCount ?? 0}
           productCourses={prodCourse}
         />
+      </TableCell>
+      <TableCell>
+        {!productStats.success
+          ? "Okänd"
+          : typeof productStats.spotsLeft === "number" &&
+              Number.isFinite(productStats.spotsLeft)
+            ? `${productStats.spotsLeft} kvar`
+            : "Obegränsat"}
       </TableCell>
       <TableCell className="text-right">
         <div className="flex justify-end gap-2">

--- a/src/app/admin/products/components/ProductItem.tsx
+++ b/src/app/admin/products/components/ProductItem.tsx
@@ -46,7 +46,7 @@ export default async function ProductItem({ product }: Props) {
           ? "Okänd"
           : typeof productStats.spotsLeft === "number" &&
               Number.isFinite(productStats.spotsLeft)
-            ? `${productStats.spotsLeft} kvar`
+            ? `${productStats.spotsLeft} kvar (${productStats.sold} skapade, ${productStats.reserved} reserverade)`
             : "Obegränsat"}
       </TableCell>
       <TableCell className="text-right">

--- a/src/app/admin/products/page.tsx
+++ b/src/app/admin/products/page.tsx
@@ -50,6 +50,7 @@ export default async function Page({
               <TableHead>Typ</TableHead>
               <TableHead>Pris</TableHead>
               <TableHead>Kurser</TableHead>
+              <TableHead>Platser</TableHead>
               <TableHead className="text-right">Åtgärder</TableHead>
             </TableRow>
           </TableHeader>

--- a/src/app/checkout/CartSummary.tsx
+++ b/src/app/checkout/CartSummary.tsx
@@ -4,6 +4,7 @@ export const revalidate = 0;
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { removeFromCart, updateCart } from "@/lib/actions/cart";
+import { getProductStats } from "@/lib/actions/purchase-actions";
 import { readCart } from "@/lib/cart";
 import prisma from "@/lib/prisma";
 
@@ -25,24 +26,51 @@ export default async function CartSummary() {
   const ids = items.map((i) => i.productId);
   const products = await prisma.product.findMany({
     where: { id: { in: ids } },
-    select: { id: true, name: true, price: true },
+    select: {
+      id: true,
+      name: true,
+      price: true,
+      maxCustomer: true,
+      unlimitedCustomers: true,
+    },
   });
-  const byId = new Map(products.map((p) => [p.id, p]));
+
+  const getProductById = new Map(products.map((p) => [p.id, p]));
 
   let total = 0;
-  const rows = items.map((it) => {
-    const p = byId.get(it.productId);
-    const unit = p ? parseFloat(String(p.price)) : 0;
-    const line = unit * it.qty;
-    total += line;
-    return {
-      id: it.productId,
-      name: p?.name ?? "Okänd produkt",
-      unit,
-      qty: it.qty,
-      line,
-    };
-  });
+  const rows = await Promise.all(
+    items.map(async (it) => {
+      const p = getProductById.get(it.productId);
+      if (!p) {
+        return {
+          id: it.productId,
+          name: "Okänd produkt",
+          unit: 0,
+          qty: 0,
+          available: 0,
+          success: false,
+          line: 0,
+        };
+      }
+
+      const unit = parseFloat(String(p.price));
+      const line = unit * it.qty;
+      const stats = await getProductStats(p.id);
+      const available = stats.success ? (stats.spotsLeft ?? 0) : 0;
+      total += line;
+
+      return {
+        id: it.productId,
+        name: p.name,
+        unit,
+        qty: stats.success ? it.qty : 0,
+        maxCustomer: p.maxCustomer,
+        success: stats.success,
+        available,
+        line,
+      };
+    }),
+  );
 
   return (
     <div className="space-y-4">
@@ -54,6 +82,20 @@ export default async function CartSummary() {
               <p className="text-sm text-muted-foreground">
                 {r.unit.toFixed(0)} kr / st
               </p>
+              <p className="text-xs text-muted-foreground">
+                {!r.success
+                  ? "Platsstatus: okänd (fel vid hämtning)"
+                  : Number.isFinite(r.available)
+                    ? `max: ${r.available}st`
+                    : "Obegränsat"}
+              </p>
+              {r.success &&
+                Number.isFinite(r.available) &&
+                r.qty >= r.available && (
+                  <p className="text-xs text-amber-600 mt-1">
+                    Max antal platser uppnått för denna produkt.
+                  </p>
+                )}
             </div>
             <div className="flex items-center gap-3">
               <form
@@ -80,7 +122,11 @@ export default async function CartSummary() {
               >
                 <button
                   type="submit"
-                  className="w-8 h-8 flex items-center justify-center rounded bg-muted hover:bg-muted/80 text-foreground"
+                  disabled={
+                    !r.success ||
+                    (Number.isFinite(r.available) && r.qty >= r.available)
+                  }
+                  className="w-8 h-8 flex items-center justify-center rounded bg-muted hover:bg-muted/80 text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   +
                 </button>

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -31,7 +31,7 @@ import {
 import prisma from "../prisma";
 
 import { formToDbDate } from "../time-convert";
-import { handleClips } from "./purchase-actions";
+import { getProductStats, handleClips } from "./purchase-actions";
 import { getSessionData } from "./sessiondata";
 
 /**
@@ -1133,15 +1133,23 @@ export async function editProduct(
     const unlimitedCustomers = validated.unlimitedCustomers === true;
     const maxCustomers = unlimitedCustomers ? 0 : validated.maxCustomers;
 
-    // kolla så vi inte sänker för lågt. och får minus i plats kvar osv.
-    const salesCount = await prisma.purchase.count({
-      where: { productId: id },
-    });
-    if (!unlimitedCustomers && maxCustomers < salesCount) {
-      return {
-        success: false,
-        msg: "Kan inte sänka maxantalet under redan sålt antal.",
-      };
+    // Kolla så vi inte sänker under redan upptagna platser (sålda + reserverade).
+    if (!unlimitedCustomers) {
+      const stats = await getProductStats(id);
+      if (!stats.success || stats.sold === null || stats.reserved === null) {
+        return {
+          success: false,
+          msg: "Kunde inte verifiera platsstatistik. Försök igen.",
+        };
+      }
+
+      const usedSpots = stats.sold + stats.reserved;
+      if (maxCustomers < usedSpots) {
+        return {
+          success: false,
+          msg: `Kan inte sänka maxantalet under redan upptagna platser (${usedSpots}).`,
+        };
+      }
     }
 
     const newProd = await prisma.product.update({

--- a/src/lib/actions/cart.ts
+++ b/src/lib/actions/cart.ts
@@ -2,6 +2,8 @@
 
 import { redirect } from "next/navigation";
 import { clearCart, readCart, writeCart } from "@/lib/cart";
+import prisma from "../prisma";
+import { getProductStats } from "./purchase-actions";
 
 export async function addToCart(params: {
   productId: string;
@@ -31,7 +33,29 @@ export async function updateCart(params: { productId: string; qty: number }) {
   const cart = await readCart();
   const item = cart.items.find((i) => i.productId === productId);
   if (item) {
-    item.qty = qty;
+    // kontroll av max.
+
+    const product = await prisma.product.findUnique({
+      where: { id: productId },
+      select: { maxCustomer: true, unlimitedCustomers: true },
+    });
+
+    let finalQty = qty;
+
+    if (product && !product.unlimitedCustomers && product.maxCustomer > 0) {
+      const stats = await getProductStats(productId);
+      if (
+        stats.success &&
+        typeof stats.spotsLeft === "number" &&
+        Number.isFinite(stats.spotsLeft)
+      ) {
+        finalQty = Math.min(qty, stats.spotsLeft);
+      } else {
+        finalQty = 0;
+      }
+    }
+
+    item.qty = finalQty;
     if (item.qty <= 0) {
       cart.items = cart.items.filter((i) => i.productId !== productId);
     }

--- a/src/lib/actions/checkout.ts
+++ b/src/lib/actions/checkout.ts
@@ -4,6 +4,8 @@ import { redirect } from "next/navigation";
 import { clearCart } from "@/lib/cart";
 import { generateOrderConfirmationHtml, sendMail } from "@/lib/mail";
 import { createOrder, getOrderById } from "@/lib/orders";
+import prisma from "../prisma";
+import { getProductStats } from "./purchase-actions";
 import { getSessionData } from "./sessiondata";
 
 export type CheckoutItem = {
@@ -25,6 +27,54 @@ export async function createCheckout(params: {
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error("No items provided");
   }
+
+  // kontrollera så platser kvar inte överstigs (och kan beräknas) och att produkten är giltig.
+
+  const pCountTotal = new Map();
+
+  for (const itm of items) {
+    const p = await prisma.product.findUnique({
+      where: { id: itm.productId },
+    });
+    if (!p)
+      throw new Error(
+        `Product ${itm.productId} was not found. Order cancelled.`,
+      );
+
+    const stats = await getProductStats(p.id);
+
+    if (!stats.success)
+      throw new Error(
+        `Could not get stats for product ${itm.productId}. Order cancelled.`,
+      );
+
+    if (
+      typeof stats.spotsLeft === "number" &&
+      Number.isFinite(stats.spotsLeft) &&
+      itm.count > stats.spotsLeft
+    )
+      throw new Error(
+        `prodcut count exceeds limit for product ${itm.productId}. Count was ${itm.count} and spotsLeft is ${stats.spotsLeft}.`,
+      );
+
+    // Vi behöver kolla totalt också.
+    pCountTotal.set(
+      itm.productId,
+      (pCountTotal.get(itm.productId) ?? 0) + itm.count,
+    );
+
+    const totalInCartForProduct = pCountTotal.get(itm.productId) ?? 0;
+    if (
+      typeof stats.spotsLeft === "number" &&
+      Number.isFinite(stats.spotsLeft) &&
+      totalInCartForProduct > stats.spotsLeft
+    )
+      throw new Error(
+        `product count exceeds limit for product ${itm.productId}. Count was ${totalInCartForProduct} and spotsLeft is ${stats.spotsLeft}.`,
+      );
+  }
+
+  // Order ok!
 
   const order = await createOrder({
     userId: session.user.id,

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -18,7 +18,8 @@ export async function updateOrderStatus(
     | "PENDING_PAYMENT"
     | "AWAITING_APPROVAL"
     | "PAID"
-    | "APPROVED",
+    | "APPROVED"
+    | "CANCELLED",
   note?: string,
 ) {
   const adminUserId = await requireAdmin();
@@ -28,6 +29,12 @@ export async function updateOrderStatus(
 
     if (!current) throw new Error("Order not found");
     if (current.status === toStatus) return { success: true };
+    if (
+      toStatus === "CANCELLED" &&
+      ["APPROVED", "PAID"].includes(current.status)
+    ) {
+      throw new Error("Kan inte avbryta en redan godkänd eller betald order.");
+    }
 
     const updated = await tx.order.update({
       where: { id: orderId },
@@ -58,6 +65,10 @@ export async function approveOrder(orderId: string, note?: string) {
 
 export async function markOrderPaid(orderId: string, note?: string) {
   return updateOrderStatus(orderId, "PAID", note);
+}
+
+export async function cancelOrder(orderId: string, note?: string) {
+  return updateOrderStatus(orderId, "CANCELLED", note);
 }
 
 export async function adminGetOrder(orderId: string) {

--- a/src/lib/actions/purchase-actions.ts
+++ b/src/lib/actions/purchase-actions.ts
@@ -116,12 +116,8 @@ export async function countSoldProducts(
   const reserved = await prisma.orderItem.aggregate({
     where: {
       productId,
-      purchaseItems: { none: {} }, // ännu ej skapat till purchases
-      // order: {
-      //   status: {
-      //     in: ["CREATED", "PENDING_PAYMENT", "AWAITING_APPROVAL", "PAID"], Här behöver vi lägga till CANCELLED innan.
-      //   },
-      // },
+      purchaseItems: { none: {} },
+      order: { status: { not: "CANCELLED" } },
     },
     _sum: { count: true },
   });

--- a/src/lib/actions/purchase-actions.ts
+++ b/src/lib/actions/purchase-actions.ts
@@ -2,6 +2,7 @@
 // Så i denna samlar vi actions som rör köpta produkter.
 
 import type { Prisma } from "@/generated/prisma/client";
+import prisma from "../prisma";
 
 // Behöver den här typen för att fortsätta en tx:
 export type PrismaTx = Prisma.TransactionClient;
@@ -97,4 +98,33 @@ export async function handleClips(
   }
 
   return { success: true };
+}
+
+// Så denna funktion räknar antal redan sålda produkter av den specifika produkten, och om man vill räkna med de som ligger och väntar i order.
+export async function countSoldProducts(
+  productId: string,
+  countReserved: boolean,
+): Promise<number> {
+  // 1. Hämta alla purchases med det produktId:t.
+
+  const sold = await prisma.purchase.count({
+    where: { productId: productId },
+  });
+
+  if (!countReserved) return sold;
+
+  const reserved = await prisma.orderItem.aggregate({
+    where: {
+      productId,
+      purchaseItems: { none: {} }, // ännu ej skapat till purchases
+      // order: {
+      //   status: {
+      //     in: ["CREATED", "PENDING_PAYMENT", "AWAITING_APPROVAL", "PAID"], Här behöver vi lägga till CANCELLED innan.
+      //   },
+      // },
+    },
+    _sum: { count: true },
+  });
+
+  return sold + (reserved._sum.count ?? 0);
 }

--- a/src/lib/actions/purchase-actions.ts
+++ b/src/lib/actions/purchase-actions.ts
@@ -101,26 +101,65 @@ export async function handleClips(
 }
 
 // Så denna funktion räknar antal redan sålda produkter av den specifika produkten, och om man vill räkna med de som ligger och väntar i order.
-export async function countSoldProducts(
-  productId: string,
-  countReserved: boolean,
-): Promise<number> {
+export async function getProductStats(productId: string): Promise<{
+  sold: number | null;
+  reserved: number | null;
+  spotsLeft: number | null;
+  success: boolean;
+  error?: string;
+}> {
   // 1. Hämta alla purchases med det produktId:t.
+  try {
+    const product = await prisma.product.findUniqueOrThrow({
+      where: { id: productId },
+      select: { maxCustomer: true, unlimitedCustomers: true },
+    });
 
-  const sold = await prisma.purchase.count({
-    where: { productId: productId },
-  });
+    const sold = await prisma.purchase.count({
+      where: {
+        productId: productId,
+        order: { status: { not: "CANCELLED" } },
+      },
+    });
 
-  if (!countReserved) return sold;
+    const orderCount = await prisma.orderItem.aggregate({
+      where: {
+        productId,
+        order: {
+          status: {
+            in: [
+              "CREATED",
+              "PENDING_PAYMENT",
+              "AWAITING_APPROVAL",
+              "PAID",
+              "APPROVED", // Så inte CANCELLED räknas med.
+            ],
+          },
+          // Förhindra dubbelräkning när purchase redan skapats för denna produkt.
+          purchases: { none: { productId } },
+        },
+      },
+      _sum: { count: true },
+    });
 
-  const reserved = await prisma.orderItem.aggregate({
-    where: {
-      productId,
-      purchaseItems: { none: {} },
-      order: { status: { not: "CANCELLED" } },
-    },
-    _sum: { count: true },
-  });
+    const reserved = orderCount._sum.count ?? 0;
 
-  return sold + (reserved._sum.count ?? 0);
+    return {
+      sold: sold,
+      reserved: reserved,
+      spotsLeft: product.unlimitedCustomers
+        ? Infinity
+        : Math.max(0, product.maxCustomer - (sold + reserved)),
+      success: true,
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      sold: null,
+      reserved: null,
+      spotsLeft: null,
+      success: false,
+      error: JSON.stringify(e),
+    };
+  }
 }


### PR DESCRIPTION
En global funktion för att hämta statistik för en produkt, och baserat på den kollas nu varukorgen så man inte kan lägga till för många. Den räknar även med reserverade produkter dvs ordrar som inte ännu blivit godkända, så inte för många köp kan göras. Kontroll görs sedan också i server-side.

Vi behövde lägga till en CANCELLED som order-status (och avbryt-knapp), och ordrar som är avbrutna räknas ej med som reserverade. Gjorde också så man kan ändra status från PAID till APPROVED så får aadmin välja själv vilken ordning.

Lade till Platser som kolumn i admin/products som visar platser kvar, antal skapade och antal reserverade. 

Redigera produkt formuläret har totalt antal som minsta gräns nu också för maxCustomer, även i server-action.

