### PR TITLE
186 kursnamnsdetaljer på kursersidan

### DIFF
--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -20,7 +20,7 @@ import {
 import { addToCart } from "@/lib/actions/cart";
 import { getProductStats } from "@/lib/actions/purchase-actions";
 import prisma from "@/lib/prisma";
-import { getVeckodag } from "@/lib/tools";
+import { getCourseName, getVeckodag } from "@/lib/tools";
 import { CourseInfoDialog } from "./components/CourseInfoDialog";
 import { CoursesFilter } from "./components/CoursesFilter";
 
@@ -252,11 +252,13 @@ export default async function Page({ searchParams }: Props) {
                                 </span>
                                 {productCourses.map((pc) => {
                                   const c = pc.course;
-                                  // For CLIP products, use totalCount; otherwise use lessonsIncluded
+
                                   const lessonCount =
                                     p.type === "CLIP"
-                                      ? p.totalCount
-                                      : pc.lessonsIncluded;
+                                      ? `${String(p.totalCount ?? 0)} (klipp)`
+                                      : pc.unlimited
+                                        ? "Obegränsat"
+                                        : String(pc.lessonsIncluded);
 
                                   return (
                                     <div
@@ -265,9 +267,9 @@ export default async function Page({ searchParams }: Props) {
                                     >
                                       <div className="flex justify-between gap-2 mb-1 items-center">
                                         <div className="font-medium">
-                                          {`${c.name} ${c.minAge}+ år - ${c.level}`}
+                                          {`${getCourseName(c)}`}
                                         </div>
-                                        {/* DIALOG FOR COURSE DETAILS */}
+
                                         <CourseInfoDialog course={c} />
                                       </div>
                                       <p className="text-muted-foreground text-xs">

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -145,9 +145,6 @@ export default async function Page({ searchParams }: Props) {
             Köp våra
             <span className="font-serif italic text-brand-light"> Kurser</span>
           </h1>
-          <p className="text-muted-foreground">
-            Paket och klippkort kommer inom kort
-          </p>
         </div>
 
         {/* Filter component */}


### PR DESCRIPTION
Nu används den globala funktionen getCourseName för att hämta rätt kursnamn, och klipp kalkyleras rätt. Tog bort texten "Klippkort kommer snart".

Closes #186 