### PR TITLE
131 information fields course page

### DIFF
--- a/src/app/courses/components/CourseInfoDialog.tsx
+++ b/src/app/courses/components/CourseInfoDialog.tsx
@@ -57,9 +57,13 @@ export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
             <p className="text-muted-foreground">
               {course.adult ? "Vuxna" : "Barn/Ungdom"}
             </p>
-            {course.minAge != null && course.maxAge != null && (
+            {course.minAge != null && (
               <p className="text-muted-foreground">
-                Åldersgrupp: {course.minAge}–{course.maxAge} år
+                Åldersgrupp: {course.minAge}
+                {course.maxAge != null && course.maxAge > 0
+                  ? `–${course.maxAge}`
+                  : "+"}{" "}
+                år
               </p>
             )}
           </div>

--- a/src/app/courses/components/CourseInfoDialog.tsx
+++ b/src/app/courses/components/CourseInfoDialog.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import Image from "next/image";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+
+type CourseForDialog = {
+  name: string;
+  minAge: number | null;
+  maxAge: number | null;
+  level: string | null;
+  description: string;
+  adult: boolean;
+  teacher: {
+    name: string;
+    email: string;
+    teacherProfile: {
+      description: string;
+      imageUrl: string | null;
+    } | null;
+  };
+};
+
+interface CourseInfoDialogProps {
+  course: CourseForDialog;
+}
+
+export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
+  const title = `${course.name}${course.minAge != null ? ` ${course.minAge}+ år` : ""}${course.level ? ` - ${course.level}` : ""}`;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <span className="flex min-w-20 gap-1 items-center text-xs text-brand hover:underline cursor-pointer">
+          Läs mer om kursen
+          <ArrowUpRight className="w-3 h-3 shrink-0" />
+        </span>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{course.description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm">
+          {/* Target group */}
+          <div className="space-y-1">
+            <p className="font-medium text-foreground">Målgrupp</p>
+            <p className="text-muted-foreground">
+              {course.adult ? "Vuxna" : "Barn/Ungdom"}
+            </p>
+            {course.minAge != null && course.maxAge != null && (
+              <p className="text-muted-foreground">
+                Åldersgrupp: {course.minAge}–{course.maxAge} år
+              </p>
+            )}
+          </div>
+
+          <Separator />
+
+          {/* Teacher section */}
+          <div className="space-y-2">
+            <p className="font-medium text-foreground">Lärare</p>
+            <div className="flex items-start gap-3">
+              {course.teacher.teacherProfile?.imageUrl && (
+                <div className="relative shrink-0 w-16 h-20 rounded-md overflow-hidden border border-border">
+                  <Image
+                    src={course.teacher.teacherProfile.imageUrl}
+                    alt={course.teacher.name}
+                    fill
+                    className="object-cover object-top"
+                    sizes="64px"
+                  />
+                </div>
+              )}
+              <div className="space-y-1">
+                <p>{course.teacher.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {course.teacher.email}
+                </p>
+                {course.teacher.teacherProfile?.description && (
+                  <p className="text-muted-foreground whitespace-pre-line mt-1 leading-relaxed">
+                    {course.teacher.teacherProfile.description}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/courses/components/CourseInfoDialog.tsx
+++ b/src/app/courses/components/CourseInfoDialog.tsx
@@ -39,7 +39,7 @@ export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <span className="flex min-w-20 gap-1 items-center text-xs text-brand hover:underline cursor-pointer">
+        <span className="flex shrink-0 gap-1 items-center whitespace-nowrap text-xs text-brand hover:underline cursor-pointer">
           Läs mer om kursen
           <ArrowUpRight className="w-3 h-3 shrink-0" />
         </span>
@@ -81,7 +81,7 @@ export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
                     alt={course.teacher.name}
                     fill
                     className="object-cover object-top"
-                    sizes="64px"
+                    sizes="96px"
                   />
                 </div>
               )}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,11 +1,4 @@
-import {
-  ArrowUpRight,
-  Book,
-  CalendarDays,
-  Clock,
-  Info,
-  MapPin,
-} from "lucide-react";
+import { Book, CalendarDays, Clock, Info, MapPin } from "lucide-react";
 import Image from "next/image";
 import { PaginationBar } from "@/components/PaginationBar";
 import {
@@ -24,18 +17,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import { addToCart } from "@/lib/actions/cart";
 import { getProductStats } from "@/lib/actions/purchase-actions";
 import prisma from "@/lib/prisma";
 import { getVeckodag } from "@/lib/tools";
+import { CourseInfoDialog } from "./components/CourseInfoDialog";
 import { CoursesFilter } from "./components/CoursesFilter";
 
 interface Props {
@@ -111,7 +97,11 @@ export default async function Page({ searchParams }: Props) {
                   termin: true,
                 },
               },
-              teacher: true,
+              teacher: {
+                include: {
+                  teacherProfile: true,
+                },
+              },
             },
           },
         },
@@ -281,37 +271,7 @@ export default async function Page({ searchParams }: Props) {
                                           {`${c.name} ${c.minAge}+ år - ${c.level}`}
                                         </div>
                                         {/* DIALOG FOR COURSE DETAILS */}
-                                        <Dialog>
-                                          <DialogTrigger asChild>
-                                            <span className="flex min-w-20 gap-1 items-center text-xs text-brand hover:underline cursor-pointer">
-                                              Läs mer om kursen
-                                              <ArrowUpRight className="w-3 h-3 shrink-0" />
-                                            </span>
-                                          </DialogTrigger>
-                                          <DialogContent>
-                                            <DialogHeader>
-                                              <DialogTitle>{`${c.name} ${c.minAge}+ år - ${c.level}`}</DialogTitle>
-                                              <DialogDescription>
-                                                {c.description}
-                                              </DialogDescription>
-                                            </DialogHeader>
-                                            {/* Bunch of dialog content that is hard to format without rawdogging divs */}
-                                            <div className="space-y-3 text-sm">
-                                              <div className="space-y-1">
-                                                <p>{`Lärare: ${c.teacher.name}`}</p>
-                                                <p className="text-xs text-muted-foreground">
-                                                  {`Email: ${c.teacher.email}`}
-                                                </p>
-                                              </div>
-                                              <p>
-                                                {`Målgrupp: ${c.adult ? "Vuxna" : "Barn/Ungdom"}`}
-                                              </p>
-                                              <p>
-                                                {`Åldersgrupp: ${c.minAge}-${c.maxAge} år`}
-                                              </p>
-                                            </div>
-                                          </DialogContent>
-                                        </Dialog>
+                                        <CourseInfoDialog course={c} />
                                       </div>
                                       <p className="text-muted-foreground text-xs">
                                         Antal Tillfällen: {lessonCount}
@@ -353,8 +313,7 @@ export default async function Page({ searchParams }: Props) {
                                                 </p>
                                               )}
                                               <div className="mt-2">
-                                                {" "}
-                                                {`Giltig: ${s.customStartDate ?? s.termin.startDate.toLocaleDateString("sv-SE")} - ${s.customEndDate ?? s.termin.endDate.toLocaleDateString("sv-SE")}`}{" "}
+                                                {`Period: ${(s.customStartDate ?? s.termin.startDate).toLocaleDateString("sv-SE")} - ${(s.customEndDate ?? s.termin.endDate).toLocaleDateString("sv-SE")}`}
                                               </div>
                                             </div>
                                           ))}


### PR DESCRIPTION
## Beskrivning

På kurssidan:
- Förbättrad popup med fixad formattering och information om läraren + profilbild
- Tagit beslut att en unik lärardescription per kurs är överflödigt, vi tar informationen som är satt i TeacherProfile bara
- Kursperiodsformattering fixad

## Relaterade issues

Closes #131 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [x] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [x] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [x] Jag har lagt till/uppdaterat typer där det behövs
