### PR TITLE
Fix TypeScript build errors after PR merges

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,12 +16,16 @@ const nextConfig: NextConfig = {
   },
   images: {
     remotePatterns: [
-      {
-        protocol: "https",
-        hostname: r2Host,
-        port: "",
-        pathname: "/**",
-      },
+      ...(r2Host
+        ? [
+            {
+              protocol: "https" as const,
+              hostname: r2Host,
+              port: "",
+              pathname: "/**",
+            },
+          ]
+        : []),
       {
         protocol: "https",
         hostname: legacyR2Host,

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -18,7 +18,7 @@ export default async function EditEventPage({ params }: PageProps) {
   return (
     <div className="p-6 max-w-xl">
       <h1 className="text-2xl font-bold mb-4">Edit event</h1>
-      <EditEventForm event={event} />
+      <EditEventForm event={event} isOpen={true} />
     </div>
   );
 }

--- a/src/components/larare-profile.tsx
+++ b/src/components/larare-profile.tsx
@@ -7,10 +7,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import type { TeacherProfile } from "@/generated/prisma/client";
 import { getTeachers } from "@/lib/actions/teacher-actions";
 
 const LarareProfile = async () => {
-  const teachers = await getTeachers();
+  const teachers: TeacherProfile[] = await getTeachers();
 
   const activeTeachers = teachers.filter((t) => t.active);
 

--- a/src/lib/actions/server-actions.ts
+++ b/src/lib/actions/server-actions.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/generated/prisma/client";
 import prisma from "../prisma";
 import { handleClips } from "./purchase-actions";
+import { calcRemainingCount, hasRemainingCount } from "./purchase-helpers";
 import { getSessionData } from "./sessiondata";
 
 export type BookingWithLesson = Prisma.BookingGetPayload<{


### PR DESCRIPTION
## Summary
- Add missing `isOpen` prop to `EditEventForm` in `events/[id]/edit` page
- Add missing import for `calcRemainingCount`/`hasRemainingCount` in `server-actions.ts`
- Add `TeacherProfile` type annotation in `larare-profile.tsx`
- Make `next.config.ts` robust against empty `S3_PUBLIC_URL`

Build verified locally.