### PR TITLE
Fixat event så gamla ej syns, samt toggle i admin + fel kursnamn fix

### DIFF
--- a/prisma/migrations/20260422200537_show_on_startpage_for_event/migration.sql
+++ b/prisma/migrations/20260422200537_show_on_startpage_for_event/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Event" ADD COLUMN     "showOnStartpage" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -475,6 +475,8 @@ model Event {
   link        String
   imageURL    String
 
+  showOnStartpage        Boolean @default(false)
+
   photos       Photo[]
   galleryItems GalleryItem[]
 

--- a/src/app/(admin)/admin/events/components/AddEventBtn.tsx
+++ b/src/app/(admin)/admin/events/components/AddEventBtn.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { PlusIcon } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,8 +14,10 @@ import {
 import NewEventForm from "./NewEventForm";
 
 export function AddEventBtn() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant="ghost" className="cursor-pointer">
           <PlusIcon /> Nytt event
@@ -25,7 +28,7 @@ export function AddEventBtn() {
           <DialogTitle>Lägg till nytt event</DialogTitle>
           <DialogDescription>Fyll i formuläret</DialogDescription>
         </DialogHeader>
-        <NewEventForm />
+        <NewEventForm onSuccess={() => setIsOpen(false)} />
       </DialogContent>
     </Dialog>
   );

--- a/src/app/(admin)/admin/events/components/EditEventForm.tsx
+++ b/src/app/(admin)/admin/events/components/EditEventForm.tsx
@@ -14,6 +14,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -47,6 +48,7 @@ export default function EditEventForm({ event, isOpen, onSuccess }: Props) {
       description: event.description,
       link: event.link,
       imageURL: event.imageURL,
+      showOnStartpage: event.showOnStartpage,
       startDate: event.startDate,
       endDate: event.endDate,
     },
@@ -63,6 +65,7 @@ export default function EditEventForm({ event, isOpen, onSuccess }: Props) {
       description: event.description,
       link: event.link,
       imageURL: event.imageURL,
+      showOnStartpage: event.showOnStartpage,
       startDate: event.startDate,
       endDate: event.endDate ?? event.startDate,
     });
@@ -74,6 +77,7 @@ export default function EditEventForm({ event, isOpen, onSuccess }: Props) {
     event.description,
     event.link,
     event.imageURL,
+    event.showOnStartpage,
     event.startDate,
     event.endDate,
   ]);
