### PR TITLE
chore: Sätt defaultBranch till dev i Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,7 +3,8 @@
   "vcs": {
     "enabled": true,
     "clientKind": "git",
-    "useIgnoreFile": true
+    "useIgnoreFile": true,
+    "defaultBranch": "dev"
   },
   "files": {
     "ignoreUnknown": true,


### PR DESCRIPTION
## Beskrivning

Lägger till `defaultBranch: "dev"` i Biome-konfigurationen så att VCS-baserad analys vet vilken branch som är huvudbranch.

## Relaterade issues

Del av #164 (DX-förbättringar)

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [x] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Ytterligare kommentarer

Denna PR fungerar också som en **demo av vår nya CI-pipeline**! 🎯

Kolla "Checks"-fliken för att se GitHub Actions köra:
1. **Biome lint** - kontrollerar kodstandard
2. **Prisma generate** - genererar databasklienten
3. **Next.js build** - verifierar att allt kompilerar

Från och med nu körs dessa checks automatiskt på varje PR innan merge.