### PR TITLE
Förbättrad kalender

### DIFF
--- a/src/app/(public)/user/components/BookingCal.tsx
+++ b/src/app/(public)/user/components/BookingCal.tsx
@@ -184,165 +184,165 @@ export default function BookingCal({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {selectedDateLessons.length > 0
-              ? // mappa lektionerna för det valda datumet.
-                selectedDateLessons.map((lesson) => {
-                  // Samla purchaseItems som kunden äger för den lektionen
-                  const lessonPurchaseItems = purschaseItems.filter(
-                    (itm) => itm.courseId === lesson.courseId,
+            {selectedDateLessons.length > 0 ? (
+              // mappa lektionerna för det valda datumet.
+              selectedDateLessons.map((lesson) => {
+                // Samla purchaseItems som kunden äger för den lektionen
+                const lessonPurchaseItems = purschaseItems.filter(
+                  (itm) => itm.courseId === lesson.courseId,
+                );
+
+                // Hämta bokningar gjorda för lektionen.
+                const bookingsOnLesson = bookings.filter(
+                  (b) => b.lessonId === lesson.id && !b.cancelled,
+                );
+
+                // Samla vilka deltagare som redan är bokade på just denna lektion.
+                const bookedParticipantIds = new Set<string>();
+                let ownerAlreadyBooked = false;
+
+                // Kolla varje bokning och markera om det är en participant eller owner.
+                for (const b of bookingsOnLesson) {
+                  const bookingPurchaseItem = lessonPurchaseItems.find(
+                    (itm) => itm.id === b.purchaseItemId,
                   );
 
-                  // Hämta bokningar gjorda för lektionen.
-                  const bookingsOnLesson = bookings.filter(
-                    (b) => b.lessonId === lesson.id && !b.cancelled,
-                  );
+                  if (!bookingPurchaseItem) continue;
 
-                  // Samla vilka deltagare som redan är bokade på just denna lektion.
-                  const bookedParticipantIds = new Set<string>();
-                  let ownerAlreadyBooked = false;
+                  const participantId =
+                    bookingPurchaseItem.purchase.participant?.id;
 
-                  // Kolla varje bokning och markera om det är en participant eller owner.
-                  for (const b of bookingsOnLesson) {
-                    const bookingPurchaseItem = lessonPurchaseItems.find(
-                      (itm) => itm.id === b.purchaseItemId,
-                    );
+                  if (participantId) {
+                    bookedParticipantIds.add(participantId);
+                  } else {
+                    ownerAlreadyBooked = true;
+                  }
+                }
 
-                    if (!bookingPurchaseItem) continue;
+                // Bygg listan över vad som går att boka nu.
+                const availablePurchaseItems: UserPurchaseWithProduct[] = [];
 
-                    const participantId =
-                      bookingPurchaseItem.purchase.participant?.id;
+                for (const itm of lessonPurchaseItems) {
+                  // Endast med klipp kvar:
+                  const remaining = calcRemainingCount({
+                    purchase: itm.purchase,
+                    purchaseItem: itm,
+                  });
+                  if (!hasRemainingCount(remaining)) continue;
 
-                    if (participantId) {
-                      bookedParticipantIds.add(participantId);
-                    } else {
-                      ownerAlreadyBooked = true;
-                    }
+                  const participantId = itm.purchase.participant?.id;
+
+                  if (participantId) {
+                    if (bookedParticipantIds.has(participantId)) continue;
+                  } else {
+                    if (ownerAlreadyBooked) continue;
                   }
 
-                  // Bygg listan över vad som går att boka nu.
-                  const availablePurchaseItems: UserPurchaseWithProduct[] = [];
+                  availablePurchaseItems.push(itm);
+                }
 
-                  for (const itm of lessonPurchaseItems) {
-                    // Endast med klipp kvar:
-                    const remaining = calcRemainingCount({
-                      purchase: itm.purchase,
-                      purchaseItem: itm,
-                    });
-                    if (!hasRemainingCount(remaining)) continue;
+                // Nu kan vi avgöra:
+                const hasAnyBooking = bookingsOnLesson.length > 0;
+                const canBookMore = availablePurchaseItems.length > 0;
+                const isPastLesson = lesson.startTime.getTime() < now;
+                const shouldShowLesson =
+                  lesson.cancelled ||
+                  hasAnyBooking ||
+                  (!isPastLesson && canBookMore);
 
-                    const participantId = itm.purchase.participant?.id;
+                // För att hämta data att visa:
+                const purchaseItemById = new Map(
+                  lessonPurchaseItems.map((itm) => [itm.id, itm]),
+                );
 
-                    if (participantId) {
-                      if (bookedParticipantIds.has(participantId)) continue;
-                    } else {
-                      if (ownerAlreadyBooked) continue;
-                    }
+                if (!shouldShowLesson) return null;
 
-                    availablePurchaseItems.push(itm);
-                  }
-
-                  // Nu kan vi avgöra:
-                  const hasAnyBooking = bookingsOnLesson.length > 0;
-                  const canBookMore = availablePurchaseItems.length > 0;
-                  const isPastLesson = lesson.startTime.getTime() < now;
-                  const shouldShowLesson =
-                    lesson.cancelled ||
-                    hasAnyBooking ||
-                    (!isPastLesson && canBookMore);
-
-                  // För att hämta data att visa:
-                  const purchaseItemById = new Map(
-                    lessonPurchaseItems.map((itm) => [itm.id, itm]),
-                  );
-
-                  if (!shouldShowLesson) return null;
-
-                  return (
-                    <div
-                      key={lesson.id}
-                      className="flex items-start justify-between border-b pb-4 last:border-0"
-                    >
-                      <div className="flex-1 min-w-0 pr-3">
-                        <p className="font-semibold">
-                          {lesson.startTime.toLocaleTimeString("sv-SE", {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {lesson.course.name}{" "}
-                          {lesson.cancelled && (
-                            <span className="font-bold text-red-500">
-                              (INSTÄLLD)
-                            </span>
-                          )}
-                          <br />
-                          {lesson.message}
-                        </p>
-                        {hasAnyBooking && (
-                          <div className="mt-2 space-y-1.5 w-full">
-                            <p className="text-xs font-medium text-muted-foreground">
-                              Dina bokningar
-                            </p>
-                            {bookingsOnLesson.map((b) => {
-                              const bookedItem = purchaseItemById.get(
-                                b.purchaseItemId,
-                              );
-                              if (!bookedItem) return null;
-
-                              const participantName =
-                                bookedItem.purchase.participant?.name ?? "Du";
-                              const productName =
-                                bookedItem.purchase.product.name;
-
-                              return (
-                                <Item
-                                  key={b.id}
-                                  variant="muted"
-                                  size="sm"
-                                  className="w-full"
-                                >
-                                  <ItemContent>
-                                    <ItemDescription className="text-xs">
-                                      {participantName} ({productName})
-                                    </ItemDescription>
-                                  </ItemContent>
-                                  <ItemActions>
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="icon"
-                                      className="h-7 w-7 text-destructive hover:text-destructive"
-                                      onClick={() =>
-                                        delBooking(lesson.id, b.purchaseItemId)
-                                      }
-                                      title="Avboka"
-                                      disabled={
-                                        lesson.cancelled ||
-                                        lesson.startTime.getTime() < Date.now()
-                                      }
-                                    >
-                                      <Trash2 className="h-4 w-4" />
-                                    </Button>
-                                  </ItemActions>
-                                </Item>
-                              );
-                            })}
-                          </div>
+                return (
+                  <div
+                    key={lesson.id}
+                    className="flex items-start justify-between border-b pb-4 last:border-0"
+                  >
+                    <div className="flex-1 min-w-0 pr-3">
+                      <p className="font-semibold">
+                        {lesson.startTime.toLocaleTimeString("sv-SE", {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {lesson.course.name}{" "}
+                        {lesson.cancelled && (
+                          <span className="font-bold text-red-500">
+                            (INSTÄLLD)
+                          </span>
                         )}
-                      </div>
-                      {lesson.cancelled ? (
-                        "Inställd."
-                      ) : (
-                        <div className="text-right flex items-center gap-2 self-start">
-                          {canBookMore && (
-                            <BookBtn
-                              lessonId={lesson.id}
-                              purschaseItems={availablePurchaseItems}
-                              disabled={lesson.startTime.getTime() < now}
-                            />
-                          )}
-                          {/* {hasAnyBooking && (
+                        <br />
+                        {lesson.message}
+                      </p>
+                      {hasAnyBooking && (
+                        <div className="mt-2 space-y-1.5 w-full">
+                          <p className="text-xs font-medium text-muted-foreground">
+                            Dina bokningar
+                          </p>
+                          {bookingsOnLesson.map((b) => {
+                            const bookedItem = purchaseItemById.get(
+                              b.purchaseItemId,
+                            );
+                            if (!bookedItem) return null;
+
+                            const participantName =
+                              bookedItem.purchase.participant?.name ?? "Du";
+                            const productName =
+                              bookedItem.purchase.product.name;
+
+                            return (
+                              <Item
+                                key={b.id}
+                                variant="muted"
+                                size="sm"
+                                className="w-full"
+                              >
+                                <ItemContent>
+                                  <ItemDescription className="text-xs">
+                                    {participantName} ({productName})
+                                  </ItemDescription>
+                                </ItemContent>
+                                <ItemActions>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-7 w-7 text-destructive hover:text-destructive"
+                                    onClick={() =>
+                                      delBooking(lesson.id, b.purchaseItemId)
+                                    }
+                                    title="Avboka"
+                                    disabled={
+                                      lesson.cancelled ||
+                                      lesson.startTime.getTime() < Date.now()
+                                    }
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                </ItemActions>
+                              </Item>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                    {lesson.cancelled ? (
+                      "Inställd."
+                    ) : (
+                      <div className="text-right flex items-center gap-2 self-start">
+                        {canBookMore && (
+                          <BookBtn
+                            lessonId={lesson.id}
+                            purschaseItems={availablePurchaseItems}
+                            disabled={lesson.startTime.getTime() < now}
+                          />
+                        )}
+                        {/* {hasAnyBooking && (
                         <Button
                           variant={"destructive"}
                           onClick={async () => await delBooking(lesson.id)}
@@ -351,16 +351,16 @@ export default function BookingCal({
                           Avboka
                         </Button>
                       )} */}
-                        </div>
-                      )}
-                    </div>
-                  );
-                })
-              : (
-                  <p className="text-muted-foreground">
-                    Inga lektioner planerade denna dag.
-                  </p>
-                )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            ) : (
+              <p className="text-muted-foreground">
+                Inga lektioner planerade denna dag.
+              </p>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/app/(public)/user/components/BookingCal.tsx
+++ b/src/app/(public)/user/components/BookingCal.tsx
@@ -46,10 +46,66 @@ export default function BookingCal({
         .map((b) => new Date(b.lesson.startTime)),
     [bookings],
   );
-  const availableDays = useMemo(
-    () => lessons.map((l) => new Date(l.startTime)),
-    [lessons],
-  );
+
+  const now = Date.now();
+
+  const availableDays = useMemo(() => {
+    return lessons
+      .filter((lesson) => {
+        if (lesson.cancelled || lesson.startTime.getTime() < now) return false;
+
+        const lessonPurchaseItems = purschaseItems.filter(
+          (itm) => itm.courseId === lesson.courseId,
+        );
+
+        const bookingsOnLesson = bookings.filter(
+          (b) => b.lessonId === lesson.id && !b.cancelled,
+        );
+
+        const bookedParticipantIds = new Set<string>();
+        let ownerAlreadyBooked = false;
+
+        for (const b of bookingsOnLesson) {
+          const bookingPurchaseItem = lessonPurchaseItems.find(
+            (itm) => itm.id === b.purchaseItemId,
+          );
+
+          if (!bookingPurchaseItem) continue;
+
+          const participantId = bookingPurchaseItem?.purchase.participant?.id;
+
+          if (participantId) {
+            bookedParticipantIds.add(participantId);
+          } else {
+            ownerAlreadyBooked = true;
+          }
+        }
+
+        // Finns det NÅGOT som går att boka?
+        for (const itm of lessonPurchaseItems) {
+          const remaining = calcRemainingCount({
+            purchase: itm.purchase,
+            purchaseItem: itm,
+          });
+
+          if (!hasRemainingCount(remaining)) continue;
+
+          const participantId = itm.purchase.participant?.id;
+
+          if (participantId) {
+            if (bookedParticipantIds.has(participantId)) continue;
+          } else {
+            if (ownerAlreadyBooked) continue;
+          }
+
+          return true; // 🔥 minst en bokningsbar plats
+        }
+
+        return false;
+      })
+      .map((l) => new Date(l.startTime));
+  }, [lessons, purschaseItems, bookings, now]);
+
   const cancelledDays = useMemo(
     () => lessons.filter((l) => l.cancelled).map((l) => new Date(l.startTime)),
     [lessons],
@@ -62,8 +118,6 @@ export default function BookingCal({
       (l) => l.startTime.toDateString() === date.toDateString(),
     );
   }, [date, lessons]);
-
-  const now = Date.now();
 
   return (
     <div className="flex flex-col gap-6 md:flex-row">
@@ -129,176 +183,179 @@ export default function BookingCal({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {selectedDateLessons.length > 0 ? (
-              // mappa lektionerna för det valda datumet.
-              selectedDateLessons.map((lesson) => {
-                // Samla purchaseItems som kunden äger för den lektionen
-                const lessonPurchaseItems = purschaseItems.filter(
-                  (itm) => itm.courseId === lesson.courseId,
-                );
-
-                // Hämta bokningar gjorda för lektionen.
-                const bookingsOnLesson = bookings.filter(
-                  (b) => b.lessonId === lesson.id && !b.cancelled,
-                );
-
-                // Samla vilka deltagare som redan är bokade på just denna lektion.
-                const bookedParticipantIds = new Set<string>();
-                let ownerAlreadyBooked = false;
-
-                // Kolla varje bokning och markera om det är en participant eller owner.
-                for (const b of bookingsOnLesson) {
-                  const bookingPurchaseItem = lessonPurchaseItems.find(
-                    (itm) => itm.id === b.purchaseItemId,
+            {selectedDateLessons.length > 0
+              ? // mappa lektionerna för det valda datumet.
+                selectedDateLessons.map((lesson) => {
+                  // Samla purchaseItems som kunden äger för den lektionen
+                  const lessonPurchaseItems = purschaseItems.filter(
+                    (itm) => itm.courseId === lesson.courseId,
                   );
 
-                  if (!bookingPurchaseItem) continue;
+                  // Hämta bokningar gjorda för lektionen.
+                  const bookingsOnLesson = bookings.filter(
+                    (b) => b.lessonId === lesson.id && !b.cancelled,
+                  );
 
-                  const participantId =
-                    bookingPurchaseItem.purchase.participant?.id;
+                  // Samla vilka deltagare som redan är bokade på just denna lektion.
+                  const bookedParticipantIds = new Set<string>();
+                  let ownerAlreadyBooked = false;
 
-                  if (participantId) {
-                    bookedParticipantIds.add(participantId);
-                  } else {
-                    ownerAlreadyBooked = true;
-                  }
-                }
+                  // Kolla varje bokning och markera om det är en participant eller owner.
+                  for (const b of bookingsOnLesson) {
+                    const bookingPurchaseItem = lessonPurchaseItems.find(
+                      (itm) => itm.id === b.purchaseItemId,
+                    );
 
-                // Bygg listan över vad som går att boka nu.
-                const availablePurchaseItems: UserPurchaseWithProduct[] = [];
+                    if (!bookingPurchaseItem) continue;
 
-                for (const itm of lessonPurchaseItems) {
-                  // Endast med klipp kvar:
-                  const remaining = calcRemainingCount({
-                    purchase: itm.purchase,
-                    purchaseItem: itm,
-                  });
-                  if (!hasRemainingCount(remaining)) continue;
+                    const participantId =
+                      bookingPurchaseItem.purchase.participant?.id;
 
-                  const participantId = itm.purchase.participant?.id;
-
-                  if (participantId) {
-                    if (bookedParticipantIds.has(participantId)) continue;
-                  } else {
-                    if (ownerAlreadyBooked) continue;
+                    if (participantId) {
+                      bookedParticipantIds.add(participantId);
+                    } else {
+                      ownerAlreadyBooked = true;
+                    }
                   }
 
-                  availablePurchaseItems.push(itm);
-                }
+                  // Bygg listan över vad som går att boka nu.
+                  const availablePurchaseItems: UserPurchaseWithProduct[] = [];
 
-                // Nu kan vi avgöra:
-                const hasAnyBooking = bookingsOnLesson.length > 0;
-                const canBookMore = availablePurchaseItems.length > 0;
+                  for (const itm of lessonPurchaseItems) {
+                    // Endast med klipp kvar:
+                    const remaining = calcRemainingCount({
+                      purchase: itm.purchase,
+                      purchaseItem: itm,
+                    });
+                    if (!hasRemainingCount(remaining)) continue;
 
-                // För att hämta data att visa:
-                const purchaseItemById = new Map(
-                  lessonPurchaseItems.map((itm) => [itm.id, itm]),
-                );
+                    const participantId = itm.purchase.participant?.id;
 
-                return (
-                  <div
-                    key={lesson.id}
-                    className="flex items-start justify-between border-b pb-4 last:border-0"
-                  >
-                    <div className="flex-1 min-w-0 pr-3">
-                      <p className="font-semibold">
-                        {lesson.startTime.toLocaleTimeString("sv-SE", {
-                          hour: "2-digit",
-                          minute: "2-digit",
-                        })}
-                      </p>
-                      <p className="text-sm text-muted-foreground">
-                        {lesson.course.name}{" "}
-                        {lesson.cancelled && (
-                          <span className="font-bold text-red-500">
-                            (INSTÄLLD)
-                          </span>
-                        )}
-                        <br />
-                        {lesson.message}
-                      </p>
-                      {hasAnyBooking && (
-                        <div className="mt-2 space-y-1.5 w-full">
-                          <p className="text-xs font-medium text-muted-foreground">
-                            Dina bokningar
-                          </p>
-                          {bookingsOnLesson.map((b) => {
-                            const bookedItem = purchaseItemById.get(
-                              b.purchaseItemId,
-                            );
-                            if (!bookedItem) return null;
+                    if (participantId) {
+                      if (bookedParticipantIds.has(participantId)) continue;
+                    } else {
+                      if (ownerAlreadyBooked) continue;
+                    }
 
-                            const participantName =
-                              bookedItem.purchase.participant?.name ?? "Du";
-                            const productName =
-                              bookedItem.purchase.product.name;
+                    availablePurchaseItems.push(itm);
+                  }
 
-                            return (
-                              <Item
-                                key={b.id}
-                                variant="muted"
-                                size="sm"
-                                className="w-full"
-                              >
-                                <ItemContent>
-                                  <ItemDescription className="text-xs">
-                                    {participantName} ({productName})
-                                  </ItemDescription>
-                                </ItemContent>
-                                <ItemActions>
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-7 w-7 text-destructive hover:text-destructive"
-                                    onClick={() =>
-                                      delBooking(lesson.id, b.purchaseItemId)
-                                    }
-                                    title="Avboka"
-                                    disabled={
-                                      lesson.cancelled ||
-                                      lesson.startTime.getTime() < Date.now()
-                                    }
-                                  >
-                                    <Trash2 className="h-4 w-4" />
-                                  </Button>
-                                </ItemActions>
-                              </Item>
-                            );
+                  // Nu kan vi avgöra:
+                  const hasAnyBooking = bookingsOnLesson.length > 0;
+                  const canBookMore = availablePurchaseItems.length > 0;
+                  const isPastLesson = lesson.startTime.getTime() < now;
+                  const shouldShowLesson =
+                    lesson.cancelled ||
+                    hasAnyBooking ||
+                    (!isPastLesson && canBookMore);
+
+                  // För att hämta data att visa:
+                  const purchaseItemById = new Map(
+                    lessonPurchaseItems.map((itm) => [itm.id, itm]),
+                  );
+
+                  if (!shouldShowLesson) return null;
+
+                  return (
+                    <div
+                      key={lesson.id}
+                      className="flex items-start justify-between border-b pb-4 last:border-0"
+                    >
+                      <div className="flex-1 min-w-0 pr-3">
+                        <p className="font-semibold">
+                          {lesson.startTime.toLocaleTimeString("sv-SE", {
+                            hour: "2-digit",
+                            minute: "2-digit",
                           })}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {lesson.course.name}{" "}
+                          {lesson.cancelled && (
+                            <span className="font-bold text-red-500">
+                              (INSTÄLLD)
+                            </span>
+                          )}
+                          <br />
+                          {lesson.message}
+                        </p>
+                        {hasAnyBooking && (
+                          <div className="mt-2 space-y-1.5 w-full">
+                            <p className="text-xs font-medium text-muted-foreground">
+                              Dina bokningar
+                            </p>
+                            {bookingsOnLesson.map((b) => {
+                              const bookedItem = purchaseItemById.get(
+                                b.purchaseItemId,
+                              );
+                              if (!bookedItem) return null;
+
+                              const participantName =
+                                bookedItem.purchase.participant?.name ?? "Du";
+                              const productName =
+                                bookedItem.purchase.product.name;
+
+                              return (
+                                <Item
+                                  key={b.id}
+                                  variant="muted"
+                                  size="sm"
+                                  className="w-full"
+                                >
+                                  <ItemContent>
+                                    <ItemDescription className="text-xs">
+                                      {participantName} ({productName})
+                                    </ItemDescription>
+                                  </ItemContent>
+                                  <ItemActions>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon"
+                                      className="h-7 w-7 text-destructive hover:text-destructive"
+                                      onClick={() =>
+                                        delBooking(lesson.id, b.purchaseItemId)
+                                      }
+                                      title="Avboka"
+                                      disabled={
+                                        lesson.cancelled ||
+                                        lesson.startTime.getTime() < Date.now()
+                                      }
+                                    >
+                                      <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                  </ItemActions>
+                                </Item>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </div>
+                      {lesson.cancelled ? (
+                        "Inställd."
+                      ) : (
+                        <div className="text-right flex items-center gap-2 self-start">
+                          {canBookMore && (
+                            <BookBtn
+                              lessonId={lesson.id}
+                              purschaseItems={availablePurchaseItems}
+                              disabled={lesson.startTime.getTime() < now}
+                            />
+                          )}
+                          {/* {hasAnyBooking && (
+                        <Button
+                          variant={"destructive"}
+                          onClick={async () => await delBooking(lesson.id)}
+                          disabled={lesson.startTime.getTime() < now}
+                        >
+                          Avboka
+                        </Button>
+                      )} */}
                         </div>
                       )}
                     </div>
-                    {lesson.cancelled ? (
-                      "Inställd."
-                    ) : (
-                      <div className="text-right flex items-center gap-2 self-start">
-                        {canBookMore && (
-                          <BookBtn
-                            lessonId={lesson.id}
-                            purschaseItems={availablePurchaseItems}
-                            disabled={lesson.startTime.getTime() < now}
-                          />
-                        )}
-                        {/* {hasAnyBooking && (
-                          <Button
-                            variant={"destructive"}
-                            onClick={async () => await delBooking(lesson.id)}
-                            disabled={lesson.startTime.getTime() < now}
-                          >
-                            Avboka
-                          </Button>
-                        )} */}
-                      </div>
-                    )}
-                  </div>
-                );
-              })
-            ) : (
-              <p className="text-muted-foreground">
-                Inga lektioner planerade denna dag.
-              </p>
-            )}
+                  );
+                })
+              : ""}
           </CardContent>
         </Card>
       </div>

--- a/src/app/(public)/user/components/BookingCal.tsx
+++ b/src/app/(public)/user/components/BookingCal.tsx
@@ -47,9 +47,8 @@ export default function BookingCal({
     [bookings],
   );
 
-  const now = Date.now();
-
   const availableDays = useMemo(() => {
+    const now = Date.now();
     return lessons
       .filter((lesson) => {
         if (lesson.cancelled || lesson.startTime.getTime() < now) return false;
@@ -104,7 +103,7 @@ export default function BookingCal({
         return false;
       })
       .map((l) => new Date(l.startTime));
-  }, [lessons, purschaseItems, bookings, now]);
+  }, [lessons, purschaseItems, bookings]);
 
   const cancelledDays = useMemo(
     () => lessons.filter((l) => l.cancelled).map((l) => new Date(l.startTime)),
@@ -118,6 +117,8 @@ export default function BookingCal({
       (l) => l.startTime.toDateString() === date.toDateString(),
     );
   }, [date, lessons]);
+
+  const now = Date.now();
 
   return (
     <div className="flex flex-col gap-6 md:flex-row">
@@ -355,7 +356,11 @@ export default function BookingCal({
                     </div>
                   );
                 })
-              : ""}
+              : (
+                  <p className="text-muted-foreground">
+                    Inga lektioner planerade denna dag.
+                  </p>
+                )}
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
## Beskrivning

Lagt till ett filter som filtrerar bort lektioner i kalendern som ändå inte går att boka p.g.a slut på klipp, eller bakåt i tiden. Man ser fortfarande gamla bokningar och inställda lektioner. Gäller både markeringar i kalendern och renderingen av lektionerna bredvid kalendern.

## Relaterade issues

Closes #276 

## Typ av ändring

- [x] Buggfix (icke-brytande ändring som löser ett problem)
- [x] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

tidigare:
<img width="901" height="683" alt="image" src="https://github.com/user-attachments/assets/b326af47-539d-458e-bd2d-a904bebeee24" />


nu (med tillagd tidigare bokning för att illustrera):
<img width="868" height="526" alt="image" src="https://github.com/user-attachments/assets/7b6b5edd-e934-4309-b667-a0a6653dd1c1" />

notera alla gröna markeringar i kalendern i den tidigare versionen, de flesta var alltså inte bokningsbara egentligen.

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
