### PR TITLE
fix: switch map tiles from Stadia Maps to CARTO

### DIFF
--- a/src/components/leaflet-map.tsx
+++ b/src/components/leaflet-map.tsx
@@ -39,11 +39,11 @@ const markerIcon = new L.DivIcon({
 });
 
 const DARK_TILES =
-  "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}{r}.png";
+  "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
 const LIGHT_TILES =
-  "https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png";
+  "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
 const ATTRIBUTION =
-  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://stadiamaps.com/">Stadia Maps</a>';
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>';
 
 function ThemeAwareTiles() {
   const { resolvedTheme } = useTheme();


### PR DESCRIPTION
## Summary
- Stadia Maps tiles return 401 Unauthorized, breaking the landing page map
- Switched to CARTO basemaps (dark_all / light_all) which are free and require no API key
- Both dark and light theme tiles verified working

## Test plan
- [ ] Visit landing page and confirm map tiles load correctly
- [ ] Toggle dark/light theme and verify tiles switch accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)