### PR TITLE
Public design polish: button rounding, leaflet revert, courses card lift

### DIFF
--- a/src/app/(public)/courses/page.tsx
+++ b/src/app/(public)/courses/page.tsx
@@ -278,7 +278,7 @@ export default async function Page({ searchParams }: Props) {
                 return (
                   <Card
                     key={p.id}
-                    className="flex flex-col h-full hover:border-brand/50 transition-colors"
+                    className="flex flex-col h-full rounded-xl border border-border/70 hover:border-brand/50 hover:shadow-lg hover:shadow-brand/5 hover:-translate-y-0.5 transition-all duration-300"
                   >
                     <CardHeader>
                       <div className="flex justify-between items-start mb-2">

--- a/src/components/leaflet-map.tsx
+++ b/src/components/leaflet-map.tsx
@@ -38,14 +38,10 @@ const markerIcon = new L.DivIcon({
   popupAnchor: [0, -36],
 });
 
-// CARTO Voyager renders proper colored streets and readable labels —
-// the previous `light_all` is meant as a quiet underlay for data overlays
-// and reads as washed-out when the map IS the focus. `dark_all` stays
-// for dark mode; we lift its contrast via the CSS filter below.
 const DARK_TILES =
   "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png";
 const LIGHT_TILES =
-  "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png";
+  "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
 const ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>';
 
@@ -70,16 +66,6 @@ export default function LeafletMap() {
   return (
     <>
       <style>{`
-        /* Lift map legibility — light tiles get a small contrast nudge,
-           dark tiles need more help because CARTO dark_all is faint by
-           design. Filter targets the tile pane only so the marker /
-           popup / attribution stay un-modified. */
-        .leaflet-tile {
-          filter: contrast(1.08) saturate(1.05);
-        }
-        .dark .leaflet-tile {
-          filter: brightness(1.18) contrast(1.22);
-        }
         .leaflet-popup-content-wrapper {
           background: var(--card);
           color: var(--card-foreground);

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -20,9 +20,12 @@ const buttonVariants = cva(
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
         // Public-site primary call-to-action. Brand-y voice: uppercase
-        // wide-tracked microcopy on a brand-coloured pill. Self-contained
-        // (own padding/height/text-size) so callers can omit `size`.
-        cta: "h-auto px-8 py-3.5 text-[10px] tracking-widest uppercase font-bold rounded-full bg-brand text-white hover:bg-white hover:text-black shadow-lg shadow-brand/20",
+        // wide-tracked microcopy on a brand-coloured rectangle. Self-
+        // contained (own padding/height/text-size) so callers can omit
+        // `size`. Uses rounded-md to stay visually consistent with the
+        // header sign-in button — the pill shape was inconsistent with
+        // the rest of the site's chrome.
+        cta: "h-auto px-8 py-3.5 text-[10px] tracking-widest uppercase font-bold rounded-md bg-brand text-white hover:bg-white hover:text-black shadow-lg shadow-brand/20",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",


### PR DESCRIPTION
## Summary

Three follow-up tweaks after the design-consistency PR landed and we walked the site:

1. **`fix(design)` cta variant** — the `cta` button I added in #286 used `rounded-full` (pill), which clashed with the `rounded-md` of the header sign-in button. Pulled to `rounded-md` so chrome buttons agree across the site. Brand voice (uppercase, wide-tracked, brand-coloured) carries the character; the pill shape was the inconsistency.

2. **`revert(design)` leaflet tiles + filter** — my previous Voyager + contrast-filter combo on the map made it worse, not better. Rolled back to the prior baseline (`light_all` / `dark_all`, no filter). We can pick a fresh approach later instead of compounding the mistake.

3. **`fix(design)` course cards** — small lift only: `rounded-xl`, softer default border, brand-shaded hover shadow, 2px translate on hover. Typography, badges, accordion and the "Köp nu" button are untouched — they're the soul of the card.

## Test plan

- [ ] CI lint-and-build green
- [ ] Header sign-in, footer "Skapa konto", hero "Se Våra Kurser", gallery "@motionzonevaxjo" all visually agree on corner radius
- [ ] /courses cards have a small but noticeable hover effect; structure unchanged
- [ ] Map renders in light + dark mode at the prior baseline (no filters applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)