### PR TITLE
Style fix #168

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 # misc
 .DS_Store
 *.pem
+.vscode/
 
 # debug
 npm-debug.log*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "WillLuke.nextjs.hasPrompted": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "WillLuke.nextjs.hasPrompted": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "WillLuke.nextjs.hasPrompted": true
+  "WillLuke.nextjs.hasPrompted": true
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import DansStilar from "@/components/dans-stilar";
 import LarareProfile from "@/components/larare-profile";
 import { getStudios } from "@/lib/actions/studio-actions";
@@ -6,7 +5,7 @@ import { getStyles } from "@/lib/actions/style-actions";
 
 export default async function About() {
   const [studios, styles] = await Promise.all([getStudios(), getStyles()]);
-  const activeStudios = studios.filter((studio) => studio.active);
+  const _activeStudios = studios.filter((studio) => studio.active);
 
   return (
     <main className="bg-background">
@@ -30,45 +29,65 @@ export default async function About() {
       <DansStilar styles={styles} />
 
       {/* Studio */}
-      <section className="py-16 bg-muted/50">
-        <div className="max-w-6xl mx-auto px-6 text-center">
-          <h2 className="text-2xl font-bold mb-4 text-foreground">
-            Våra lokaler
-          </h2>
-          {activeStudios.length === 0 ? (
-            <p className="text-muted-foreground mb-8">
-              Information om våra studios kommer snart.
-            </p>
-          ) : (
-            <div className="mx-auto flex max-w-6xl flex-wrap justify-center gap-6">
-              {activeStudios.map((studio) => (
-                <div
-                  key={studio.id}
-                  className="flex w-[500px] max-w-full flex-col items-center rounded-lg border-2 border-border p-6 text-center"
-                >
-                  {studio.imageUrl && (
-                    <Image
-                      src={studio.imageUrl}
-                      alt={studio.name}
-                      height={220}
-                      width={420}
-                      className="mb-4 h-[220px] w-full rounded-lg object-cover"
-                    />
-                  )}
-                  <h3 className="font-semibold text-lg">{studio.name}</h3>
-                  <p className="mt-2 text-muted-foreground">
-                    {studio.description}
-                  </p>
-                </div>
-              ))}
+      <section className="relative w-full bg-black overflow-hidden py-28">
+        {/* Background image with overlay */}
+        <div className="absolute inset-0 z-0">
+          <div
+            className="absolute inset-0 bg-cover bg-center scale-105"
+            style={{
+              backgroundImage: "url('/hiphop.jpg')",
+              animation: "subtlePan 20s ease-in-out infinite alternate",
+            }}
+          />
+          {/* Gradient overlays to match hero */}
+          <div className="absolute inset-0 bg-black/70" />
+          <div className="absolute inset-0 bg-linear-to-r from-black via-black/50 to-black/30" />
+          <div className="absolute inset-0 bg-linear-to-t from-black via-transparent to-black/60" />
+        </div>
+
+        {/* Decorative vertical line */}
+        <div className="absolute left-0 top-0 bottom-0 w-px bg-linear-to-b from-transparent via-brand/40 to-transparent" />
+
+        <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12">
+          <div className="grid md:grid-cols-2 gap-16 items-center">
+            {/* Left: Text content */}
+            <div>
+              <div className="flex items-center gap-3 mb-6 animate-fade-in-left">
+                <span className="h-[2px] w-8 bg-brand" />
+                <p className="text-brand-secondary font-semibold tracking-[0.2em] uppercase text-sm">
+                  Vår Studio
+                </p>
+              </div>
+
+              <h2 className="text-4xl md:text-6xl font-light text-white leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:150ms]">
+                En plats skapad
+                <br />
+                <span className="font-serif italic text-brand-light">
+                  för rörelse
+                </span>
+              </h2>
+
+              <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-light max-w-md mb-10 animate-fade-in-left [animation-delay:300ms]">
+                Vår studio är designad för att kännas inspirerande, trygg och
+                professionell. Ljusa salar, speglar och högkvalitativa golv
+                skapar den perfekta miljön för dans.
+              </p>
+
+              <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
+                <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
+                <p className="text-white text-xl font-light leading-snug">
+                  Här är alla välkomna –{" "}
+                  <span className="font-serif italic text-brand-light">
+                    oavsett nivå.
+                  </span>
+                </p>
+              </div>
             </div>
-          )}
-          <div className="bg-brand rounded-lg p-6 mb-10 mt-8">
-            <p className="text-white text-lg font-semibold">
-              Här är alla välkomna - oavsett nivå.
-            </p>
           </div>
         </div>
+
+        {/* Bottom fade */}
+        <div className="absolute bottom-0 left-0 right-0 h-16 bg-linear-to-t from-black to-transparent" />
       </section>
     </main>
   );

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import DansStilar from "@/components/dans-stilar";
 import LarareProfile from "@/components/larare-profile";
 import { getStudios } from "@/lib/actions/studio-actions";
@@ -5,7 +6,7 @@ import { getStyles } from "@/lib/actions/style-actions";
 
 export default async function About() {
   const [studios, styles] = await Promise.all([getStudios(), getStyles()]);
-  const _activeStudios = studios.filter((studio) => studio.active);
+  const activeStudios = studios.filter((studio) => studio.active);
 
   return (
     <main className="bg-background">
@@ -28,67 +29,68 @@ export default async function About() {
       <LarareProfile />
       <DansStilar styles={styles} />
 
-      {/* Studio */}
+
       <section className="relative w-full bg-black overflow-hidden py-28">
-        {/* Background image with overlay */}
-        <div className="absolute inset-0 z-0">
-          <div
-            className="absolute inset-0 bg-cover bg-center scale-105"
-            style={{
-              backgroundImage: "url('/hiphop.jpg')",
-              animation: "subtlePan 20s ease-in-out infinite alternate",
-            }}
-          />
-          {/* Gradient overlays to match hero */}
-          <div className="absolute inset-0 bg-black/70" />
-          <div className="absolute inset-0 bg-linear-to-r from-black via-black/50 to-black/30" />
-          <div className="absolute inset-0 bg-linear-to-t from-black via-transparent to-black/60" />
-        </div>
 
-        {/* Decorative vertical line */}
-        <div className="absolute left-0 top-0 bottom-0 w-px bg-linear-to-b from-transparent via-brand/40 to-transparent" />
+      <div className="absolute inset-0 z-0">
+        <div
+          className="absolute inset-0 bg-cover bg-center scale-105"
+          style={{
+            backgroundImage: "url('/hiphop.jpg')",
+            animation: "subtlePan 20s ease-in-out infinite alternate",
+          }}
+        />
 
-        <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12">
-          <div className="grid md:grid-cols-2 gap-16 items-center">
-            {/* Left: Text content */}
-            <div>
-              <div className="flex items-center gap-3 mb-6 animate-fade-in-left">
-                <span className="h-[2px] w-8 bg-brand" />
-                <p className="text-brand-secondary font-semibold tracking-[0.2em] uppercase text-sm">
-                  Vår Studio
-                </p>
-              </div>
+        <div className="absolute inset-0 bg-black/70" />
+        <div className="absolute inset-0 bg-linear-to-r from-black via-black/50 to-black/30" />
+        <div className="absolute inset-0 bg-linear-to-t from-black via-transparent to-black/60" />
+      </div>
 
-              <h2 className="text-4xl md:text-6xl font-light text-white leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:150ms]">
-                En plats skapad
-                <br />
-                <span className="font-serif italic text-brand-light">
-                  för rörelse
-                </span>
-              </h2>
+      <div className="absolute left-0 top-0 bottom-0 w-px bg-linear-to-b from-transparent via-brand/40 to-transparent" />
 
-              <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-light max-w-md mb-10 animate-fade-in-left [animation-delay:300ms]">
-                Vår studio är designad för att kännas inspirerande, trygg och
-                professionell. Ljusa salar, speglar och högkvalitativa golv
-                skapar den perfekta miljön för dans.
+      <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12">
+        <div className="grid md:grid-cols-2 gap-16 items-center">
+
+          <div>
+
+            <div className="flex items-center gap-3 mb-6 animate-fade-in-left">
+              <span className="h-[2px] w-8 bg-brand" />
+              <p className="text-brand-secondary font-semibold tracking-[0.2em] uppercase text-sm">
+                Vår Studio
               </p>
+            </div>
+
+            <h2 className="text-4xl md:text-6xl font-light text-white leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:150ms]">
+              En plats skapad
+              <br />
+              <span className="font-serif italic text-brand-light">för rörelse</span>
+            </h2>
+
+            <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-light max-w-md mb-10 animate-fade-in-left [animation-delay:300ms]">
+              Vår studio är designad för att kännas inspirerande, trygg och
+              professionell. Ljusa salar, speglar och högkvalitativa golv skapar
+              den perfekta miljön för dans.
+            </p>
 
               <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
-                <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
-                <p className="text-white text-xl font-light leading-snug">
-                  Här är alla välkomna –{" "}
-                  <span className="font-serif italic text-brand-light">
-                    oavsett nivå.
-                  </span>
-                </p>
-              </div>
+              <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
+              <p className="text-white text-xl font-light leading-snug">
+                Här är alla välkomna –{" "}
+                <span className="font-serif italic text-brand-light">oavsett nivå.</span>
+              </p>
             </div>
-          </div>
-        </div>
 
-        {/* Bottom fade */}
-        <div className="absolute bottom-0 left-0 right-0 h-16 bg-linear-to-t from-black to-transparent" />
-      </section>
+          </div>
+
+        
+        </div>
+      </div>
+
+      {/* Bottom fade */}
+      <div className="absolute bottom-0 left-0 right-0 h-16 bg-linear-to-t from-black to-transparent" />
+
+      
+    </section>
     </main>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import DansStilar from "@/components/dans-stilar";
 import LarareProfile from "@/components/larare-profile";
 import { getStudios } from "@/lib/actions/studio-actions";
@@ -6,7 +5,7 @@ import { getStyles } from "@/lib/actions/style-actions";
 
 export default async function About() {
   const [studios, styles] = await Promise.all([getStudios(), getStyles()]);
-  const activeStudios = studios.filter((studio) => studio.active);
+  const _activeStudios = studios.filter((studio) => studio.active);
 
   return (
     <main className="bg-background">
@@ -29,68 +28,63 @@ export default async function About() {
       <LarareProfile />
       <DansStilar styles={styles} />
 
-
       <section className="relative w-full bg-black overflow-hidden py-28">
+        <div className="absolute inset-0 z-0">
+          <div
+            className="absolute inset-0 bg-cover bg-center scale-105"
+            style={{
+              backgroundImage: "url('/hiphop.jpg')",
+              animation: "subtlePan 20s ease-in-out infinite alternate",
+            }}
+          />
 
-      <div className="absolute inset-0 z-0">
-        <div
-          className="absolute inset-0 bg-cover bg-center scale-105"
-          style={{
-            backgroundImage: "url('/hiphop.jpg')",
-            animation: "subtlePan 20s ease-in-out infinite alternate",
-          }}
-        />
+          <div className="absolute inset-0 bg-black/70" />
+          <div className="absolute inset-0 bg-linear-to-r from-black via-black/50 to-black/30" />
+          <div className="absolute inset-0 bg-linear-to-t from-black via-transparent to-black/60" />
+        </div>
 
-        <div className="absolute inset-0 bg-black/70" />
-        <div className="absolute inset-0 bg-linear-to-r from-black via-black/50 to-black/30" />
-        <div className="absolute inset-0 bg-linear-to-t from-black via-transparent to-black/60" />
-      </div>
+        <div className="absolute left-0 top-0 bottom-0 w-px bg-linear-to-b from-transparent via-brand/40 to-transparent" />
 
-      <div className="absolute left-0 top-0 bottom-0 w-px bg-linear-to-b from-transparent via-brand/40 to-transparent" />
+        <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12">
+          <div className="grid md:grid-cols-2 gap-16 items-center">
+            <div>
+              <div className="flex items-center gap-3 mb-6 animate-fade-in-left">
+                <span className="h-[2px] w-8 bg-brand" />
+                <p className="text-brand-secondary font-semibold tracking-[0.2em] uppercase text-sm">
+                  Vår Studio
+                </p>
+              </div>
 
-      <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12">
-        <div className="grid md:grid-cols-2 gap-16 items-center">
+              <h2 className="text-4xl md:text-6xl font-light text-white leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:150ms]">
+                En plats skapad
+                <br />
+                <span className="font-serif italic text-brand-light">
+                  för rörelse
+                </span>
+              </h2>
 
-          <div>
-
-            <div className="flex items-center gap-3 mb-6 animate-fade-in-left">
-              <span className="h-[2px] w-8 bg-brand" />
-              <p className="text-brand-secondary font-semibold tracking-[0.2em] uppercase text-sm">
-                Vår Studio
+              <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-light max-w-md mb-10 animate-fade-in-left [animation-delay:300ms]">
+                Vår studio är designad för att kännas inspirerande, trygg och
+                professionell. Ljusa salar, speglar och högkvalitativa golv
+                skapar den perfekta miljön för dans.
               </p>
-            </div>
-
-            <h2 className="text-4xl md:text-6xl font-light text-white leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:150ms]">
-              En plats skapad
-              <br />
-              <span className="font-serif italic text-brand-light">för rörelse</span>
-            </h2>
-
-            <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-light max-w-md mb-10 animate-fade-in-left [animation-delay:300ms]">
-              Vår studio är designad för att kännas inspirerande, trygg och
-              professionell. Ljusa salar, speglar och högkvalitativa golv skapar
-              den perfekta miljön för dans.
-            </p>
 
               <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
-              <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
-              <p className="text-white text-xl font-light leading-snug">
-                Här är alla välkomna –{" "}
-                <span className="font-serif italic text-brand-light">oavsett nivå.</span>
-              </p>
+                <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
+                <p className="text-white text-xl font-light leading-snug">
+                  Här är alla välkomna –{" "}
+                  <span className="font-serif italic text-brand-light">
+                    oavsett nivå.
+                  </span>
+                </p>
+              </div>
             </div>
-
           </div>
-
-        
         </div>
-      </div>
 
-      {/* Bottom fade */}
-      <div className="absolute bottom-0 left-0 right-0 h-16 bg-linear-to-t from-black to-transparent" />
-
-      
-    </section>
+        {/* Bottom fade */}
+        <div className="absolute bottom-0 left-0 right-0 h-16 bg-linear-to-t from-black to-transparent" />
+      </section>
     </main>
   );
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import DansStilar from "@/components/dans-stilar";
 import LarareProfile from "@/components/larare-profile";
 import { getStudios } from "@/lib/actions/studio-actions";
@@ -5,7 +6,7 @@ import { getStyles } from "@/lib/actions/style-actions";
 
 export default async function About() {
   const [studios, styles] = await Promise.all([getStudios(), getStyles()]);
-  const _activeStudios = studios.filter((studio) => studio.active);
+  const activeStudios = studios.filter((studio) => studio.active);
 
   return (
     <main className="bg-background">
@@ -28,62 +29,46 @@ export default async function About() {
       <LarareProfile />
       <DansStilar styles={styles} />
 
-      <section className="relative w-full bg-black overflow-hidden py-28">
-        <div className="absolute inset-0 z-0">
-          <div
-            className="absolute inset-0 bg-cover bg-center scale-105"
-            style={{
-              backgroundImage: "url('/hiphop.jpg')",
-              animation: "subtlePan 20s ease-in-out infinite alternate",
-            }}
-          />
-
-          <div className="absolute inset-0 bg-black/70" />
-          <div className="absolute inset-0 bg-linear-to-r from-black via-black/50 to-black/30" />
-          <div className="absolute inset-0 bg-linear-to-t from-black via-transparent to-black/60" />
-        </div>
-
-        <div className="absolute left-0 top-0 bottom-0 w-px bg-linear-to-b from-transparent via-brand/40 to-transparent" />
-
-        <div className="relative z-10 w-full max-w-7xl mx-auto px-6 md:px-12">
-          <div className="grid md:grid-cols-2 gap-16 items-center">
-            <div>
-              <div className="flex items-center gap-3 mb-6 animate-fade-in-left">
-                <span className="h-[2px] w-8 bg-brand" />
-                <p className="text-brand-secondary font-semibold tracking-[0.2em] uppercase text-sm">
-                  Vår Studio
-                </p>
-              </div>
-
-              <h2 className="text-4xl md:text-6xl font-light text-white leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:150ms]">
-                En plats skapad
-                <br />
-                <span className="font-serif italic text-brand-light">
-                  för rörelse
-                </span>
-              </h2>
-
-              <p className="text-zinc-300 text-base md:text-lg leading-relaxed font-light max-w-md mb-10 animate-fade-in-left [animation-delay:300ms]">
-                Vår studio är designad för att kännas inspirerande, trygg och
-                professionell. Ljusa salar, speglar och högkvalitativa golv
-                skapar den perfekta miljön för dans.
-              </p>
-
-              <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
-                <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
-                <p className="text-white text-xl font-light leading-snug">
-                  Här är alla välkomna –{" "}
-                  <span className="font-serif italic text-brand-light">
-                    oavsett nivå.
-                  </span>
-                </p>
-              </div>
+      {/* Studio */}
+      <section className="py-16 bg-muted/50">
+        <div className="max-w-6xl mx-auto px-6 text-center">
+          <h2 className="text-2xl font-bold mb-4 text-foreground">
+            Våra lokaler
+          </h2>
+          {activeStudios.length === 0 ? (
+            <p className="text-muted-foreground mb-8">
+              Information om våra studios kommer snart.
+            </p>
+          ) : (
+            <div className="mx-auto flex max-w-6xl flex-wrap justify-center gap-6">
+              {activeStudios.map((studio) => (
+                <div
+                  key={studio.id}
+                  className="flex w-[500px] max-w-full flex-col items-center rounded-lg border-2 border-border p-6 text-center"
+                >
+                  {studio.imageUrl && (
+                    <Image
+                      src={studio.imageUrl}
+                      alt={studio.name}
+                      height={220}
+                      width={420}
+                      className="mb-4 h-[220px] w-full rounded-lg object-cover"
+                    />
+                  )}
+                  <h3 className="font-semibold text-lg">{studio.name}</h3>
+                  <p className="mt-2 text-muted-foreground">
+                    {studio.description}
+                  </p>
+                </div>
+              ))}
             </div>
+          )}
+          <div className="bg-brand rounded-lg p-6 mb-10 mt-8">
+            <p className="text-white text-lg font-semibold">
+              Här är alla välkomna - oavsett nivå.
+            </p>
           </div>
         </div>
-
-        {/* Bottom fade */}
-        <div className="absolute bottom-0 left-0 right-0 h-16 bg-linear-to-t from-black to-transparent" />
       </section>
     </main>
   );

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -63,10 +63,12 @@ export default async function About() {
               ))}
             </div>
           )}
-          <div className="bg-brand rounded-lg p-6 mb-10 mt-8">
-            <p className="text-white text-lg font-semibold">
-              Här är alla välkomna - oavsett nivå.
-            </p>
+          <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
+              <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
+              <p className="text-white text-xl font-light leading-snug">
+                Här är alla välkomna –{" "}
+                <span className="font-serif italic text-brand-light">oavsett nivå.</span>
+              </p>
           </div>
         </div>
       </section>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -64,11 +64,13 @@ export default async function About() {
             </div>
           )}
           <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
-              <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
-              <p className="text-white text-xl font-light leading-snug">
-                Här är alla välkomna –{" "}
-                <span className="font-serif italic text-brand-light">oavsett nivå.</span>
-              </p>
+            <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
+            <p className="text-white text-xl font-light leading-snug">
+              Här är alla välkomna –{" "}
+              <span className="font-serif italic text-brand-light">
+                oavsett nivå.
+              </span>
+            </p>
           </div>
         </div>
       </section>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -73,7 +73,7 @@ export default function Page() {
             <h2 className="text-4xl md:text-5xl font-black mb-4 text-foreground tracking-tight">
               Bilder från studion
             </h2>
-            <p className="text-brand-secondary font-bold animate-pulse max-w-xl mx-auto text-lg">
+            <p className="text-brand-secondary font-bold max-w-xl mx-auto text-lg">
               Ta en titt in i vår värld
             </p>
           </div>

--- a/src/app/start/Hero.tsx
+++ b/src/app/start/Hero.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { ArrowRight } from "lucide-react";
 import Link from "next/link";
 
 export default function Hero() {
@@ -53,25 +54,9 @@ export default function Hero() {
 
             <Link
               href="/about"
-              className="group flex items-center gap-2 text-white/80 font-medium text-sm hover:text-white transition-colors"
+              className="group flex items-center gap-2 px-8 py-3.5 rounded-full border border-white/20 text-white/80 font-medium text-sm hover:text-white hover:border-brand transition-all duration-300"
             >
-              <span className="w-8 h-8 rounded-full border border-white/20 flex items-center justify-center group-hover:border-brand transition-all">
-                <svg
-                  className="w-3 h-3"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <title>Pil höger</title>
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 5l7 7-7 7"
-                  />
-                </svg>
-              </span>
+              <ArrowRight className="w-3 h-3" />
               Om Oss
             </Link>
           </div>


### PR DESCRIPTION
## Beskrivning

Closes #168

- Tagit bort `animate-pulse` i galleriet
- Bytt inline SVG till `lucide-react` ArrowRight-ikon i Hero
- Stiländringar på "Om Oss"-länkknappen i Hero (rounded-full border)
- Stylade om "Här är alla välkomna"-bannern på about-sidan
- Lagt till `.vscode/` i `.gitignore`

## Skärmdumpar (om relevant)

<img width="1863" height="1248" alt="image" src="https://github.com/user-attachments/assets/76e56edc-f0c5-4f07-a688-c38d0e7429c5" />

<img width="795" height="591" alt="image" src="https://github.com/user-attachments/assets/d1f81c35-999d-4d65-94a9-51ad8e3b35f9" />