### PR TITLE
Fixed tables so they are scrollable

### DIFF
--- a/src/app/(admin)/admin/legal/components/LegalPageList.tsx
+++ b/src/app/(admin)/admin/legal/components/LegalPageList.tsx
@@ -54,7 +54,7 @@ export function LegalPageList({ pages }: LegalPageListProps) {
         </DialogContent>
       </Dialog>
 
-      <Table>
+      <Table className="min-w-[720px]">
         <TableHeader>
           <TableRow>
             <TableHead>Titel</TableHead>

--- a/src/app/(admin)/admin/omoss/components/StudiosList.tsx
+++ b/src/app/(admin)/admin/omoss/components/StudiosList.tsx
@@ -86,7 +86,7 @@ export function StudiosList({ studios }: StudiosListProps) {
       </div>
 
       <div className="mt-2">
-        <Table>
+        <Table className="min-w-[640px]">
           <TableHeader>
             <TableRow>
               <TableHead>Namn</TableHead>

--- a/src/app/(admin)/admin/omoss/components/StyleList.tsx
+++ b/src/app/(admin)/admin/omoss/components/StyleList.tsx
@@ -86,7 +86,7 @@ export function StyleList({ styles }: StyleListProps) {
       </div>
 
       <div className="mt-2">
-        <Table>
+        <Table className="min-w-[640px]">
           <TableHeader>
             <TableRow>
               <TableHead>Namn</TableHead>

--- a/src/app/(admin)/admin/omoss/components/teacher-list.tsx
+++ b/src/app/(admin)/admin/omoss/components/teacher-list.tsx
@@ -94,7 +94,7 @@ export function TeacherList({
       </div>
 
       <div className="mt-2">
-        <Table>
+        <Table className="min-w-[720px]">
           <TableHeader>
             <TableRow>
               <TableHead>Namn</TableHead>

--- a/src/app/(admin)/admin/orders/OrdersView.tsx
+++ b/src/app/(admin)/admin/orders/OrdersView.tsx
@@ -257,8 +257,8 @@ export default function OrdersView({
         </div>
       </div>
 
-      <div className="border rounded-lg overflow-hidden mt-4">
-        <table className="w-full text-sm">
+      <div className="mt-4 overflow-x-auto rounded-lg border">
+        <table className="min-w-[1100px] w-full text-sm">
           <thead>
             <tr className="bg-muted/50 text-muted-foreground border-b">
               <th className="p-3 text-left font-medium">Order</th>

--- a/src/app/(admin)/admin/orders/view/view-client.tsx
+++ b/src/app/(admin)/admin/orders/view/view-client.tsx
@@ -382,71 +382,75 @@ export default function OrderDetailsClient() {
         <div className="bg-muted/50 px-4 py-3 border-b">
           <h2 className="font-semibold">Beställda produkter</h2>
         </div>
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="text-left text-muted-foreground border-b bg-muted/20">
-              <th className="px-4 py-2 font-medium">Produkt</th>
-              <th className="px-4 py-2 font-medium text-right">Pris/st</th>
-              <th className="px-4 py-2 font-medium text-right">Antal</th>
-              <th className="px-4 py-2 font-medium text-right">Summa</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y">
-            {(order.orderItems || []).map((it) => {
-              const unit = Number(it.price ?? 0);
-              const sum = unit * (it.count ?? 0);
-              return (
-                <tr key={it.id} className="hover:bg-muted/30">
-                  <td className="px-4 py-3">
-                    <div className="flex flex-col">
-                      <span className="font-medium text-foreground">
-                        {it.product?.name ?? it.productId}
-                      </span>
-                      {it.participant ? (
-                        <div className="flex items-center gap-1.5 mt-1">
-                          <span className="text-[10px] bg-brand text-white px-1.5 py-0.5 rounded uppercase font-bold">
-                            Deltagare
-                          </span>
-                          <span className="text-xs text-brand font-semibold">
-                            {it.participant.name}
-                          </span>
-                          {it.participant.allowPhotoVideo ? (
-                            <span title="Foto OK" className="text-xs">
-                              📸
-                            </span>
-                          ) : (
-                            <span title="Inga foton" className="text-xs">
-                              🚫
-                            </span>
-                          )}
-                        </div>
-                      ) : (
-                        <span className="text-xs text-muted-foreground italic mt-0.5">
-                          Kund själv
+        <div className="overflow-x-auto">
+          <table className="min-w-[640px] w-full text-sm">
+            <thead>
+              <tr className="text-left text-muted-foreground border-b bg-muted/20">
+                <th className="px-4 py-2 font-medium">Produkt</th>
+                <th className="px-4 py-2 font-medium text-right">Pris/st</th>
+                <th className="px-4 py-2 font-medium text-right">Antal</th>
+                <th className="px-4 py-2 font-medium text-right">Summa</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {(order.orderItems || []).map((it) => {
+                const unit = Number(it.price ?? 0);
+                const sum = unit * (it.count ?? 0);
+                return (
+                  <tr key={it.id} className="hover:bg-muted/30">
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="font-medium text-foreground">
+                          {it.product?.name ?? it.productId}
                         </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-right">{formatPrice(unit)}</td>
-                  <td className="px-4 py-3 text-right">{it.count}</td>
-                  <td className="px-4 py-3 text-right font-semibold">
-                    {formatPrice(sum)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-          <tfoot>
-            <tr className="bg-muted/50 font-bold">
-              <td colSpan={3} className="px-4 py-3 text-right">
-                Totalt att betala
-              </td>
-              <td className="px-4 py-3 text-right text-lg">
-                {formatPrice(total)}
-              </td>
-            </tr>
-          </tfoot>
-        </table>
+                        {it.participant ? (
+                          <div className="flex items-center gap-1.5 mt-1">
+                            <span className="text-[10px] bg-brand text-white px-1.5 py-0.5 rounded uppercase font-bold">
+                              Deltagare
+                            </span>
+                            <span className="text-xs text-brand font-semibold">
+                              {it.participant.name}
+                            </span>
+                            {it.participant.allowPhotoVideo ? (
+                              <span title="Foto OK" className="text-xs">
+                                📸
+                              </span>
+                            ) : (
+                              <span title="Inga foton" className="text-xs">
+                                🚫
+                              </span>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-xs text-muted-foreground italic mt-0.5">
+                            Kund själv
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {formatPrice(unit)}
+                    </td>
+                    <td className="px-4 py-3 text-right">{it.count}</td>
+                    <td className="px-4 py-3 text-right font-semibold">
+                      {formatPrice(sum)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+            <tfoot>
+              <tr className="bg-muted/50 font-bold">
+                <td colSpan={3} className="px-4 py-3 text-right">
+                  Totalt att betala
+                </td>
+                <td className="px-4 py-3 text-right text-lg">
+                  {formatPrice(total)}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
       </div>
 
       {/* Status History */}

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -72,8 +72,8 @@ export default async function Page({
         <span>Totalt {totalProducts} produkter</span>
       </div>
 
-      <div className="w-full overflow-x-auto rounded border">
-        <Table>
+      <div className="w-full rounded border">
+        <Table className="min-w-[1040px]">
           <TableHeader>
             <TableRow>
               <TableHead>Produkt</TableHead>

--- a/src/app/(admin)/admin/termin/page.tsx
+++ b/src/app/(admin)/admin/termin/page.tsx
@@ -44,7 +44,7 @@ export default async function Page({
       </div>
 
       <div className="border rounded-lg w-full mt-2">
-        <Table className="w-full text-sm ">
+        <Table className="min-w-[640px] w-full text-sm">
           <TableHeader>
             <TableRow className="bg-muted/50 text-xs uppercase tracking-wide text-muted-foreground">
               <TableHead className="p-3 text-left">Namn</TableHead>

--- a/src/app/(admin)/admin/users/UsersView.tsx
+++ b/src/app/(admin)/admin/users/UsersView.tsx
@@ -97,8 +97,8 @@ export default function UsersView({
         </Button>
       </form>
 
-      <div className="border rounded-lg overflow-hidden">
-        <table className="w-full text-sm">
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="min-w-[900px] w-full text-sm">
           <thead>
             <tr className="bg-muted/50 text-muted-foreground border-b">
               <th className="p-3 text-left font-medium">Namn</th>

--- a/src/app/(admin)/admin/video-gallery/page.tsx
+++ b/src/app/(admin)/admin/video-gallery/page.tsx
@@ -31,7 +31,7 @@ export default async function AdminVideoGalleryPage() {
           Inga videor än. Lägg till din första video!
         </p>
       ) : (
-        <Table>
+        <Table className="min-w-[900px]">
           <TableHeader>
             <TableRow>
               <TableHead>Titel</TableHead>


### PR DESCRIPTION
## Beskrivning

Vi har fixat tabell-scroll i de här filerna:

[UsersView.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): gjorde admin/users horisontellt skrollbar genom overflow-x-auto på wrappern och min-w-[900px] på tabellen.
[OrdersView.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): samma upplägg för orderlistan, med min-w-[1100px].
[view-client.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): wrappade produkttabellen i orderdetaljvyn med overflow-x-auto och gav tabellen min-w-[640px].
[page.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): lade min-w-[900px] på Table.
[LegalPageList.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): lade min-w-[720px] på Table.
[page.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): tog bort extra yttre scroll-wrapper och satte min-w-[1040px] på Table.
[teacher-list.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): lade min-w-[720px] på Table.
[StyleList.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): lade min-w-[640px] på Table.
[StudiosList.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): lade min-w-[640px] på Table.
[page.tsx](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/hunga/.vscode/extensions/openai.chatgpt-26.5318.11754-win32-x64/webview/): lade min-w-[640px] på Table.
Kort sagt: vi standardiserade tabellerna så de beter sig som de redan fungerande tabellerna, alltså att de blir horisontellt skrollbara i stället för att tryckas ihop på mindre skärmar.

## Relaterade issues

Closes #219 

## Typ av ändring

- [x ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x ] Jag har testat mina ändringar lokalt
- [x ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<img width="491" height="541" alt="image" src="https://github.com/user-attachments/assets/f7a77ed9-3d7b-45f2-9144-19587411e732" />

<img width="483" height="446" alt="image" src="https://github.com/user-attachments/assets/43784296-3480-43e0-8ac7-4bddc6fe62f1" />


## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
