### PR TITLE
229 mailtutskick dedup

### DIFF
--- a/src/app/(admin)/admin/students/components/StudentTableClient.tsx
+++ b/src/app/(admin)/admin/students/components/StudentTableClient.tsx
@@ -44,8 +44,8 @@ const STORAGE_KEY = "admin-students-selection";
 
 function getStudentEmail(student: StudentSummary) {
   return (
-    student.participant?.email ??
-    student.participant?.addedBy.email ??
+    student.participant?.email ||
+    student.participant?.addedBy.email ||
     student.user.email
   );
 }
@@ -449,6 +449,7 @@ export default function StudentTableClient({
 
     try {
       const parsed = JSON.parse(stored);
+
       if (!isStudentsSelectedType(parsed)) {
         window.localStorage.removeItem(STORAGE_KEY);
         return;

--- a/src/app/(admin)/admin/students/page.tsx
+++ b/src/app/(admin)/admin/students/page.tsx
@@ -496,6 +496,7 @@ export default async function Page({
     },
   });
 
+  // fix: den verkar inte få mail på addedBy:
   const allStudents = buildStudentSummaries(purchasesWithData);
 
   const ITEMS_PER_PAGE = 10;

--- a/src/app/(admin)/admin/students/page.tsx
+++ b/src/app/(admin)/admin/students/page.tsx
@@ -496,7 +496,6 @@ export default async function Page({
     },
   });
 
-  // fix: den verkar inte få mail på addedBy:
   const allStudents = buildStudentSummaries(purchasesWithData);
 
   const ITEMS_PER_PAGE = 10;

--- a/src/lib/actions/newsletter.ts
+++ b/src/lib/actions/newsletter.ts
@@ -85,8 +85,12 @@ export async function sendStudentNewsletter(input: {
 
     for (const recipient of validated.recipients) {
       const key = recipient.email.toLowerCase();
-      const existing = emailMap.get(key) ?? [];
-      emailMap.set(key, [...existing, recipient.name]);
+      let existing = emailMap.get(key);
+      if (!existing) {
+        existing = [];
+        emailMap.set(key, existing);
+      }
+      existing.push(recipient.name);
     }
 
     const recipients = Array.from(emailMap.entries()).map(([email, names]) => ({

--- a/src/lib/actions/newsletter.ts
+++ b/src/lib/actions/newsletter.ts
@@ -78,14 +78,21 @@ export async function sendStudentNewsletter(input: {
 
   try {
     const validated = await sendStudentNewsletterSchema.parseAsync(input);
-    const recipients = Array.from(
-      new Map(
-        validated.recipients.map((recipient) => [
-          recipient.email.toLowerCase(),
-          recipient,
-        ]),
-      ).values(),
-    );
+
+    const emailMap = new Map<string, string[]>();
+
+    // fixed: dedup removing emails for particpants. This joins it in the same instead! :)
+
+    for (const recipient of validated.recipients) {
+      const key = recipient.email.toLowerCase();
+      const existing = emailMap.get(key) ?? [];
+      emailMap.set(key, [...existing, recipient.name]);
+    }
+
+    const recipients = Array.from(emailMap.entries()).map(([email, names]) => ({
+      email,
+      name: names.join(", "),
+    }));
 
     const contentHtml = await marked.parse(validated.content);
     const contentText = markdownToTxt(validated.content);

--- a/src/lib/actions/newsletter.ts
+++ b/src/lib/actions/newsletter.ts
@@ -81,7 +81,7 @@ export async function sendStudentNewsletter(input: {
 
     const emailMap = new Map<string, string[]>();
 
-    // fixed: dedup removing emails for particpants. This joins it in the same instead! :)
+    // Merge duplicate recipient email addresses by combining their names.
 
     for (const recipient of validated.recipients) {
       const key = recipient.email.toLowerCase();


### PR DESCRIPTION
## Beskrivning

Den fixar en bugg som gjorde att participants utan mail inte fick sin ägares mail när de valdes. 
Samt dedup problemet är löst genom att den kombinerar alla participant och ägare som är valda, och endast 1 mail skickas men alla som skall vara med är med i samma mail.

<img width="791" height="327" alt="image" src="https://github.com/user-attachments/assets/3442237d-8092-4203-a288-a04e9abf7a12" />


## Relaterade issues

Closes #229 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

Blivit väldigt mycket kod av Codex, kanske går att förenkla allting? Vad tycker du @LexiconAlex ?
