### PR TITLE
Ändrad logik för hur ordrar räknas

### DIFF
--- a/prisma/migrations/20260416084509_count_customer_in_product/migration.sql
+++ b/prisma/migrations/20260416084509_count_customer_in_product/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "product" ADD COLUMN     "countCustomer" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -283,6 +283,7 @@ model Product {
 
   maxCustomer        Int     @default(0) // För att säkra att inte för många köper produkten. Så blir som en "platser kvar"
   unlimitedCustomers Boolean @default(false) // Obegränsat antal köp.
+  countCustomer      Int     @default(0) // För att räkna antal köp kontra maxCustomer. Använd spotsLeft från getProductStats.
 
   imageURL String?
 

--- a/src/app/(public)/checkout/CartSummary.tsx
+++ b/src/app/(public)/checkout/CartSummary.tsx
@@ -4,10 +4,10 @@ export const revalidate = 0;
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { removeFromCart, updateCart } from "@/lib/actions/cart";
-import { getProductStats } from "@/lib/actions/purchase-actions";
 import { readCart } from "@/lib/cart";
 import { formatPrice } from "@/lib/money";
 import prisma from "@/lib/prisma";
+import { getProductSpotsLeft } from "@/lib/product-capacity";
 
 export default async function CartSummary() {
   const cart = await readCart();
@@ -33,6 +33,7 @@ export default async function CartSummary() {
       price: true,
       maxCustomer: true,
       unlimitedCustomers: true,
+      countCustomer: true,
     },
   });
 
