### PR TITLE
Feature/gallery event integration fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -27,7 +27,9 @@
       "Bash(\"src/app/\\(admin\\)/admin/orders/OrdersView.tsx\")",
       "Bash(\"src/app/\\(admin\\)/admin/orders/page.tsx\")",
       "Bash(git ls-tree:*)",
-      "Bash(\"src/app/\\(admin\\)/admin/students/components/StudentsFilter.tsx\")"
+      "Bash(\"src/app/\\(admin\\)/admin/students/components/StudentsFilter.tsx\")",
+      "Bash(ls:*)",
+      "Bash(npm install:*)"
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
+        "embla-carousel-react": "^8.6.0",
         "i18next": "^25.8.13",
         "i18next-browser-languagedetector": "^8.2.1",
         "leaflet": "^1.9.4",
@@ -6522,6 +6523,34 @@
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
       }
     },
     "node_modules/empathic": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
+    "embla-carousel-react": "^8.6.0",
     "i18next": "^25.8.13",
     "i18next-browser-languagedetector": "^8.2.1",
     "leaflet": "^1.9.4",

--- a/prisma/migrations/20260225121631_add_photo_model/migration.sql
+++ b/prisma/migrations/20260225121631_add_photo_model/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "Photo" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "caption" TEXT,
+    "description" TEXT,
+    "eventId" TEXT,
+    "isVisible" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Photo_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Photo" ADD CONSTRAINT "Photo_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -469,8 +469,22 @@ model Event {
   link        String
   imageURL    String
 
+  photos Photo[]
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model Photo {
+  id          String   @id @default(uuid())
+  url         String
+  caption     String?
+  description String?
+  eventId     String?
+  event       Event?   @relation(fields: [eventId], references: [id])
+  isVisible   Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 // Enum for order lifecycle states

--- a/src/app/(admin)/admin/gallery/GalleryAdmin.tsx
+++ b/src/app/(admin)/admin/gallery/GalleryAdmin.tsx
@@ -1,0 +1,487 @@
+"use client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import type z from "zod";
+import AdminGalleryPagination from "@/components/AdminGalleryPagination";
+import ImageInput from "@/components/ImageInput";
+// Removed Loader to avoid showing spinner during uploads; only button text used
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { addPhoto, deletePhoto, editPhoto } from "@/lib/actions/admin";
+import { uploadImageFromBlob } from "@/lib/uploads";
+import { adminPhotoSchema } from "@/validations/adminforms";
+
+interface Photo {
+  id: string;
+  url: string;
+  caption?: string;
+  description?: string;
+  eventId?: string;
+  isVisible: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+interface Event {
+  id: string;
+  headline: string;
+}
+
+export default function GalleryAdmin({
+  photos,
+  events,
+  currentPage,
+  totalPages,
+}: {
+  photos: Photo[];
+  events: Event[];
+  currentPage: number;
+  totalPages: number;
+}) {
+  const [editingPhoto, setEditingPhoto] = useState<Photo | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [modalKey, setModalKey] = useState(0); // for resetting ImageInput
+  const [filterText, setFilterText] = useState("");
+  const [filterEvent, setFilterEvent] = useState("");
+  const [filterVisible, setFilterVisible] = useState("");
+  const router = useRouter();
+
+  // Add/Edit modal form
+  const form = useForm<z.infer<typeof adminPhotoSchema>>({
+    resolver: zodResolver(adminPhotoSchema),
+    defaultValues: {
+      caption: "",
+      description: "",
+      eventId: "",
+      url: "",
+      isVisible: true,
+    },
+  });
+
+  const openAddModal = () => {
+    setEditingPhoto(null);
+    setPreviewUrl(null);
+    form.reset({
+      caption: "",
+      description: "",
+      eventId: "",
+      url: "",
+      isVisible: true,
+    });
+    setModalKey((k) => k + 1); // force ImageInput reset
+    setIsModalOpen(true);
+  };
+  const openEditModal = (photo: Photo) => {
+    setEditingPhoto(photo);
+    form.reset({
+      caption: photo.caption || "",
+      description: photo.description || "",
+      eventId: photo.eventId || "",
+      url: photo.url,
+      isVisible: photo.isVisible,
+    });
+    setPreviewUrl(photo.url);
+    setModalKey((k) => k + 1); // force ImageInput reset
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setEditingPhoto(null);
+    setPreviewUrl(null);
+    form.reset({
+      caption: "",
+      description: "",
+      eventId: "",
+      url: "",
+      isVisible: true,
+    });
+  };
+
+  // Add/Edit photo handler
+  type AdminPhotoForm = z.infer<typeof adminPhotoSchema>;
+  const onSubmit = async (values: AdminPhotoForm) => {
+    setIsBusy(true);
+    let finalUrl = values.url;
+    if (finalUrl.startsWith("blob:")) {
+      try {
+        const res = await fetch(finalUrl);
+        const blob = await res.blob();
+        finalUrl = await uploadImageFromBlob(blob);
+        URL.revokeObjectURL(values.url);
+      } catch (_e) {
+        toast.error("Uppladdning misslyckades.");
+        setIsBusy(false);
+        return;
+      }
+    }
+    const res = editingPhoto
+      ? await editPhoto(editingPhoto.id, { ...values, url: finalUrl })
+      : await addPhoto({ ...values, url: finalUrl });
+    if (res.success) {
+      toast.success(res.msg);
+      setTimeout(() => {
+        closeModal();
+        router.refresh();
+      }, 800);
+    } else {
+      toast.error(res.msg);
+    }
+    setIsBusy(false);
+  };
+
+  // Delete photo handler
+  const handleDeletePhoto = async (photoId: string) => {
+    if (!window.confirm("Är du säker på att du vill ta bort denna bild?"))
+      return;
+    setIsBusy(true);
+    const res = await deletePhoto(photoId);
+    if (res.success) {
+      toast.success(res.msg);
+      router.refresh();
+    } else {
+      toast.error(res.msg);
+    }
+    setIsBusy(false);
+  };
+
+  // Filter photos in-memory
+  const filteredPhotos = useMemo(() => {
+    return photos.filter((photo) => {
+      const matchesText =
+        !filterText ||
+        photo.caption?.toLowerCase().includes(filterText.toLowerCase()) ||
+        photo.description?.toLowerCase().includes(filterText.toLowerCase());
+      const matchesEvent = !filterEvent || photo.eventId === filterEvent;
+      const matchesVisible =
+        filterVisible === ""
+          ? true
+          : filterVisible === "true"
+            ? photo.isVisible
+            : !photo.isVisible;
+      return matchesText && matchesEvent && matchesVisible;
+    });
+  }, [photos, filterText, filterEvent, filterVisible]);
+
+  return (
+    <div className="p-4 w-full bg-background text-foreground">
+      <h1 className="text-2xl font-bold mb-6">
+        Galleri - Hantera bilder
+        <span className="text-sm text-muted-foreground ml-3">
+          Sida {currentPage} av {totalPages}
+        </span>
+      </h1>
+      <Button onClick={openAddModal} className="cursor-pointer">
+        Lägg till bild
+      </Button>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-4 mt-6 mb-4 items-end justify-between">
+        {/* Sök filter on the left */}
+        <div>
+          <label htmlFor="filterText" className="block text-xs mb-1">
+            Sök
+          </label>
+          <Input
+            id="filterText"
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+            placeholder="Sök rubrik eller beskrivning..."
+            className="min-w-160"
+          />
+        </div>
+        {/* Event & Synlig filters on the far right */}
+        <div className="flex gap-4">
+          <div>
+            <label htmlFor="filterEvent" className="block text-xs mb-1">
+              Event
+            </label>
+            <select
+              id="filterEvent"
+              aria-label="Event filter"
+              value={filterEvent}
+              onChange={(e) => setFilterEvent(e.target.value)}
+              className="border border-border rounded p-2 min-w-[120px] bg-background text-foreground dark:bg-input dark:text-foreground"
+            >
+              <option value="">Alla</option>
+              {events.map((event) => (
+                <option key={event.id} value={event.id}>
+                  {event.headline}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="filterVisible" className="block text-xs mb-1">
+              Synlig
+            </label>
+            <select
+              id="filterVisible"
+              aria-label="Synlig filter"
+              value={filterVisible}
+              onChange={(e) => setFilterVisible(e.target.value)}
+              className="border border-border rounded p-2 min-w-[100px] bg-background text-foreground dark:bg-input dark:text-foreground"
+            >
+              <option value="">Alla</option>
+              <option value="true">Endast synliga</option>
+              <option value="false">Endast dolda</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {filteredPhotos.length === 0 ? (
+        <div className="text-center text-muted-foreground mt-10">
+          Inga bilder matchar filtren.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
+          {filteredPhotos.map((photo, _idx) => (
+            <Card
+              key={photo.id}
+              className="relative group bg-card text-card-foreground"
+            >
+              <CardContent>
+                <a
+                  href={photo.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative w-full h-48 flex items-center justify-center bg-transparent border-transparent rounded overflow-hidden"
+                  title={
+                    photo.caption || photo.description || "Visa i full storlek"
+                  }
+                  aria-label={
+                    photo.caption || photo.description || "Visa i full storlek"
+                  }
+                >
+                  <Image
+                    src={photo.url}
+                    alt={photo.caption || "Bild"}
+                    fill
+                    className="object-contain rounded-lg bg-transparent border-transparent"
+                  />
+                </a>
+                <div className="mt-3 text-center">
+                  {photo.caption && (
+                    <div className="text-lg md:text-xl font-semibold text-foreground leading-tight">
+                      {photo.caption}
+                    </div>
+                  )}
+                  {photo.description && (
+                    <div className="mt-1 text-sm md:text-base text-muted-foreground px-2">
+                      <em>{photo.description}</em>
+                    </div>
+                  )}
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground mt-2">
+                    {photo.eventId
+                      ? events.find((e) => e.id === photo.eventId)?.headline
+                      : "Ingen"}
+                  </div>
+                  <div className="flex gap-2 mt-2 justify-center">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="sm"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            openEditModal(photo);
+                          }}
+                          className="transition-colors group-hover:border-blue-500 cursor-pointer"
+                        >
+                          Redigera
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Redigera</TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="sm"
+                          variant="destructive"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleDeletePhoto(photo.id);
+                          }}
+                          className="transition-colors group-hover:border-red-500 cursor-pointer"
+                        >
+                          Ta bort
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Ta bort</TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+      <div className="mt-6">
+        <AdminGalleryPagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+        />
+      </div>
+      {/* While busy we keep only the disabled button state; no global spinner */}
+      {isModalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+          <div className="bg-white dark:bg-card dark:text-card-foreground rounded-lg p-6 w-full max-w-md max-h-[90vh] overflow-y-auto border border-border">
+            <h2 className="text-xl font-bold mb-4">
+              {editingPhoto ? "Redigera bild" : "Lägg till bild"}
+            </h2>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit(onSubmit)}
+                className="space-y-4"
+              >
+                <FormField
+                  control={form.control}
+                  name="url"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Bild</FormLabel>
+                      <FormControl>
+                        <div>
+                          <ImageInput
+                            key={modalKey}
+                            {...field}
+                            onChange={(val: string | undefined) => {
+                              field.onChange(val);
+                              setPreviewUrl(val ?? null);
+                            }}
+                          />
+                          {/* Only show preview image in edit mode, never in add mode. Only keep the preview below the upload input. */}
+                          {editingPhoto && previewUrl && (
+                            <Image
+                              src={previewUrl}
+                              alt="Förhandsvisning"
+                              width={800}
+                              height={192}
+                              className="mt-2 w-full h-48 object-cover rounded border-transparent bg-transparent"
+                            />
+                          )}
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="caption"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Rubrik</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="description"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Beskrivning</FormLabel>
+                      <FormControl>
+                        <Textarea {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="eventId"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Event</FormLabel>
+                      <FormControl>
+                        <select
+                          {...field}
+                          className="w-full border rounded p-2 bg-background text-foreground dark:bg-input border-border"
+                        >
+                          <option value="">Ingen</option>
+                          {events.map((event) => (
+                            <option key={event.id} value={event.id}>
+                              {event.headline}
+                            </option>
+                          ))}
+                        </select>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="isVisible"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Synlig</FormLabel>
+                      <FormControl>
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            checked={field.value}
+                            onChange={(e) => field.onChange(e.target.checked)}
+                            className="accent-primary dark:accent-primary bg-background dark:bg-input/30 border border-border rounded"
+                            aria-label="Synlig"
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                {/* No inline spinner while uploading; keep button disabled with text only */}
+                <div className="flex gap-2 mt-4">
+                  <Button
+                    type="submit"
+                    disabled={isBusy}
+                    className={isBusy ? "cursor-not-allowed" : "cursor-pointer"}
+                  >
+                    {isBusy
+                      ? "Uppladdar..."
+                      : editingPhoto
+                        ? "Uppdatera"
+                        : "Lägg till"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={closeModal}
+                    className="cursor-pointer"
+                  >
+                    Avbryt
+                  </Button>
+                </div>
+              </form>
+            </Form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/gallery/[page]/loading.tsx
+++ b/src/app/(admin)/admin/gallery/[page]/loading.tsx
@@ -1,0 +1,18 @@
+export default function Loading() {
+  return (
+    <div className="p-6 w-full">
+      <div className="max-w-5xl mx-auto">
+        <div className="h-10 w-1/2 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded mb-6" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3, 4, 5, 6].map((n) => (
+            <div key={n} className="p-4 border rounded bg-transparent">
+              <div className="h-40 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded mb-3" />
+              <div className="h-4 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded w-3/4 mb-2" />
+              <div className="h-3 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded w-1/2" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/gallery/[page]/page.tsx
+++ b/src/app/(admin)/admin/gallery/[page]/page.tsx
@@ -1,0 +1,48 @@
+import { notFound } from "next/navigation";
+import prisma from "@/lib/prisma";
+import GalleryAdmin from "../GalleryAdmin";
+
+type Props = { params: Promise<{ page: string }> };
+
+export const dynamic = "force-dynamic";
+
+export default async function Page({ params }: Props) {
+  const resolved = await params;
+  const page = Math.max(1, Number(resolved.page ?? 1));
+  const pageSize = 12;
+
+  const total = await prisma.photo.count();
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  if (page > totalPages) return notFound();
+
+  const photos = await prisma.photo.findMany({
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+  });
+  // Normalize nullable fields (Prisma may return `null`) to `undefined` to match
+  // the `Photo` type expectations in client components.
+  const normalizedPhotos = photos.map((p) => ({
+    ...p,
+    caption: p.caption ?? undefined,
+    description: p.description ?? undefined,
+    eventId: p.eventId ?? undefined,
+    createdAt: p.createdAt.toISOString(),
+    updatedAt: p.updatedAt.toISOString(),
+  }));
+  const events = await prisma.event.findMany({
+    orderBy: { startDate: "desc" },
+    select: { id: true, headline: true },
+  });
+
+  return (
+    <GalleryAdmin
+      key={page}
+      photos={normalizedPhotos}
+      events={events}
+      currentPage={page}
+      totalPages={totalPages}
+    />
+  );
+}

--- a/src/app/(admin)/admin/gallery/page.tsx
+++ b/src/app/(admin)/admin/gallery/page.tsx
@@ -1,3 +1,6 @@
+import { redirect } from "next/navigation";
+
+// Redirect to page 1 path route for consistent pagination handling
 export default function Page() {
-  return <div>hantera glleriet.</div>;
+  redirect("/admin/gallery/1");
 }

--- a/src/app/(public)/gallery/GalleryCarouselsClient.tsx
+++ b/src/app/(public)/gallery/GalleryCarouselsClient.tsx
@@ -1,0 +1,113 @@
+"use client";
+import dynamic from "next/dynamic";
+import type { ComponentType } from "react";
+
+type Photo = {
+  id: string;
+  url: string;
+  caption?: string | undefined;
+  description?: string | undefined;
+  createdAt: string;
+  updatedAt: string;
+  isVisible: boolean;
+};
+
+type Group = {
+  event: { id: string; headline: string; startDate: string };
+  photos: Photo[];
+};
+
+const GalleryCarousel = dynamic(
+  () => import("@/components/GalleryCarousel").then((m) => m.default ?? m),
+  {
+    ssr: false,
+  },
+) as unknown as ComponentType<{ photos: Photo[]; showIndicators?: boolean }>;
+
+export default function GalleryCarouselsClient({
+  grouped,
+  unlinked,
+}: {
+  grouped: Group[];
+  unlinked: Photo[];
+}) {
+  if (!Array.isArray(grouped)) {
+    console.error("GalleryCarouselsClient: expected 'grouped' array", grouped);
+    return null;
+  }
+  return (
+    <>
+      {grouped.map((gItem) => {
+        const item = gItem as unknown;
+        let eventObj: Record<string, unknown> | null = null;
+        let photosArr: Photo[] = [];
+
+        if (typeof item === "object" && item !== null) {
+          const rec = item as Record<string, unknown>;
+          if ("event" in rec && "photos" in rec) {
+            eventObj = (rec.event as Record<string, unknown>) ?? null;
+            photosArr = (rec.photos as Photo[]) ?? [];
+          } else if ("headline" in rec) {
+            // sometimes the grouped item may already be the event object
+            eventObj = rec;
+            photosArr = (rec.photos as Photo[]) ?? [];
+          } else {
+            // unexpected shape
+            console.error(
+              "GalleryCarouselsClient: unexpected grouped item",
+              rec,
+            );
+          }
+        }
+
+        type EventRecord = {
+          id?: string;
+          headline?: string;
+          startDate?: string;
+        };
+        const er = eventObj as EventRecord | null;
+        const headline = er?.headline ? String(er.headline) : "";
+        const startDateStr = er?.startDate
+          ? new Date(String(er.startDate)).toLocaleDateString()
+          : "";
+        const key = String(
+          er?.id ?? headline ?? Math.random().toString(36).slice(2, 9),
+        );
+
+        return (
+          <div key={key} className="mb-16">
+            <div className="mb-2 text-center">
+              <h3 className="text-2xl md:text-3xl font-extrabold text-foreground tracking-tight">
+                {headline}
+              </h3>
+              <div className="text-sm uppercase tracking-wide text-muted-foreground mt-1">
+                {startDateStr}
+              </div>
+            </div>
+            <div>
+              <GalleryCarousel
+                photos={photosArr.filter((p) => p.isVisible)}
+                showIndicators={false}
+              />
+            </div>
+          </div>
+        );
+      })}
+      {unlinked.length > 0 && (
+        <div className="mb-16">
+          <div className="mb-2 text-center">
+            <h3 className="text-2xl md:text-3xl font-extrabold text-foreground tracking-tight">
+              Övriga bilder
+            </h3>
+          </div>
+          <div>
+            <GalleryCarousel
+              photos={unlinked.filter((p) => p.isVisible)}
+              showIndicators={false}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/(public)/gallery/loading.tsx
+++ b/src/app/(public)/gallery/loading.tsx
@@ -1,0 +1,23 @@
+export default function Loading() {
+  return (
+    <main className="bg-background">
+      <section className="py-16 md:py-20 text-center border-b border-border">
+        <div className="max-w-7xl mx-auto px-6">
+          <div className="mx-auto w-1/3 h-12 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded" />
+          <div className="mx-auto mt-4 w-2/3 h-4 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded" />
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="max-w-7xl mx-auto px-6 space-y-12">
+          {[1, 2].map((i) => (
+            <div key={i} className="space-y-4">
+              <div className="h-8 w-1/3 bg-gray-200 dark:bg-neutral-700 animate-pulse rounded mx-auto" />
+              <div className="h-[50vh] bg-gray-200 dark:bg-neutral-700 animate-pulse rounded" />
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/(public)/gallery/page.tsx
+++ b/src/app/(public)/gallery/page.tsx
@@ -1,118 +1,114 @@
 import { Instagram } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import type { Event, Photo } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import GalleryCarouselsClient from "./GalleryCarouselsClient";
 
-const galleryItems = [
-  {
-    id: 1,
-    alt: "Danslektion Hip Hop",
-    accentGradient: "from-violet-600 via-brand to-brand-secondary",
-    accentVar: "var(--color-brand)",
-  },
-  {
-    id: 2,
-    alt: "Balett uppträdande",
-    accentGradient: "from-cyan-500 via-brand-secondary to-blue-600",
-    accentVar: "var(--color-brand-secondary)",
-  },
-  {
-    id: 3,
-    alt: "Studio miljö",
-    accentGradient: "from-brand-secondary via-purple-500 to-brand",
-    accentVar: "var(--color-brand)",
-  },
-  {
-    id: 4,
-    alt: "Gruppträning",
-    accentGradient: "from-violet-600 via-brand to-brand-secondary",
-    accentVar: "var(--color-brand)",
-  },
-  {
-    id: 5,
-    alt: "Elevuppvisning",
-    accentGradient: "from-cyan-500 via-brand-secondary to-blue-600",
-    accentVar: "var(--color-brand-secondary)",
-  },
-  {
-    id: 6,
-    alt: "Instruktör demonstration",
-    accentGradient: "from-brand-secondary via-purple-500 to-brand",
-    accentVar: "var(--color-brand)",
-  },
-];
+export default async function Page() {
+  // Fetch all visible photos and their events
+  const photos = await prisma.photo.findMany({
+    where: { isVisible: true },
+    include: { event: true },
+    orderBy: [{ event: { startDate: "desc" } }, { createdAt: "desc" }],
+  });
 
-export default function Page() {
+  // Group photos by event
+  const eventMap = new Map<string, { event: Event; photos: Photo[] }>();
+  const unlinkedPhotos: Photo[] = [];
+  for (const photo of photos) {
+    if (photo.event) {
+      const eventId = photo.event.id;
+      if (!eventMap.has(eventId)) {
+        eventMap.set(eventId, {
+          event: photo.event as Event,
+          photos: [],
+        });
+      }
+      const bucket = eventMap.get(eventId);
+      if (bucket) {
+        bucket.photos.push(photo as Photo);
+      }
+    } else {
+      unlinkedPhotos.push(photo as Photo);
+    }
+  }
+  const grouped = [...eventMap.values()].map(({ event, photos }) => ({
+    event: {
+      ...event,
+      createdAt:
+        event.createdAt instanceof Date
+          ? event.createdAt.toISOString()
+          : event.createdAt,
+      updatedAt:
+        event.updatedAt instanceof Date
+          ? event.updatedAt.toISOString()
+          : event.updatedAt,
+      startDate:
+        event.startDate instanceof Date
+          ? event.startDate.toISOString()
+          : event.startDate,
+      endDate:
+        event.endDate instanceof Date
+          ? event.endDate?.toISOString()
+          : event.endDate,
+    },
+    photos: photos.map((photo) => ({
+      ...photo,
+      caption: photo.caption ?? undefined,
+      description: photo.description ?? undefined,
+      createdAt:
+        photo.createdAt instanceof Date
+          ? photo.createdAt.toISOString()
+          : photo.createdAt,
+      updatedAt:
+        photo.updatedAt instanceof Date
+          ? photo.updatedAt.toISOString()
+          : photo.updatedAt,
+    })),
+  }));
+
+  const unlinked = unlinkedPhotos.map((photo) => ({
+    ...photo,
+    caption: photo.caption ?? undefined,
+    description: photo.description ?? undefined,
+    createdAt:
+      photo.createdAt instanceof Date
+        ? photo.createdAt.toISOString()
+        : photo.createdAt,
+    updatedAt:
+      photo.updatedAt instanceof Date
+        ? photo.updatedAt.toISOString()
+        : photo.updatedAt,
+  }));
+
   return (
     <main className="bg-background">
       {/* Hero */}
       <section className="py-16 md:py-20 text-center border-b border-border">
         <div className="max-w-7xl mx-auto px-6">
-          <h1 className="text-5xl md:text-7xl font-light text-foreground leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:200ms]">
+          <h1 className="text-5xl md:text-7xl font-light text-foreground leading-[1.1] tracking-tight mb-4 animate-fade-in-left [animation-delay:200ms]">
             Bild
             <span className="font-serif italic text-brand-light"> Galleri</span>
           </h1>
-          <p className="text-muted-foreground">
+          <p className="text-muted-foreground mb-4">
             Se bilder från våra lektioner, uppträdanden och studio.
           </p>
         </div>
       </section>
 
-      {/* Gallery Grid */}
-      <section
-        id="galleri"
-        className="py-20 md:py-32 relative overflow-hidden"
-        style={{ background: "var(--background)" }}
-      >
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-0 left-1/4 w-96 h-96 rounded-full bg-brand/5 blur-[120px]" />
-          <div className="absolute bottom-0 right-1/4 w-96 h-96 rounded-full bg-brand-secondary/5 blur-[120px]" />
-        </div>
-
-        <div className="max-w-7xl mx-auto px-4 md:px-8 relative z-10">
-          <div className="text-center mb-16">
-            <h2 className="text-4xl md:text-5xl font-black mb-4 text-foreground tracking-tight">
-              Bilder från studion
-            </h2>
-            <p className="text-brand-secondary font-bold max-w-xl mx-auto text-lg">
-              Ta en titt in i vår värld
-            </p>
-          </div>
-
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-10">
-            {galleryItems.map((item) => (
-              <div key={item.id} className="group relative cursor-pointer">
-                <div
-                  className={`absolute -inset-1 bg-linear-to-r ${item.accentGradient} rounded-2xl blur-lg opacity-20 group-hover:opacity-50 transition duration-500`}
-                />
-
-                <div className="relative h-full backdrop-blur-xl bg-card/60 border border-white/10 rounded-2xl shadow-2xl transform transition-all duration-500 group-hover:scale-[1.03] group-hover:-translate-y-2 flex flex-col overflow-hidden">
-                  <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-white/20 to-transparent z-10" />
-
-                  <div className="relative overflow-hidden aspect-square flex items-center justify-center bg-muted">
-                    <span className="text-muted-foreground text-sm z-10 relative">
-                      {item.alt}
-                    </span>
-                    <div className="absolute inset-0 bg-linear-to-t from-slate-900/80 via-transparent to-transparent opacity-60" />
-                  </div>
-
-                  <div className="p-6 relative">
-                    <div
-                      className="h-1 rounded-full transition-all duration-500 w-12 group-hover:w-24"
-                      style={{ background: item.accentVar }}
-                    />
-                    <p className="mt-4 text-lg font-bold text-foreground">
-                      {item.alt}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+      {/* Gallery Carousels by Event */}
+      <section className="py-10 md:py-12">
+        <div className="max-w-7xl mx-auto px-6">
+          <h2 className="text-2xl font-bold mb-6 text-center text-foreground">
+            Bilder från studion
+          </h2>
+          <GalleryCarouselsClient grouped={grouped} unlinked={unlinked} />
         </div>
       </section>
 
       {/* Instagram CTA */}
-      <section className="py-16 relative overflow-hidden">
+      <section className="py-10 relative overflow-hidden">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full bg-brand/10 blur-[120px]" />
         </div>
@@ -128,10 +124,10 @@ export default function Page() {
                 </div>
 
                 <div>
-                  <h2 className="text-3xl md:text-4xl font-black mb-3 text-foreground tracking-tight">
+                  <h2 className="text-3xl md:text-4xl font-black mb-2 text-foreground tracking-tight">
                     Följ oss på Instagram
                   </h2>
-                  <p className="text-muted-foreground text-lg mb-8">
+                  <p className="text-muted-foreground text-lg mb-4">
                     Se fler bilder och håll dig uppdaterad om våra aktiviteter.
                   </p>
                 </div>

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -83,35 +83,46 @@ export async function POST(req: Request) {
 
     const s3Resources = getS3Resources();
     if (!s3Resources) {
+      // Log details server-side only
+      console.error("[UPLOAD] S3 config missing");
       return NextResponse.json(
-        { error: "Saknar S3-konfiguration i miljövariabler" },
+        { error: "Internt serverfel vid uppladdning" },
         { status: 500 },
       );
     }
 
     const { bucket, publicUrl, client } = s3Resources;
+    try {
+      const command = new PutObjectCommand({
+        Bucket: bucket,
+        Key: uniqueFileName,
+        ContentType: contentType,
+      });
 
-    const command = new PutObjectCommand({
-      Bucket: bucket,
-      Key: uniqueFileName,
-      ContentType: contentType,
-    });
+      const uploadUrl = await getSignedUrl(client, command, {
+        expiresIn: 60,
+      });
 
-    const uploadUrl = await getSignedUrl(client, command, {
-      expiresIn: 60,
-    });
+      const imageUrl = `${publicUrl}/${uniqueFileName}`;
 
-    const imageUrl = `${publicUrl}/${uniqueFileName}`;
-
-    return NextResponse.json({
-      success: true,
-      uploadUrl,
-      url: imageUrl,
-      key: uniqueFileName,
-      method: "PUT",
-    });
-  } catch (error) {
-    console.error("S3 Upload Error:", error);
+      return NextResponse.json({
+        success: true,
+        uploadUrl,
+        url: imageUrl,
+        key: uniqueFileName,
+        method: "PUT",
+      });
+    } catch (_err) {
+      // Log details server-side only
+      console.error("[UPLOAD] S3 presign error:", _err);
+      return NextResponse.json(
+        { error: "Internt serverfel vid uppladdning" },
+        { status: 500 },
+      );
+    }
+  } catch (_error) {
+    // Log details server-side only
+    console.error("[UPLOAD] Unexpected error:", _error);
     return NextResponse.json(
       { error: "Internt serverfel vid uppladdning" },
       { status: 500 },

--- a/src/components/AdminGalleryPagination.tsx
+++ b/src/components/AdminGalleryPagination.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+interface Props {
+  currentPage: number;
+  totalPages: number;
+}
+
+export default function AdminGalleryPagination({
+  currentPage,
+  totalPages,
+}: Props) {
+  if (totalPages <= 1) return null;
+
+  const createPageURL = (page: number) => {
+    // use path-based pagination: /admin/gallery/<page>
+    const base = window.location.origin;
+    return `${base}/admin/gallery/${page}`;
+  };
+
+  const goto = (page: number) => {
+    // full navigation to ensure server renders correct data
+    window.location.href = createPageURL(page);
+  };
+
+  const pages = [] as number[];
+  for (let i = 1; i <= totalPages; i++) pages.push(i);
+
+  return (
+    <nav className="flex items-center justify-center">
+      <div className="inline-flex gap-2">
+        <button
+          type="button"
+          className={`px-3 py-1 rounded border ${currentPage === 1 ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+          onClick={() => goto(Math.max(1, currentPage - 1))}
+          disabled={currentPage === 1}
+        >
+          Föregående
+        </button>
+
+        {pages.map((p) => (
+          <button
+            key={p}
+            type="button"
+            className={`px-3 py-1 rounded border ${p === currentPage ? "bg-primary text-white" : "cursor-pointer"}`}
+            onClick={() => goto(p)}
+          >
+            {p}
+          </button>
+        ))}
+
+        <button
+          type="button"
+          className={`px-3 py-1 rounded border ${currentPage === totalPages ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+          onClick={() => goto(Math.min(totalPages, currentPage + 1))}
+          disabled={currentPage === totalPages}
+        >
+          Nästa
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/GalleryCarousel.tsx
+++ b/src/components/GalleryCarousel.tsx
@@ -1,0 +1,233 @@
+import useEmblaCarousel from "embla-carousel-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import Image from "next/image";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Photo {
+  url: string;
+  caption?: string; // rubrik / headline
+  description?: string;
+  // `event` can be a simple label string or an object (server may include the whole event)
+  event?: string | { headline?: string };
+}
+
+interface GalleryCarouselProps {
+  photos: Photo[];
+  showIndicators?: boolean;
+}
+
+export default function GalleryCarousel({
+  photos,
+  showIndicators = true,
+}: GalleryCarouselProps) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    loop: false,
+    align: "center",
+  });
+  const [selected, setSelected] = useState(0);
+  const mountedRef = useRef(true);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [aspects, setAspects] = useState<Record<number, number>>({});
+  const lastWheelRef = useRef(0);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (!mountedRef.current) return;
+        const w = entry.contentRect.width;
+        setContainerWidth(w);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      // Throttle wheel to avoid rapid changes
+      const now = Date.now();
+      if (now - lastWheelRef.current < 400) return;
+      lastWheelRef.current = now;
+
+      // Only respond to mostly-horizontal gestures (trackpad/scrollwheel horizontal swipes).
+      // Let vertical scrolling propagate to the page.
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+
+      // Prevent page from also scrolling during a horizontal swipe gesture.
+      e.preventDefault();
+
+      if (e.deltaX > 0) emblaApi?.scrollNext();
+      else emblaApi?.scrollPrev();
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, [emblaApi]);
+
+  const onSelect = useCallback(() => {
+    const idx = emblaApi?.selectedScrollSnap() ?? 0;
+    setSelected(idx);
+  }, [emblaApi]);
+
+  useEffect(() => {
+    const api = emblaApi;
+    if (!api) return;
+    api.on("select", onSelect);
+    onSelect();
+    return () => {
+      api.off("select", onSelect);
+    };
+  }, [emblaApi, onSelect]);
+
+  const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
+  const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
+  const scrollTo = useCallback(
+    (i: number) => emblaApi?.scrollTo(i),
+    [emblaApi],
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative border border-border rounded-lg"
+    >
+      <div className="overflow-hidden" ref={emblaRef}>
+        <div className="flex touch-pan-y">
+          {photos.map((photo, idx) => {
+            const _aspect = aspects[idx];
+            // Previously we used computed inline heights; switch to responsive classes
+            // to avoid inline styles and satisfy lint rules.
+
+            return (
+              <div key={photo.url} className="min-w-full shrink-0 px-2">
+                <div className="flex flex-col items-center justify-start py-3">
+                  {photo.caption ? (
+                    <div className="text-lg md:text-xl font-semibold text-foreground tracking-tight mb-2 text-center px-4">
+                      {typeof photo.caption === "string"
+                        ? photo.caption
+                        : String(photo.caption)}
+                    </div>
+                  ) : null}
+
+                  <div className="flex flex-col items-center w-full">
+                    <div className="relative w-full max-w-6xl mx-auto border border-border/20 rounded-md overflow-hidden">
+                      {aspects[idx] && containerWidth ? (
+                        (() => {
+                          const aspect = aspects[idx];
+                          const imgWidth = Math.max(
+                            320,
+                            Math.min(containerWidth, 1200),
+                          );
+                          const imgHeight = Math.round(imgWidth * aspect);
+                          return (
+                            <div className="w-full flex justify-center">
+                              <Image
+                                src={photo.url}
+                                alt={photo.caption || "Gallery photo"}
+                                width={imgWidth}
+                                height={imgHeight}
+                                sizes="(max-width: 1024px) 100vw, 80vw"
+                                onLoad={(e) => {
+                                  const img =
+                                    e.currentTarget as HTMLImageElement;
+                                  if (!mountedRef.current) return;
+                                  if (img.naturalWidth && img.naturalHeight) {
+                                    setAspects((s) => ({
+                                      ...s,
+                                      [idx]:
+                                        img.naturalHeight / img.naturalWidth,
+                                    }));
+                                  }
+                                }}
+                                className="object-contain rounded-md bg-transparent border-transparent w-full h-auto max-w-full"
+                              />
+                            </div>
+                          );
+                        })()
+                      ) : (
+                        <div className="h-[40vh] md:h-[55vh] max-h-[55vh]">
+                          <Image
+                            src={photo.url}
+                            alt={photo.caption || "Gallery photo"}
+                            fill
+                            sizes="(max-width: 1024px) 100vw, 80vw"
+                            onLoad={(e) => {
+                              const img = e.currentTarget as HTMLImageElement;
+                              if (!mountedRef.current) return;
+                              if (img.naturalWidth && img.naturalHeight) {
+                                setAspects((s) => ({
+                                  ...s,
+                                  [idx]: img.naturalHeight / img.naturalWidth,
+                                }));
+                              }
+                            }}
+                            className="object-contain rounded-md bg-transparent border-transparent"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* caption shown above as rubrik */}
+
+                  {photo.description && (
+                    <div className="mt-1 text-base md:text-lg text-muted-foreground text-center px-6 max-w-3xl">
+                      <em>
+                        {typeof photo.description === "string"
+                          ? photo.description
+                          : String(photo.description)}
+                      </em>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={scrollPrev}
+        className="absolute left-4 top-1/2 -translate-y-1/2 z-30 bg-white/30 dark:bg-black/30 backdrop-blur-sm hover:bg-white/50 dark:hover:bg-black/50 p-3 rounded-full shadow-lg flex items-center justify-center cursor-pointer transition"
+        aria-label="Föregående"
+      >
+        <ChevronLeft className="w-5 h-5 text-foreground" />
+      </button>
+
+      <button
+        type="button"
+        onClick={scrollNext}
+        className="absolute right-4 top-1/2 -translate-y-1/2 z-30 bg-white/30 dark:bg-black/30 backdrop-blur-sm hover:bg-white/50 dark:hover:bg-black/50 p-3 rounded-full shadow-lg flex items-center justify-center cursor-pointer transition"
+        aria-label="Nästa"
+      >
+        <ChevronRight className="w-5 h-5 text-foreground" />
+      </button>
+
+      {showIndicators && (
+        <div className="flex items-center justify-center gap-2 mt-6">
+          {photos.map((p, i) => (
+            <button
+              key={p.url}
+              type="button"
+              onClick={() => scrollTo(i)}
+              aria-label={`Gå till bild ${i + 1}`}
+              className={`w-3 h-3 rounded-full ${i === selected ? "bg-foreground" : "bg-muted"}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -1824,3 +1824,86 @@ export async function removeUserFromLesson(
     return { success: false, msg: "Ett tekniskt fel uppstod." };
   }
 }
+
+export async function addPhoto(data: {
+  url: string;
+  caption?: string;
+  description?: string;
+  eventId?: string;
+  isVisible?: boolean;
+}) {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, msg: "No permission." };
+
+  try {
+    await prisma.photo.create({
+      data: {
+        url: data.url,
+        caption: data.caption ?? null,
+        description: data.description ?? null,
+        eventId: data.eventId ?? null,
+        isVisible: data.isVisible ?? true,
+      },
+    });
+
+    revalidatePath("/admin/gallery");
+    revalidatePath("/gallery");
+
+    return { success: true, msg: "Bild skapad." };
+  } catch (e) {
+    console.error(e);
+    return { success: false, msg: "Kunde inte lägga till bilden." };
+  }
+}
+
+export async function editPhoto(
+  id: string,
+  data: {
+    url: string;
+    caption?: string;
+    description?: string;
+    eventId?: string;
+    isVisible?: boolean;
+  },
+) {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, msg: "No permission." };
+
+  try {
+    await prisma.photo.update({
+      where: { id },
+      data: {
+        url: data.url,
+        caption: data.caption ?? null,
+        description: data.description ?? null,
+        eventId: data.eventId ?? null,
+        isVisible: data.isVisible ?? true,
+      },
+    });
+
+    revalidatePath("/admin/gallery");
+    revalidatePath("/gallery");
+
+    return { success: true, msg: "Bild uppdaterad." };
+  } catch (e) {
+    console.error(e);
+    return { success: false, msg: "Kunde inte uppdatera bilden." };
+  }
+}
+
+export async function deletePhoto(id: string) {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, msg: "No permission." };
+
+  try {
+    await prisma.photo.delete({ where: { id } });
+
+    revalidatePath("/admin/gallery");
+    revalidatePath("/gallery");
+
+    return { success: true, msg: "Bild borttagen." };
+  } catch (e) {
+    console.error(e);
+    return { success: false, msg: "Kunde inte ta bort bilden." };
+  }
+}

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -2,6 +2,14 @@ import z from "zod";
 
 import { Weekday } from "@/generated/prisma/enums";
 
+export const adminPhotoSchema = z.object({
+  url: z.string().min(1, "Bild krävs."),
+  caption: z.string().optional(),
+  description: z.string().optional(),
+  eventId: z.string().optional(),
+  isVisible: z.boolean(),
+});
+
 const TIME_REGEX = /^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$/;
 
 // fix: max-booking per tillfälle (t.ex om de har ett tillfälle i studio-1 och ett annat i studio-2 eller bara vill kunna ha olika per dag.)


### PR DESCRIPTION
# Galleri: Event-koppling, admin-funktioner & UI-fix

## Vad är nytt/förbättrat?

- Infört `Photo`-modell och koppling till `Event`.
- Admin kan nu ladda upp, redigera, dölja/visa och ta bort bilder (inkl. radering i S3).
- Tydligt alternativ **“Inget event (Övriga bilder)”** för att avlänka bilder.
- Gruppvisning per event med karusell.
- Alla bilder visas nu korrekt och i samma storlek i galleriet, även om aspect ratio saknas initialt.
- Lint / format / build körda och grönt.
- S3-klient används som singleton överallt.
- Input validering i alla API-routes.
- Felhantering i upload-route är nu säker (ingen stack trace eller config till klienten).
- All debug-output borttagen.

---

## Stänger issues

- Closes #108   
- Closes #109 
- Closes #110 
- Closes #111 
- Closes #148  (Borttagna migreringar)  
- Closes #149  (Säkerhetsbrist i error responses)  
- Closes #150  (Kodkvalitet S3-klient, debug-kod, inputvalidering)

---

## Övrigt

- Alla migrations är återskapade, ingen gammal är borttagen.
- All kod är testad i dev, admin-galleri och publikt galleri ser bra ut och funkar.