### PR TITLE
Fixat race condition i checkout

### DIFF
--- a/src/lib/actions/checkout.ts
+++ b/src/lib/actions/checkout.ts
@@ -35,62 +35,70 @@ export async function createCheckout(params: {
     price: number;
   }[] = [];
 
-  for (const itm of items) {
-    const p = await prisma.product.findUnique({
-      where: { id: itm.productId },
-    });
-    if (!p)
-      throw new Error(
-        `Product ${itm.productId} was not found. Order cancelled.`,
-      );
+  // Gör en transaction här då.
+  const order = await prisma.$transaction(
+    async (tx) => {
+      for (const itm of items) {
+        const p = await tx.product.findUnique({
+          where: { id: itm.productId },
+        });
+        if (!p)
+          throw new Error(
+            `Product ${itm.productId} was not found. Order cancelled.`,
+          );
 
-    const stats = await getProductStats(p.id);
+        const stats = await getProductStats(p.id, tx);
 
-    if (!stats.success)
-      throw new Error(
-        `Could not get stats for product ${itm.productId}. Order cancelled.`,
-      );
+        if (!stats.success)
+          throw new Error(
+            `Could not get stats for product ${itm.productId}. Order cancelled.`,
+          );
 
-    if (
-      typeof stats.spotsLeft === "number" &&
-      Number.isFinite(stats.spotsLeft) &&
-      itm.count > stats.spotsLeft
-    )
-      throw new Error(
-        `Product count exceeds limit for product ${itm.productId}. Count was ${itm.count} and spotsLeft is ${stats.spotsLeft}.`,
-      );
+        if (
+          typeof stats.spotsLeft === "number" &&
+          Number.isFinite(stats.spotsLeft) &&
+          itm.count > stats.spotsLeft
+        )
+          throw new Error(
+            `Product count exceeds limit for product ${itm.productId}. Count was ${itm.count} and spotsLeft is ${stats.spotsLeft}.`,
+          );
 
-    // Vi behöver kolla totalt också.
-    pCountTotal.set(
-      itm.productId,
-      (pCountTotal.get(itm.productId) ?? 0) + itm.count,
-    );
+        // Vi behöver kolla totalt också.
+        pCountTotal.set(
+          itm.productId,
+          (pCountTotal.get(itm.productId) ?? 0) + itm.count,
+        );
 
-    const totalInCartForProduct = pCountTotal.get(itm.productId) ?? 0;
-    if (
-      typeof stats.spotsLeft === "number" &&
-      Number.isFinite(stats.spotsLeft) &&
-      totalInCartForProduct > stats.spotsLeft
-    )
-      throw new Error(
-        `product count exceeds limit for product ${itm.productId}. Count was ${totalInCartForProduct} and spotsLeft is ${stats.spotsLeft}.`,
-      );
+        const totalInCartForProduct = pCountTotal.get(itm.productId) ?? 0;
+        if (
+          typeof stats.spotsLeft === "number" &&
+          Number.isFinite(stats.spotsLeft) &&
+          totalInCartForProduct > stats.spotsLeft
+        )
+          throw new Error(
+            `product count exceeds limit for product ${itm.productId}. Count was ${totalInCartForProduct} and spotsLeft is ${stats.spotsLeft}.`,
+          );
 
-    // Use the server-fetched price directly — never trust the client.
-    serverItems.push({
-      productId: itm.productId,
-      count: itm.count,
-      participantId: itm.participantId,
-      price: p.price,
-    });
-  }
+        // Use the server-fetched price directly — never trust the client.
+        serverItems.push({
+          productId: itm.productId,
+          count: itm.count,
+          participantId: itm.participantId,
+          price: p.price,
+        });
+      }
 
-  const order = await createOrder({
-    userId: session.user.id,
-    items: serverItems,
-    postalcode,
-    note,
-  });
+      const order = await createOrder(tx, {
+        userId: session.user.id,
+        items: serverItems,
+        postalcode,
+        note,
+      });
+
+      return order;
+    },
+    { isolationLevel: "Serializable" },
+  );
 
   // Try to send confirmation email
   try {

--- a/src/lib/actions/purchase-actions.ts
+++ b/src/lib/actions/purchase-actions.ts
@@ -101,7 +101,10 @@ export async function handleClips(
 }
 
 // Så denna funktion räknar antal redan sålda produkter av den specifika produkten, och om man vill räkna med de som ligger och väntar i order.
-export async function getProductStats(productId: string): Promise<{
+export async function getProductStats(
+  productId: string,
+  tx?: PrismaTx,
+): Promise<{
   sold: number | null;
   reserved: number | null;
   total: number | null;
@@ -111,19 +114,21 @@ export async function getProductStats(productId: string): Promise<{
 }> {
   // 1. Hämta alla purchases med det produktId:t.
   try {
-    const product = await prisma.product.findUniqueOrThrow({
+    const db = tx ?? prisma;
+
+    const product = await db.product.findUniqueOrThrow({
       where: { id: productId },
       select: { maxCustomer: true, unlimitedCustomers: true },
     });
 
-    const sold = await prisma.purchase.count({
+    const sold = await db.purchase.count({
       where: {
         productId: productId,
         order: { status: { not: "CANCELLED" } },
       },
     });
 
-    const orderCount = await prisma.orderItem.aggregate({
+    const orderCount = await db.orderItem.aggregate({
       where: {
         productId,
         order: {

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,3 +1,4 @@
+import type { PrismaTx } from "./actions/admin";
 import prisma from "./prisma";
 
 export type OrderItemInput = {
@@ -7,12 +8,15 @@ export type OrderItemInput = {
   participantId?: string | null;
 };
 
-export async function createOrder(params: {
-  userId: string;
-  items: OrderItemInput[];
-  postalcode?: string;
-  note?: string; // optional note to include in first status event
-}) {
+export async function createOrder(
+  tx: PrismaTx,
+  params: {
+    userId: string;
+    items: OrderItemInput[];
+    postalcode?: string;
+    note?: string; // optional note to include in first status event
+  },
+) {
   const { userId, items, postalcode, note } = params;
 
   if (!items || items.length === 0) throw new Error("No items provided");
@@ -22,42 +26,39 @@ export async function createOrder(params: {
   const totalStr = String(total);
 
   // Create order + items + initial status event atomically
-  const result = await prisma.$transaction(async (tx) => {
-    const order = await tx.order.create({
-      data: {
-        userId,
-        postalcode,
-        totalPrice: Number.parseFloat(totalStr),
-        // default status is PENDING_PAYMENT per schema
-      },
-    });
 
-    await tx.orderItem.createMany({
-      data: items.map((it) => ({
-        orderId: order.id,
-        productId: it.productId,
-        count: it.count,
-        price: it.price,
-        participantId: it.participantId || null,
-      })),
-      skipDuplicates: true,
-    });
-
-    // Seed first status event (from null -> PENDING_PAYMENT)
-    await tx.orderStatusEvent.create({
-      data: {
-        orderId: order.id,
-        fromStatus: null,
-        toStatus: "PENDING_PAYMENT",
-        changedByUserId: userId,
-        note,
-      },
-    });
-
-    return order;
+  const orderResult = await tx.order.create({
+    data: {
+      userId,
+      postalcode,
+      totalPrice: Number.parseFloat(totalStr),
+      // default status is PENDING_PAYMENT per schema
+    },
   });
 
-  return result;
+  await tx.orderItem.createMany({
+    data: items.map((it) => ({
+      orderId: orderResult.id,
+      productId: it.productId,
+      count: it.count,
+      price: it.price,
+      participantId: it.participantId || null,
+    })),
+    skipDuplicates: true,
+  });
+
+  // Seed first status event (from null -> PENDING_PAYMENT)
+  await tx.orderStatusEvent.create({
+    data: {
+      orderId: orderResult.id,
+      fromStatus: null,
+      toStatus: "PENDING_PAYMENT",
+      changedByUserId: userId,
+      note,
+    },
+  });
+
+  return orderResult;
 }
 
 export async function getOrderById(orderId: string) {


### PR DESCRIPTION
Closes #161

Fixar TOCTOU i checkout genom att köra tillgänglighetskontroll och order-skapande i samma Prisma-transaction med isolationLevel: "Serializable" i [checkout.ts](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-0.4.78-win32-x64/webview/#).
getProductStats accepterar nu valfri tx och använder tx ?? prisma, och anropas med tx från checkout så att läsningar sker i samma transaktionskontext.
createOrder körs också med samma tx.