@@ -56,17 +57,16 @@ export default async function CartSummary() {
 
       const unit = p.price;
       const line = unit * it.qty;
-      const stats = await getProductStats(p.id);
-      const available = stats.success ? (stats.spotsLeft ?? 0) : 0;
+      const available = getProductSpotsLeft(p);
       total += line;
 
       return {
         id: it.productId,
         name: p.name,
         unit,
-        qty: stats.success ? it.qty : 0,
+        qty: it.qty,
         maxCustomer: p.maxCustomer,
-        success: stats.success,
+        success: true,
         available,
         line,
       };

--- a/src/app/(public)/courses/page.tsx
+++ b/src/app/(public)/courses/page.tsx
@@ -25,9 +25,9 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { addToCart } from "@/lib/actions/cart";
-import { getProductStats } from "@/lib/actions/purchase-actions";
 import { formatPrice } from "@/lib/money";
 import prisma from "@/lib/prisma";
+import { getProductSpotsLeft } from "@/lib/product-capacity";
 import { getCourseName, getVeckodag } from "@/lib/tools";
 import { CourseInfoDialog } from "./components/CourseInfoDialog";
 import { CoursesFilter } from "./components/CoursesFilter";
@@ -88,14 +88,36 @@ export default async function Page({ searchParams }: Props) {
   const ITEMS_PER_PAGE = 6;
   const currentPage = Number(sp.page) || 1;
   const skip = (currentPage - 1) * ITEMS_PER_PAGE;
+  const sortedProductSnapshots = await prisma.product.findMany({
+    where: filters,
+    select: {
+      id: true,
+      maxCustomer: true,
+      unlimitedCustomers: true,
+      countCustomer: true,
+    },
+    orderBy: getSortOrder(),
+  });
+  const availableProductIds = sortedProductSnapshots
+    .filter(
+      (product) =>
+        product.unlimitedCustomers || getProductSpotsLeft(product) > 0,
+    )
+    .map((product) => product.id);
 
   // Get total count for pagination
-  const totalProducts = await prisma.product.count({ where: filters });
+  const totalProducts = availableProductIds.length;
   const totalPages = Math.ceil(totalProducts / ITEMS_PER_PAGE);
+  const pagedProductIds = availableProductIds.slice(
+    skip,
+    skip + ITEMS_PER_PAGE,
+  );
 
   // Fetch paginated products with all needed relations
   const products = await prisma.product.findMany({
-    where: filters,
+    where: {
+      id: { in: pagedProductIds },
+    },
     include: {
       courses: {
         include: {
@@ -116,35 +138,34 @@ export default async function Page({ searchParams }: Props) {
         },
       },
     },
-    skip,
-    take: ITEMS_PER_PAGE,
     orderBy: getSortOrder(),
   });
+  const productsById = new Map(
+    products.map((product) => [product.id, product]),
+  );
+  const orderedProducts = pagedProductIds
+    .map((id) => productsById.get(id))
+    .filter((product) => product !== undefined);
 
   // Calculate all async data before rendering
-  const productsWithData = await Promise.all(
-    products.map(async (p) => {
-      const stats = await getProductStats(p.id);
+  const productsWithData = orderedProducts.map((p) => {
+    const schemaItems = p.courses.flatMap((pc) => pc.course.schemaItems);
 
-      // Extract unique schemaItems and terminer from all courses in the product
-      const schemaItems = p.courses.flatMap((pc) => pc.course.schemaItems);
+    const terminMap = new Map();
+    schemaItems.forEach((s) => {
+      if (s.termin) {
+        terminMap.set(s.termin.id, s.termin);
+      }
+    });
+    const terminer = Array.from(terminMap.values());
 
-      const terminMap = new Map();
-      schemaItems.forEach((s) => {
-        if (s.termin) {
-          terminMap.set(s.termin.id, s.termin);
-        }
-      });
-      const terminer = Array.from(terminMap.values());
-
-      return {
-        ...p,
-        schemaItems,
-        terminer,
-        spotsLeft: stats.spotsLeft,
-      };
-    }),
-  );
+    return {
+      ...p,
+      schemaItems,
+      terminer,
+      spotsLeft: getProductSpotsLeft(p),
+    };
+  });
 
   return (
     <main className="bg-background">

--- a/src/lib/actions/cart.ts
+++ b/src/lib/actions/cart.ts
@@ -3,7 +3,7 @@
 import { redirect } from "next/navigation";
 import { clearCart, readCart, writeCart } from "@/lib/cart";
 import prisma from "../prisma";
-import { getProductStats } from "./purchase-actions";
+import { getProductSpotsLeft } from "../product-capacity";
 
 export async function addToCart(params: {
   productId: string;
@@ -13,10 +13,14 @@ export async function addToCart(params: {
   const { productId, qty = 1, redirectTo } = params;
   if (!productId) throw new Error("productId required");
 
-  // Block adding inactive products to cart
   const product = await prisma.product.findUnique({
     where: { id: productId },
-    select: { active: true },
+    select: {
+      active: true,
+      maxCustomer: true,
+      unlimitedCustomers: true,
+      countCustomer: true,
+    },
   });
   if (!product || !product.active) {
     throw new Error("Produkten är inte tillgänglig.");
@@ -24,6 +28,12 @@ export async function addToCart(params: {
 
   const cart = await readCart();
   const existing = cart.items.find((i) => i.productId === productId);
+  const nextQty = (existing?.qty ?? 0) + qty;
+
+  if (!product.unlimitedCustomers && getProductSpotsLeft(product) < nextQty) {
+    throw new Error("Produkten har inga lediga platser kvar.");
+  }
+
   if (existing) {
     existing.qty += qty;
   } else {
@@ -42,26 +52,19 @@ export async function updateCart(params: { productId: string; qty: number }) {
   const cart = await readCart();
   const item = cart.items.find((i) => i.productId === productId);
   if (item) {
-    // kontroll av max.
-
     const product = await prisma.product.findUnique({
       where: { id: productId },
-      select: { maxCustomer: true, unlimitedCustomers: true },
+      select: {
+        maxCustomer: true,
+        unlimitedCustomers: true,
+        countCustomer: true,
+      },
     });
 
     let finalQty = qty;
 
-    if (product && !product.unlimitedCustomers && product.maxCustomer > 0) {
-      const stats = await getProductStats(productId);
-      if (
-        stats.success &&
-        typeof stats.spotsLeft === "number" &&
-        Number.isFinite(stats.spotsLeft)
-      ) {
-        finalQty = Math.min(qty, stats.spotsLeft);
-      } else {
-        finalQty = 0;
-      }
+    if (product && !product.unlimitedCustomers) {
+      finalQty = Math.min(qty, getProductSpotsLeft(product));
     }
 
     item.qty = finalQty;

--- a/src/lib/actions/checkout.ts
+++ b/src/lib/actions/checkout.ts
@@ -5,7 +5,7 @@ import { clearCart } from "@/lib/cart";
 import { generateOrderConfirmationHtml, sendMail } from "@/lib/mail";
 import { createOrder, getOrderById } from "@/lib/orders";
 import prisma from "../prisma";
-import { getProductStats } from "./purchase-actions";
+import { getProductSpotsLeft } from "../product-capacity";
 import { getSessionData } from "./sessiondata";
 
 export type CheckoutItem = {
@@ -27,7 +27,7 @@ export async function createCheckout(params: {
     throw new Error("No items provided");
   }
 
-  const pCountTotal = new Map();
+  const pCountTotal = new Map<string, number>();
   const serverItems: {
     productId: string;
     count: number;
@@ -35,72 +35,64 @@ export async function createCheckout(params: {
     price: number;
   }[] = [];
 
-  // Gör en transaction här då.
   const order = await prisma.$transaction(
     async (tx) => {
       for (const itm of items) {
-        const p = await tx.product.findUnique({
+        const product = await tx.product.findUnique({
           where: { id: itm.productId },
+          select: {
+            id: true,
+            price: true,
+            maxCustomer: true,
+            unlimitedCustomers: true,
+            countCustomer: true,
+          },
         });
-        if (!p)
+
+        if (!product) {
           throw new Error(
             `Product ${itm.productId} was not found. Order cancelled.`,
           );
+        }
 
-        const stats = await getProductStats(p.id, tx);
+        const spotsLeft = getProductSpotsLeft(product);
 
-        if (!stats.success)
+        if (Number.isFinite(spotsLeft) && itm.count > spotsLeft) {
           throw new Error(
-            `Could not get stats for product ${itm.productId}. Order cancelled.`,
+            `Product count exceeds limit for product ${itm.productId}. Count was ${itm.count} and spotsLeft is ${spotsLeft}.`,
           );
+        }
 
-        if (
-          typeof stats.spotsLeft === "number" &&
-          Number.isFinite(stats.spotsLeft) &&
-          itm.count > stats.spotsLeft
-        )
-          throw new Error(
-            `Product count exceeds limit for product ${itm.productId}. Count was ${itm.count} and spotsLeft is ${stats.spotsLeft}.`,
-          );
-
-        // Vi behöver kolla totalt också.
         pCountTotal.set(
           itm.productId,
           (pCountTotal.get(itm.productId) ?? 0) + itm.count,
         );
 
         const totalInCartForProduct = pCountTotal.get(itm.productId) ?? 0;
-        if (
-          typeof stats.spotsLeft === "number" &&
-          Number.isFinite(stats.spotsLeft) &&
-          totalInCartForProduct > stats.spotsLeft
-        )
+        if (Number.isFinite(spotsLeft) && totalInCartForProduct > spotsLeft) {
           throw new Error(
-            `product count exceeds limit for product ${itm.productId}. Count was ${totalInCartForProduct} and spotsLeft is ${stats.spotsLeft}.`,
+            `Product count exceeds limit for product ${itm.productId}. Count was ${totalInCartForProduct} and spotsLeft is ${spotsLeft}.`,
           );
+        }
 
-        // Use the server-fetched price directly — never trust the client.
         serverItems.push({
           productId: itm.productId,
           count: itm.count,
           participantId: itm.participantId,
-          price: p.price,
+          price: product.price,
         });
       }
 
-      const order = await createOrder(tx, {
+      return createOrder(tx, {
         userId: session.user.id,
         items: serverItems,
         postalcode,
         note,
       });
-
-      return order;
     },
     { isolationLevel: "Serializable" },
   );
 
-  // Try to send confirmation email
   try {
     const fullOrder = await getOrderById(order.id);
     if (fullOrder?.user.email) {
@@ -112,11 +104,9 @@ export async function createCheckout(params: {
       );
     }
   } catch (emailError) {
-    // We don't want to fail the checkout if the email fails, but we should log it
     console.error("Failed to send confirmation email:", emailError);
   }
 
-  // Clear cart after order
   await clearCart();
 
   return {

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -1,8 +1,42 @@
 "use server";
 
+import type { Prisma } from "@/generated/prisma/client";
 import prisma from "../prisma";
 import { autobook } from "./server-actions";
 import { getSessionData } from "./sessiondata";
+
+async function releaseProductCapacityForOrder(
+  tx: Prisma.TransactionClient,
+  orderId: string,
+) {
+  const orderItems = await tx.orderItem.findMany({
+    where: { orderId },
+    select: { productId: true, count: true },
+  });
+
+  const productCounts = new Map<string, number>();
+
+  for (const item of orderItems) {
+    productCounts.set(
+      item.productId,
+      (productCounts.get(item.productId) ?? 0) + item.count,
+    );
+  }
+
+  for (const [productId, count] of productCounts) {
+    await tx.product.updateMany({
+      where: {
+        id: productId,
+        countCustomer: {
+          gte: count,
+        },
+      },
+      data: {
+        countCustomer: { decrement: count },
+      },
+    });
+  }
+}
 
 async function requireAdmin() {
   const session = await getSessionData();
@@ -35,6 +69,10 @@ export async function updateOrderStatus(
       where: { id: orderId },
       data: { status: toStatus },
     });
+
+    if (toStatus === "CANCELLED") {
+      await releaseProductCapacityForOrder(tx, orderId);
+    }
 
     await tx.orderStatusEvent.create({
       data: {

--- a/src/lib/actions/purchase-actions.ts
+++ b/src/lib/actions/purchase-actions.ts
@@ -3,11 +3,12 @@
 
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "../prisma";
+import { getProductSpotsLeft } from "../product-capacity";
 
 // Behöver den här typen för att fortsätta en tx:
 export type PrismaTx = Prisma.TransactionClient;
 
-// // Okej, så nu den magiska funktionen handleClips då :)
+// Okej, så nu den magiska funktionen handleClips då :)
 export async function handleClips(
   tx: PrismaTx,
   purchaseItemId: string,
@@ -17,7 +18,6 @@ export async function handleClips(
     return { success: true, msg: "No adjustment needed." };
   }
 
-  // Så vi hämtar purschaseItem, och inkluderar även purchasen så vi kan se vilken typ det är (CLIP, PACK eller COURSE). Kolla även unlimited.
   const purchaseItem = await tx.purchaseItem.findUnique({
     where: { id: purchaseItemId },
     select: {
@@ -34,28 +34,23 @@ export async function handleClips(
     },
   });
 
-  // Om den inte hittas, returnera false.
   if (!purchaseItem) {
     return { success: false, msg: "PurchaseItem not found." };
   }
 
-  // kolla om det är ett klippkort:
   const isClip = purchaseItem.purchase.type === "CLIP";
-  const amount = Math.abs(adjustment); // amoint som absolutbelopp, avgör istället med if sats..
+  const amount = Math.abs(adjustment);
 
   if (purchaseItem.unlimited) {
     return { success: true, msg: "Unlimited purchase; no adjustment made." };
   }
 
   if (isClip) {
-    // Varför skulle den vara null dock?
     if (purchaseItem.purchase.remainingCount == null) {
       return { success: false, msg: "Purchase remainingCount is null." };
     }
 
-    // Kolla om det skall dras eller ges tillbaka.
     if (adjustment < 0) {
-      // Uppdatera saldot i purchases ( eftersom det är ett klippkort )
       const result = await tx.purchase.updateMany({
         where: {
           id: purchaseItem.purchase.id,
@@ -74,14 +69,11 @@ export async function handleClips(
       });
     }
   } else {
-    // det är kurser / paket och just denna kurs skall alltså ges tillbaka eller dras.
-
-    // Kolla om det skall dras eller ges tillbaka :)
     if (adjustment < 0) {
       const result = await tx.purchaseItem.updateMany({
         where: {
           id: purchaseItem.id,
-          remainingCount: { gte: amount }, // Hämta bara om det finns så många bokningar kvar.
+          remainingCount: { gte: amount },
         },
         data: { remainingCount: { decrement: amount } },
       });
@@ -100,7 +92,6 @@ export async function handleClips(
   return { success: true };
 }
 
-// Så denna funktion räknar antal redan sålda produkter av den specifika produkten, och om man vill räkna med de som ligger och väntar i order.
 export async function getProductStats(
   productId: string,
   tx?: PrismaTx,
@@ -112,49 +103,48 @@ export async function getProductStats(
   success: boolean;
   error?: string;
 }> {
-  // 1. Hämta alla purchases med det produktId:t.
   try {
     const db = tx ?? prisma;
 
     const product = await db.product.findUniqueOrThrow({
       where: { id: productId },
-      select: { maxCustomer: true, unlimitedCustomers: true },
-    });
-
-    const sold = await db.purchase.count({
-      where: {
-        productId: productId,
-        order: { status: { not: "CANCELLED" } },
+      select: {
+        maxCustomer: true,
+        unlimitedCustomers: true,
+        countCustomer: true,
       },
     });
 
-    const orderCount = await db.orderItem.aggregate({
-      where: {
-        productId,
-        order: {
-          status: {
-            in: [
-              "PENDING_PAYMENT",
-              "PAID",
-              "APPROVED", // Så inte CANCELLED räknas med.
-            ],
+    const [soldOrderCount, reservedOrderCount] = await Promise.all([
+      db.orderItem.aggregate({
+        where: {
+          productId,
+          order: {
+            status: {
+              in: ["PAID", "APPROVED", "COMPLETED"],
+            },
           },
-          // Förhindra dubbelräkning när purchase redan skapats för denna produkt.
-          purchases: { none: { productId } },
         },
-      },
-      _sum: { count: true },
-    });
-
-    const reserved = orderCount._sum.count ?? 0;
+        _sum: { count: true },
+      }),
+      db.orderItem.aggregate({
+        where: {
+          productId,
+          order: {
+            status: {
+              in: ["PENDING_PAYMENT", "AWAITING_APPROVAL"],
+            },
+          },
+        },
+        _sum: { count: true },
+      }),
+    ]);
 
     return {
-      sold: sold,
-      reserved: reserved,
-      total: sold + reserved,
-      spotsLeft: product.unlimitedCustomers
-        ? Infinity
-        : Math.max(0, product.maxCustomer - (sold + reserved)),
+      sold: soldOrderCount._sum.count ?? 0,
+      reserved: reservedOrderCount._sum.count ?? 0,
+      total: product.countCustomer,
+      spotsLeft: getProductSpotsLeft(product),
       success: true,
     };
   } catch (e) {

--- a/src/lib/actions/server-actions.ts
+++ b/src/lib/actions/server-actions.ts
@@ -532,8 +532,17 @@ export async function getRemainingSlotsForCourse(
   productId: string,
   maxCustomer: number,
 ) {
-  const totalPurchases = await prisma.purchase.count({
-    where: { productId: productId },
+  const product = await prisma.product.findUnique({
+    where: { id: productId },
+    select: {
+      maxCustomer: true,
+      unlimitedCustomers: true,
+      countCustomer: true,
+    },
   });
-  return maxCustomer - totalPurchases;
+
+  if (!product) return maxCustomer;
+  if (product.unlimitedCustomers) return null;
+
+  return Math.max(product.maxCustomer - product.countCustomer, 0);
 }

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -1,5 +1,6 @@
 import type { PrismaTx } from "./actions/admin";
 import prisma from "./prisma";
+import { getProductSpotsLeft } from "./product-capacity";
 
 export type OrderItemInput = {
   productId: string;
@@ -23,6 +24,68 @@ export async function createOrder(
 
   // All prices are integers in öre — plain integer arithmetic, no rounding needed
   const total = items.reduce((acc, it) => acc + it.count * it.price, 0);
+  const productCounts = new Map<string, number>();
+
+  for (const item of items) {
+    productCounts.set(
+      item.productId,
+      (productCounts.get(item.productId) ?? 0) + item.count,
+    );
+  }
+
+  const productIds = Array.from(productCounts.keys());
+  const products = await tx.product.findMany({
+    where: { id: { in: productIds } },
+    select: {
+      id: true,
+      maxCustomer: true,
+      unlimitedCustomers: true,
+      countCustomer: true,
+    },
+  });
+  const productsById = new Map(
+    products.map((product) => [product.id, product]),
+  );
+
+  for (const [productId, requestedCount] of productCounts) {
+    const product = productsById.get(productId);
+
+    if (!product) {
+      throw new Error(`Product ${productId} was not found. Order cancelled.`);
+    }
+
+    if (getProductSpotsLeft(product) < requestedCount) {
+      throw new Error(
+        `Product count exceeds limit for product ${productId}. Count was ${requestedCount}.`,
+      );
+    }
+
+    if (product.unlimitedCustomers) {
+      await tx.product.update({
+        where: { id: productId },
+        data: { countCustomer: { increment: requestedCount } },
+      });
+      continue;
+    }
+
+    const updated = await tx.product.updateMany({
+      where: {
+        id: productId,
+        countCustomer: {
+          lte: product.maxCustomer - requestedCount,
+        },
+      },
+      data: {
+        countCustomer: { increment: requestedCount },
+      },
+    });
+
+    if (updated.count === 0) {
+      throw new Error(
+        `Product count exceeds limit for product ${productId}. Count was ${requestedCount}.`,
+      );
+    }
+  }
 
   // Create order + items + initial status event atomically
 

--- a/src/lib/product-capacity.ts
+++ b/src/lib/product-capacity.ts
@@ -1,0 +1,17 @@
+type ProductCapacitySnapshot = {
+  maxCustomer: number;
+  unlimitedCustomers: boolean;
+  countCustomer: number;
+};
+
+export function getProductSpotsLeft(product: ProductCapacitySnapshot): number {
+  if (product.unlimitedCustomers) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.max(product.maxCustomer - product.countCustomer, 0);
+}
+
+export function hasProductSpotsLeft(product: ProductCapacitySnapshot): boolean {
+  return getProductSpotsLeft(product) > 0;
+}


### PR DESCRIPTION

## Beskrivning


Infört product.countCustomer som källa för produktkapacitet i köpflödet.

Uppdaterat orderskapandet så countCustomer ökar atomärt när en order skapas.

Uppdaterat orderavbrott så countCustomer minskar igen när en order sätts till CANCELLED.

Förenklat platslogiken med en gemensam hjälpfunktion för spotsLeft.

Bytt kundflödena från beräknad platsstatistik till databaskolumnen i varukorg och checkout.

Uppdaterat sidan Våra kurser så slutsålda produkter filtreras bort före paginering.

Säkrat att pagination nu räknas på faktiskt visbara produkter i stället för att bli fel efter filtrering i efterhand.

Förenklat getRemainingSlotsForCourse så den också använder den nya räknaren.

## Relaterade issues

Closes #264 

## Typ av ändring

- [x] Buggfix (icke-brytande ändring som löser ett problem)
- [x] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [x] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [x] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