@@ -97,6 +101,7 @@ export default function EditEventForm({ event, isOpen, onSuccess }: Props) {
     const res = await editNewEvent({ ...values, imageURL: finalImageURL });
     if (res.success) {
       toast.success(res.msg);
+      form.reset(values);
       onSuccess?.();
       router.refresh();
     } else {
@@ -155,6 +160,29 @@ export default function EditEventForm({ event, isOpen, onSuccess }: Props) {
                   <FormControl>
                     <Textarea {...field} />
                   </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="showOnStartpage"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Visa på startsidan</FormLabel>
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value === true}
+                      onCheckedChange={(checked) =>
+                        field.onChange(checked === true)
+                      }
+                      className="w-6 h-6"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Endast markerade och aktuella event visas på startsidan.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/app/(admin)/admin/events/components/NewEventForm.tsx
+++ b/src/app/(admin)/admin/events/components/NewEventForm.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -14,6 +14,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -31,7 +32,11 @@ const formSchema = adminEventSchema;
 type FormInput = z.input<typeof adminEventSchema>;
 type FormOutput = z.output<typeof adminEventSchema>;
 
-export default function NewEventForm() {
+interface Props {
+  onSuccess?: () => void;
+}
+
+export default function NewEventForm({ onSuccess }: Props) {
   const form = useForm<FormInput, unknown, FormOutput>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -39,18 +44,13 @@ export default function NewEventForm() {
       description: "",
       link: "",
       imageURL: "",
+      showOnStartpage: false,
       startDate: "",
       endDate: "",
     },
   });
 
   const router = useRouter();
-
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    if (!isOpen) form.reset();
-  }, [isOpen, form]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     let finalImageURL = values.imageURL ?? "";
@@ -70,7 +70,8 @@ export default function NewEventForm() {
     const res = await addNewEvent({ ...values, imageURL: finalImageURL });
     if (res.success) {
       toast.success(res.msg);
-      setIsOpen(false);
+      form.reset();
+      onSuccess?.();
       router.refresh();
     } else {
       toast.error(res.msg);
@@ -112,6 +113,29 @@ export default function NewEventForm() {
                   <FormControl>
                     <Textarea {...field} />
                   </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="showOnStartpage"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Visa på startsidan</FormLabel>
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value === true}
+                      onCheckedChange={(checked) =>
+                        field.onChange(checked === true)
+                      }
+                      className="w-6 h-6"
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Endast markerade och aktuella event visas på startsidan.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/app/(admin)/admin/events/components/ToggleEventStartpageBtn.tsx
+++ b/src/app/(admin)/admin/events/components/ToggleEventStartpageBtn.tsx
@@ -41,7 +41,7 @@ export default function ToggleEventStartpageBtn({
       variant="ghost"
       size="icon"
       onClick={handleToggle}
-      title={showOnStartpage ? "Dolj pa startsidan" : "Visa pa startsidan"}
+      title={showOnStartpage ? "Dölj på startsidan" : "Visa på startsidan"}
     >
       {showOnStartpage ? (
         <EyeIcon className="h-4 w-4" />
@@ -50,8 +50,8 @@ export default function ToggleEventStartpageBtn({
       )}
       <span className="sr-only">
         {showOnStartpage
-          ? "Dolj event pa startsidan"
-          : "Visa event pa startsidan"}
+          ? "Dölj event på startsidan"
+          : "Visa event på startsidan"}
       </span>
     </Button>
   );

--- a/src/app/(admin)/admin/events/components/ToggleEventStartpageBtn.tsx
+++ b/src/app/(admin)/admin/events/components/ToggleEventStartpageBtn.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { EyeIcon, EyeOffIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { toggleEventStartpageVisibility } from "@/lib/actions/admin";
+
+interface Props {
+  eventId: string;
+  showOnStartpage: boolean;
+}
+
+export default function ToggleEventStartpageBtn({
+  eventId,
+  showOnStartpage,
+}: Props) {
+  const router = useRouter();
+
+  const handleToggle = async () => {
+    try {
+      const { success, msg } = await toggleEventStartpageVisibility(
+        eventId,
+        !showOnStartpage,
+      );
+      if (!success) {
+        toast.error(msg);
+        return;
+      }
+
+      toast.success(msg);
+      router.refresh();
+    } catch (e) {
+      console.error(e);
+      toast.error("Kunde inte uppdatera startsidans eventvisning.");
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleToggle}
+      title={showOnStartpage ? "Dolj pa startsidan" : "Visa pa startsidan"}
+    >
+      {showOnStartpage ? (
+        <EyeIcon className="h-4 w-4" />
+      ) : (
+        <EyeOffIcon className="h-4 w-4 text-muted-foreground" />
+      )}
+      <span className="sr-only">
+        {showOnStartpage
+          ? "Dolj event pa startsidan"
+          : "Visa event pa startsidan"}
+      </span>
+    </Button>
+  );
+}

--- a/src/app/(admin)/admin/events/page.tsx
+++ b/src/app/(admin)/admin/events/page.tsx
@@ -30,7 +30,7 @@ export default async function EventsPage() {
             <TableRow>
               <TableHead>Rubrik</TableHead>
               <TableHead>Datum</TableHead>
-              <TableHead className="text-right">Åtgarder</TableHead>
+              <TableHead className="text-right">Åtgärder</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/src/app/(admin)/admin/events/page.tsx
+++ b/src/app/(admin)/admin/events/page.tsx
@@ -10,24 +10,7 @@ import prisma from "@/lib/prisma";
 import { AddEventBtn } from "./components/AddEventBtn";
 import DelEventBtn from "./components/DelEventBtn";
 import EditEventBtn from "./components/EditEventBtn";
-
-/*
-
-Skapa lägg till och edit formulär:
-
-1. Skapa zod-schema för skapa i validations/adminforms.ts
-
-2. Skapa addBtn och formulär (useForm med zodResolver, defaultValues, onSubmit som anropar action) i components/NewEventForm.tsx och components/AddEventBtn.tsx
-
-3. Skapa server-action i lib/actions/admin.ts som validerar med zod och uppdaterar databasen.
-
-4. Skapa zod-schema för edit i validations/adminforms.ts (om det skiljer sig från skapa med id!)
-
-5. Skapa editBtn och formulär (useForm med zodResolver, defaultValues, onSubmit som anropar action) i components/EditEventForm.tsx och components/EditEventBtn.tsx
-
-6. Skapa server-action i lib/actions/admin.ts som validerar med zod och uppdaterar databasen.
-
-*/
+import ToggleEventStartpageBtn from "./components/ToggleEventStartpageBtn";
 
 export default async function EventsPage() {
   const events = await prisma.event.findMany({
@@ -47,7 +30,7 @@ export default async function EventsPage() {
             <TableRow>
               <TableHead>Rubrik</TableHead>
               <TableHead>Datum</TableHead>
-              <TableHead className="text-right">Åtgärder</TableHead>
+              <TableHead className="text-right">Åtgarder</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -61,6 +44,10 @@ export default async function EventsPage() {
                     ` - ${event.endDate.toLocaleDateString("sv-SE")}`}
                 </TableCell>
                 <TableCell className="flex justify-end gap-2">
+                  <ToggleEventStartpageBtn
+                    eventId={event.id}
+                    showOnStartpage={event.showOnStartpage}
+                  />
                   <EditEventBtn event={event} />
                   <DelEventBtn eventId={event.id} imageURL={event.imageURL} />
                 </TableCell>

--- a/src/app/(public)/courses/components/CourseInfoDialog.tsx
+++ b/src/app/(public)/courses/components/CourseInfoDialog.tsx
@@ -11,6 +11,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
+import { getCourseName } from "@/lib/tools";
 
 type CourseForDialog = {
   name: string;
@@ -34,7 +35,7 @@ interface CourseInfoDialogProps {
 }
 
 export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
-  const title = `${course.name}${course.minAge != null ? ` ${course.minAge}+ år` : ""}${course.level ? ` - ${course.level}` : ""}`;
+  const title = getCourseName(course);
 
   return (
     <Dialog>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -6,8 +6,20 @@ import Features from "./start/Features";
 import Hero from "./start/Hero";
 
 export default async function Page() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
   const [events, startPageContent] = await Promise.all([
-    prisma.event.findMany(),
+    prisma.event.findMany({
+      where: {
+        showOnStartpage: true,
+        OR: [
+          { endDate: { gte: today } },
+          { endDate: null, startDate: { gte: today } },
+        ],
+      },
+      orderBy: [{ startDate: "asc" }, { createdAt: "desc" }],
+    }),
     getStartPageContent(),
   ]);
 

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -134,11 +134,13 @@ export async function editNewEvent(
         description: validated.description,
         imageURL: validated.imageURL ?? "",
         link: validated.link ?? "",
+        showOnStartpage: validated.showOnStartpage,
         startDate: new Date(validated.startDate),
         endDate: validated.endDate ? new Date(validated.endDate) : null,
       },
     });
     revalidatePath("/admin/events");
+    revalidatePath("/");
 
     return {
       success: true,
@@ -164,10 +166,13 @@ export async function addNewEvent(formData: z.infer<typeof adminEventSchema>) {
         description: validated.description,
         imageURL: validated.imageURL ?? "",
         link: validated.link ?? "",
+        showOnStartpage: validated.showOnStartpage,
         startDate: new Date(validated.startDate),
         endDate: validated.endDate ? new Date(validated.endDate) : null,
       },
     });
+    revalidatePath("/admin/events");
+    revalidatePath("/");
     return {
       success: true,
       msg: `Event ${newEvent.headline} skapades.`,
@@ -2150,5 +2155,32 @@ export async function toggleProductActive(
   } catch (e) {
     console.error(e);
     return { success: false, msg: "Kunde inte uppdatera produkten." };
+  }
+}
+
+export async function toggleEventStartpageVisibility(
+  id: string,
+  showOnStartpage: boolean,
+): Promise<{ success: boolean; msg: string }> {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, msg: "No permission." };
+
+  try {
+    const event = await prisma.event.update({
+      where: { id },
+      data: { showOnStartpage },
+    });
+    revalidatePath("/admin/events");
+    revalidatePath("/");
+    return {
+      success: true,
+      msg: `Eventet "${event.headline}" visas nu ${showOnStartpage ? "" : "inte "}på startsidan.`,
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      success: false,
+      msg: "Kunde inte uppdatera eventets synlighet på startsidan.",
+    };
   }
 }

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -69,6 +69,7 @@ export const adminEventSchema = z.object({
   description: z.string().min(1, "Beskrivning måste anges."),
   link: z.string().optional(),
   imageURL: z.string().optional(),
+  showOnStartpage: z.boolean(),
   startDate: z.coerce.date("Ogiltigt datum"),
   endDate: z.coerce.date("Ogiltigt datum").optional(),
 });
@@ -79,6 +80,7 @@ export const adminEditEventSchema = z.object({
   description: z.string().min(1, "Beskrivning måste anges."),
   link: z.string().optional(),
   imageURL: z.string().optional(),
+  showOnStartpage: z.boolean(),
   startDate: z.coerce.date("Ogiltigt datum"),
   endDate: z.coerce.date("Ogiltigt datum").optional(),
 });


### PR DESCRIPTION
## Beskrivning

<!-- Beskriv kortfattat vad denna PR gör och varför. -->
Eftersom vissa event skapas endast för galleriet är det mest logiskt att ha en checkbox för det i admin/event när man skapar / redigerar. 
Ny migration som innehåller ett fält för showOnStartpage för varje event. 
Uppdaterad logik på startsidan som kollar så den är true, samt att inte datumen passerat dvs startdatum eller slutdatum om satt.

Fixade även att fel kursnamn visas i "Våra kurser" sida i "läs mer om kursen".



## Relaterade issues

Closes #266 

Closes #268 


## Typ av ändring

- [x] Buggfix (icke-brytande ändring som löser ett problem)
- [x] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [x] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
