### PR TITLE
281 kontrast på om oss sidan

### DIFF
--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -70,18 +70,18 @@ export default async function About() {
                   </div>
                 ))}
               </div>
-
-              <div className="relative mt-6 overflow-hidden rounded-2xl border border-brand/30 bg-brand/10 p-7 backdrop-blur-sm">
-                <div className="absolute top-0 left-0 h-full w-1 rounded-l-2xl bg-brand" />
-                <p className="text-xl font-light leading-snug text-white">
-                  Här är alla välkomna –{" "}
-                  <span className="font-serif italic text-brand-light">
-                    oavsett nivå.
-                  </span>
-                </p>
-              </div>
             </div>
           )}
+
+          <div className="relative mt-6 overflow-hidden rounded-2xl border border-brand/30 bg-brand/10 p-7 backdrop-blur-sm">
+            <div className="absolute top-0 left-0 h-full w-1 rounded-l-2xl bg-brand" />
+            <p className="text-xl font-light leading-snug text-foreground">
+              Här är alla välkomna –{" "}
+              <span className="font-serif italic text-brand-light">
+                oavsett nivå.
+              </span>
+            </p>
+          </div>
         </div>
       </section>
     </main>

--- a/src/app/(public)/about/page.tsx
+++ b/src/app/(public)/about/page.tsx
@@ -75,7 +75,7 @@ export default async function About() {
 
           <div className="relative mt-6 overflow-hidden rounded-2xl border border-brand/30 bg-brand/10 p-7 backdrop-blur-sm">
             <div className="absolute top-0 left-0 h-full w-1 rounded-l-2xl bg-brand" />
-            <p className="text-xl font-light leading-snug text-foreground">
+            <p className="text-xl  leading-snug text-foreground">
               Här är alla välkomna –{" "}
               <span className="font-serif italic text-brand-light">
                 oavsett nivå.


### PR DESCRIPTION
## Beskrivning

Fixar färgerna på ena rutan på om oss sidan, och flyttat ut den ur villkorlig rendering.




## Relaterade issues

<!-- Länka till relevanta issues, t.ex. Closes #123 -->

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<img width="1273" height="242" alt="image" src="https://github.com/user-attachments/assets/1596d26e-0d25-4d60-83fe-12b78a469158" />

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
