### PR TITLE
220 bg i footer & profilssida som knapp + designfixar

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -7,20 +7,24 @@ import { getStyles } from "@/lib/actions/style-actions";
 export default async function About() {
   const [studios, styles] = await Promise.all([getStudios(), getStyles()]);
   const activeStudios = studios.filter((studio) => studio.active);
+  const studioContentMaxWidth = Math.min(
+    activeStudios.length * 500 + Math.max(activeStudios.length - 1, 0) * 24,
+    1152,
+  );
 
   return (
     <main className="bg-background">
       {/* Hero */}
-      <section className="py-16 md:py-20 text-center border-b border-border">
-        <div className="max-w-7xl mx-auto px-6">
-          <h1 className="text-5xl md:text-7xl font-light text-foreground leading-[1.1] tracking-tight mb-6 animate-fade-in-left [animation-delay:200ms]">
+      <section className="border-b border-border py-16 text-center md:py-20">
+        <div className="mx-auto max-w-7xl px-6">
+          <h1 className="mb-6 animate-fade-in-left text-5xl font-light leading-[1.1] tracking-tight text-foreground [animation-delay:200ms] md:text-7xl">
             Om vår
             <span className="font-serif italic text-brand-light">
               {" "}
               Dansstudio
             </span>
           </h1>
-          <p className="text-muted-foreground max-w-2xl mx-auto">
+          <p className="mx-auto max-w-2xl text-muted-foreground">
             En plats där rörelse möter gemenskap, kreativitet och passion.
           </p>
         </div>
@@ -30,48 +34,54 @@ export default async function About() {
       <DansStilar styles={styles} />
 
       {/* Studio */}
-      <section className="py-16 bg-muted/50">
-        <div className="max-w-6xl mx-auto px-6 text-center">
-          <h2 className="text-2xl font-bold mb-4 text-foreground">
+      <section className="bg-muted/50 py-16">
+        <div className="mx-auto max-w-6xl px-6 text-center">
+          <h2 className="mb-4 text-2xl font-bold text-foreground">
             Våra lokaler
           </h2>
           {activeStudios.length === 0 ? (
-            <p className="text-muted-foreground mb-8">
+            <p className="mb-8 text-muted-foreground">
               Information om våra studios kommer snart.
             </p>
           ) : (
-            <div className="mx-auto flex max-w-6xl flex-wrap justify-center gap-6">
-              {activeStudios.map((studio) => (
-                <div
-                  key={studio.id}
-                  className="flex w-[500px] max-w-full flex-col items-center rounded-lg border-2 border-border p-6 text-center"
-                >
-                  {studio.imageUrl && (
-                    <Image
-                      src={studio.imageUrl}
-                      alt={studio.name}
-                      height={220}
-                      width={420}
-                      className="mb-4 h-[220px] w-full rounded-lg object-cover"
-                    />
-                  )}
-                  <h3 className="font-semibold text-lg">{studio.name}</h3>
-                  <p className="mt-2 text-muted-foreground">
-                    {studio.description}
-                  </p>
-                </div>
-              ))}
+            <div
+              className="mx-auto w-full max-w-full"
+              style={{ maxWidth: `${studioContentMaxWidth}px` }}
+            >
+              <div className="flex flex-wrap justify-center gap-6">
+                {activeStudios.map((studio) => (
+                  <div
+                    key={studio.id}
+                    className="flex w-[500px] max-w-full flex-col items-center rounded-lg border-2 border-border p-6 text-center"
+                  >
+                    {studio.imageUrl && (
+                      <Image
+                        src={studio.imageUrl}
+                        alt={studio.name}
+                        height={220}
+                        width={420}
+                        className="mb-4 h-[220px] w-full rounded-lg object-cover"
+                      />
+                    )}
+                    <h3 className="text-lg font-semibold">{studio.name}</h3>
+                    <p className="mt-2 text-muted-foreground">
+                      {studio.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="relative mt-6 overflow-hidden rounded-2xl border border-brand/30 bg-brand/10 p-7 backdrop-blur-sm">
+                <div className="absolute top-0 left-0 h-full w-1 rounded-l-2xl bg-brand" />
+                <p className="text-xl font-light leading-snug text-white">
+                  Här är alla välkomna –{" "}
+                  <span className="font-serif italic text-brand-light">
+                    oavsett nivå.
+                  </span>
+                </p>
+              </div>
             </div>
           )}
-          <div className="relative border border-brand/30 bg-brand/10 backdrop-blur-sm rounded-2xl p-7 overflow-hidden">
-            <div className="absolute top-0 left-0 w-1 h-full bg-brand rounded-l-2xl" />
-            <p className="text-white text-xl font-light leading-snug">
-              Här är alla välkomna –{" "}
-              <span className="font-serif italic text-brand-light">
-                oavsett nivå.
-              </span>
-            </p>
-          </div>
         </div>
       </section>
     </main>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -24,13 +24,13 @@ const legalLinks = [
 
 const Footer = () => {
   return (
-    <footer className="relative border-t border-brand/20 bg-card min-h-[300px]">
+    <footer className="relative border-t border-brand/20 bg-card [background-image:linear-gradient(180deg,rgba(76,173,178,0.08)_0%,rgba(30,41,59,0.18)_38%,rgba(154,89,215,0.05)_100%),radial-gradient(circle_at_top_left,rgba(76,173,178,0.12),transparent_42%),radial-gradient(circle_at_bottom_right,rgba(154,89,215,0.1),transparent_48%)]">
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
         <div className="absolute -top-40 -left-40 w-96 h-96 rounded-full bg-brand/5 blur-3xl" />
         <div className="absolute -bottom-20 -right-40 w-96 h-96 rounded-full bg-brand-secondary/5 blur-3xl" />
       </div>
 
-      <div className="relative z-10 max-w-7xl mx-auto px-6 pt-16 pb-8">
+      <div className="relative z-10 max-w-7xl mx-auto px-6 pt-16 pb-[calc(3rem+env(safe-area-inset-bottom))] sm:pb-8">
         <div className="grid gap-12 md:grid-cols-4 mb-12">
           <div className="md:col-span-1">
             <Link href="/" className="flex items-center group mb-4">

--- a/src/components/Navbar-auth.tsx
+++ b/src/components/Navbar-auth.tsx
@@ -23,12 +23,22 @@ export default function NavBarAuth({ mobile = false }: NavBarAuthProps) {
           mobile && "w-full flex-col items-start gap-2",
         )}
       >
-        <Link
-          href="/user"
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+        <Button
+          asChild
+          size="sm"
+          variant="outline"
+          className={cn(
+            "h-auto min-h-8 flex-col items-start gap-0 px-3 py-1.5 text-left leading-tight",
+            mobile && "w-full justify-start",
+          )}
         >
-          {user.name}
-        </Link>
+          <Link href="/user">
+            <span>Profil &amp; boka</span>
+            <span className="max-w-[12rem] truncate text-xs font-normal text-muted-foreground">
+              {user.name}
+            </span>
+          </Link>
+        </Button>
         <div
           className={cn(
             "flex items-center gap-3",

--- a/src/components/Navbar-auth.tsx
+++ b/src/components/Navbar-auth.tsx
@@ -9,9 +9,13 @@ import { cn } from "@/lib/utils";
 
 interface NavBarAuthProps {
   mobile?: boolean;
+  onNavigate?: () => void;
 }
 
-export default function NavBarAuth({ mobile = false }: NavBarAuthProps) {
+export default function NavBarAuth({
+  mobile = false,
+  onNavigate,
+}: NavBarAuthProps) {
   const { session, user } = useSession();
   const router = useRouter();
 
@@ -32,7 +36,7 @@ export default function NavBarAuth({ mobile = false }: NavBarAuthProps) {
             mobile && "w-full justify-start",
           )}
         >
-          <Link href="/user">
+          <Link href="/user" onClick={onNavigate}>
             <span>Profil &amp; boka</span>
             <span className="max-w-[12rem] truncate text-xs font-normal text-muted-foreground">
               {user.name}
@@ -52,13 +56,16 @@ export default function NavBarAuth({ mobile = false }: NavBarAuthProps) {
               variant="outline"
               className={cn(mobile && "justify-center")}
             >
-              <Link href="/admin">Admin</Link>
+              <Link href="/admin" onClick={onNavigate}>
+                Admin
+              </Link>
             </Button>
           )}
           <Button
             variant="ghost"
             className="text-muted-foreground hover:text-foreground"
             onClick={() => {
+              onNavigate?.();
               authClient.signOut({
                 fetchOptions: {
                   onSuccess: () => {
@@ -84,7 +91,9 @@ export default function NavBarAuth({ mobile = false }: NavBarAuthProps) {
         mobile && "w-full justify-center",
       )}
     >
-      <Link href="/signin">Logga in</Link>
+      <Link href="/signin" onClick={onNavigate}>
+        Logga in
+      </Link>
     </Button>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -106,7 +106,7 @@ export default function NavBar() {
               <LanguageSwitcher />
               <ModeToggle />
             </div>
-            <NavBarAuth mobile />
+            <NavBarAuth mobile onNavigate={() => setMenuOpen(false)} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Beskrivning

Fixar så footer sträcker sig hela vägen vertikalt, och gör om länken till profilsidan till en knapp "Profil & boka" i navbar.
Fixar även så navbaren stängs i hamburgarläge när man klickar på länk, samt lite design på om oss-sidan (se issue 217).

## Relaterade issues

Closes #220 
Closes #217 


## Typ av ändring

- [x ] Buggfix (icke-brytande ändring som löser ett problem)
- [x ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x ] Jag har testat mina ändringar lokalt
- [x ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<img width="1295" height="232" alt="image" src="https://github.com/user-attachments/assets/0a668fd7-2169-4cd9-af64-a855d6cfd60d" />

<img width="471" height="861" alt="image" src="https://github.com/user-attachments/assets/28cfb239-fa8e-4002-b95e-c60be10c0a21" />

<img width="1078" height="562" alt="image" src="https://github.com/user-attachments/assets/b8ac7864-ba04-43cd-913e-1bda86f9d2a0" />


## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
