### PR TITLE
292 i18n implementering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { auth } from "@/lib/auth";
 import { SessionProvider } from "@/lib/session-provider";
+import { LocalizationProvider } from "@/locales";
 
 const lora = Lora({
   subsets: ["latin"],
@@ -67,16 +68,18 @@ export default async function RootLayout({
             session={session?.session ?? null}
             user={session?.user ?? null}
           >
-            <a
-              href="#main-content"
-              className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:font-medium focus:shadow-lg focus:ring-2 focus:ring-ring focus:outline-none"
-            >
-              Hoppa till huvudinnehållet
-            </a>
-            <NavBar />
-            {children}
-            <CookieConsent />
-            <Toaster richColors position="top-center" />
+            <LocalizationProvider>
+              <a
+                href="#main-content"
+                className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:font-medium focus:shadow-lg focus:ring-2 focus:ring-ring focus:outline-none"
+              >
+                Hoppa till huvudinnehållet
+              </a>
+              <NavBar />
+              {children}
+              <CookieConsent />
+              <Toaster richColors position="top-center" />
+            </LocalizationProvider>
           </SessionProvider>
         </ThemeProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Lora, Montserrat } from "next/font/google";
-import { headers } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { CookieConsent } from "@/components/CookieConsent";
 import NavBar from "@/components/Navbar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { auth } from "@/lib/auth";
 import { SessionProvider } from "@/lib/session-provider";
-import { LocalizationProvider } from "@/locales";
+import { LocalizationProvider, normalizeLang } from "@/locales";
 
 const lora = Lora({
   subsets: ["latin"],
@@ -47,13 +47,15 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = await cookies();
+  const lang = normalizeLang(cookieStore.get("i18nextLng")?.value);
   const session = await auth.api.getSession({
     headers: await headers(),
   });
 
   return (
     <html
-      lang="sv"
+      lang={lang}
       suppressHydrationWarning
       className={`${lora.variable} ${montserrat.variable}`}
     >
@@ -68,7 +70,7 @@ export default async function RootLayout({
             session={session?.session ?? null}
             user={session?.user ?? null}
           >
-            <LocalizationProvider>
+            <LocalizationProvider lang={lang}>
               <a
                 href="#main-content"
                 className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:rounded-md focus:bg-background focus:px-4 focus:py-2 focus:font-medium focus:shadow-lg focus:ring-2 focus:ring-ring focus:outline-none"

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -4,6 +4,7 @@ import { ShoppingCart } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getCart } from "@/lib/actions/cart";
 
 interface CartIconProps {
@@ -14,6 +15,7 @@ interface CartIconProps {
 export default function CartIcon({ showLabel, onClick }: CartIconProps) {
   const [count, setCount] = useState(0);
   const pathname = usePathname();
+  const { t } = useTranslation();
 
   useEffect(() => {
     async function fetchCount() {
@@ -44,7 +46,7 @@ export default function CartIcon({ showLabel, onClick }: CartIconProps) {
           </span>
         )}
       </span>
-      {showLabel && <span>Varukorg</span>}
+      {showLabel && <span>{t("cart.title")}</span>}
     </Link>
   );
 }

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,10 +2,12 @@
 
 import i18next from "i18next";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { allLangs } from "@/locales";
 
 export default function LanguageSwitcher() {
   const [currentLang, setCurrentLang] = useState("sv");
+  const { t } = useTranslation();
 
   useEffect(() => {
     const stored = localStorage.getItem("i18nextLng");
@@ -34,7 +36,7 @@ export default function LanguageSwitcher() {
                 ? "bg-brand/10 scale-105"
                 : "opacity-50 hover:opacity-100 hover:bg-brand/5"
             }`}
-            aria-label={`Byt till ${lang.label}`}
+            aria-label={t("language.switchTo", { language: lang.label })}
             aria-pressed={isActive}
           >
             {lang.shortLabel}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -4,27 +4,32 @@ import i18next from "i18next";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { allLangs, defaultLang, normalizeLang } from "@/locales";
+import {
+  readClientLangCookie,
+  writeClientLangCookie,
+} from "@/locales/client-lang-cookie";
 
 export default function LanguageSwitcher() {
   const [currentLang, setCurrentLang] = useState(defaultLang.value);
   const { t } = useTranslation();
 
   useEffect(() => {
-    const stored = document.cookie
-      .split("; ")
-      .find((row) => row.startsWith("i18nextLng="))
-      ?.split("=")[1];
-    const nextLang = normalizeLang(stored ?? i18next.resolvedLanguage);
+    async function syncLang() {
+      const stored = await readClientLangCookie();
+      const nextLang = normalizeLang(stored ?? i18next.resolvedLanguage);
 
-    setCurrentLang(nextLang);
-    void i18next.changeLanguage(nextLang);
+      setCurrentLang(nextLang);
+      void i18next.changeLanguage(nextLang);
+    }
+
+    void syncLang();
   }, []);
 
   function handleChange(value: string) {
     const nextLang = normalizeLang(value);
     setCurrentLang(nextLang);
     localStorage.setItem("i18nextLng", nextLang);
-    document.cookie = `i18nextLng=${nextLang}; Path=/; Max-Age=31536000; SameSite=Lax`;
+    void writeClientLangCookie(nextLang);
     void i18next.changeLanguage(nextLang);
   }
 

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import i18next from "i18next";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { allLangs, defaultLang, normalizeLang } from "@/locales";
@@ -12,6 +13,7 @@ import {
 export default function LanguageSwitcher() {
   const [currentLang, setCurrentLang] = useState(defaultLang.value);
   const { t } = useTranslation();
+  const router = useRouter();
 
   useEffect(() => {
     async function syncLang() {
@@ -31,6 +33,7 @@ export default function LanguageSwitcher() {
     localStorage.setItem("i18nextLng", nextLang);
     void writeClientLangCookie(nextLang);
     void i18next.changeLanguage(nextLang);
+    router.refresh();
   }
 
   return (

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import i18next from "i18next";
 import { useEffect, useState } from "react";
 import { allLangs } from "@/locales";
 
@@ -9,11 +10,13 @@ export default function LanguageSwitcher() {
   useEffect(() => {
     const stored = localStorage.getItem("i18nextLng");
     if (stored) setCurrentLang(stored.slice(0, 2));
+    if (stored) i18next.changeLanguage(stored.slice(0, 2));
   }, []);
 
   function handleChange(value: string) {
     setCurrentLang(value);
     localStorage.setItem("i18nextLng", value);
+    i18next.changeLanguage(value);
   }
 
   return (

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -3,22 +3,29 @@
 import i18next from "i18next";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { allLangs } from "@/locales";
+import { allLangs, defaultLang, normalizeLang } from "@/locales";
 
 export default function LanguageSwitcher() {
-  const [currentLang, setCurrentLang] = useState("sv");
+  const [currentLang, setCurrentLang] = useState(defaultLang.value);
   const { t } = useTranslation();
 
   useEffect(() => {
-    const stored = localStorage.getItem("i18nextLng");
-    if (stored) setCurrentLang(stored.slice(0, 2));
-    if (stored) i18next.changeLanguage(stored.slice(0, 2));
+    const stored = document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("i18nextLng="))
+      ?.split("=")[1];
+    const nextLang = normalizeLang(stored ?? i18next.resolvedLanguage);
+
+    setCurrentLang(nextLang);
+    void i18next.changeLanguage(nextLang);
   }, []);
 
   function handleChange(value: string) {
-    setCurrentLang(value);
-    localStorage.setItem("i18nextLng", value);
-    i18next.changeLanguage(value);
+    const nextLang = normalizeLang(value);
+    setCurrentLang(nextLang);
+    localStorage.setItem("i18nextLng", nextLang);
+    document.cookie = `i18nextLng=${nextLang}; Path=/; Max-Age=31536000; SameSite=Lax`;
+    void i18next.changeLanguage(nextLang);
   }
 
   return (

--- a/src/components/Navbar-auth.tsx
+++ b/src/components/Navbar-auth.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { authClient } from "@/lib/auth-client";
 import { useSession } from "@/lib/session-provider";
@@ -18,6 +19,7 @@ export default function NavBarAuth({
 }: NavBarAuthProps) {
   const { session, user } = useSession();
   const router = useRouter();
+  const { t } = useTranslation();
 
   if (session && user) {
     return (
@@ -37,7 +39,7 @@ export default function NavBarAuth({
           )}
         >
           <Link href="/user" onClick={onNavigate}>
-            <span>Profil &amp; boka</span>
+            <span>{t("auth.profileAndBook")}</span>
             <span className="max-w-[12rem] truncate text-xs font-normal text-muted-foreground">
               {user.name}
             </span>
@@ -57,7 +59,7 @@ export default function NavBarAuth({
               className={cn(mobile && "justify-center")}
             >
               <Link href="/admin" onClick={onNavigate}>
-                Admin
+                {t("auth.admin")}
               </Link>
             </Button>
           )}
@@ -76,7 +78,7 @@ export default function NavBarAuth({
               });
             }}
           >
-            Logga ut
+            {t("auth.signOut")}
           </Button>
         </div>
       </div>
@@ -92,7 +94,7 @@ export default function NavBarAuth({
       )}
     >
       <Link href="/signin" onClick={onNavigate}>
-        Logga in
+        {t("auth.signIn")}
       </Link>
     </Button>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import CartIcon from "./CartIcon";
 import LanguageSwitcher from "./LanguageSwitcher";
 import { ModeToggle } from "./mode-toggle";
@@ -15,11 +16,12 @@ const MOBILE_MENU_ID = "mobile-nav-menu";
 export default function NavBar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const pathname = usePathname();
+  const { t } = useTranslation();
   const navLinks = [
-    { href: "/", label: "Hem" },
-    { href: "/courses", label: "Våra kurser" },
-    { href: "/about", label: "Om oss" },
-    { href: "/gallery", label: "Galleri" },
+    { href: "/", label: t("nav.home") },
+    { href: "/courses", label: t("nav.courses") },
+    { href: "/about", label: t("nav.about") },
+    { href: "/gallery", label: t("nav.gallery") },
   ];
 
   useEffect(() => {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -93,7 +93,7 @@ export default function NavBar() {
           type="button"
           onClick={() => setMenuOpen(!menuOpen)}
           className="md:hidden w-9 h-9 rounded-lg flex items-center justify-center border border-brand/20 text-foreground hover:border-brand/50 hover:bg-brand/5 transition-all duration-200"
-          aria-label={menuOpen ? "Stäng meny" : "Öppna meny"}
+          aria-label={menuOpen ? t("nav.closeMenu") : t("nav.openMenu")}
           aria-expanded={menuOpen}
           aria-controls={MOBILE_MENU_ID}
         >

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -2,6 +2,7 @@
 
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -12,6 +13,7 @@ import {
 
 export function ModeToggle() {
   const { setTheme } = useTheme();
+  const { t } = useTranslation();
 
   return (
     <DropdownMenu>
@@ -28,10 +30,10 @@ export function ModeToggle() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setTheme("light")}>
-          Ljust
+          {t("mode.light")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Mörkt
+          {t("mode.dark")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
           System

--- a/src/locales/client-lang-cookie.ts
+++ b/src/locales/client-lang-cookie.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import type { AppLang } from "./config-lang";
+
+type CookieStoreLike = {
+  get(name: string): Promise<{ value?: string } | null>;
+  set(options: {
+    name: string;
+    value: string;
+    path?: string;
+    expires?: number | Date;
+    sameSite?: "lax" | "strict" | "none";
+  }): Promise<void>;
+};
+
+const LANG_COOKIE_NAME = "i18nextLng";
+const ONE_YEAR_MS = 1000 * 60 * 60 * 24 * 365;
+
+function getCookieStore(): CookieStoreLike | undefined {
+  return (window as Window & { cookieStore?: CookieStoreLike }).cookieStore;
+}
+
+export async function readClientLangCookie(): Promise<string | undefined> {
+  const cookieStore = getCookieStore();
+  if (cookieStore) {
+    const cookie = await cookieStore.get(LANG_COOKIE_NAME);
+    return cookie?.value;
+  }
+
+  return document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${LANG_COOKIE_NAME}=`))
+    ?.split("=")[1];
+}
+
+export async function writeClientLangCookie(lang: AppLang): Promise<void> {
+  const cookieStore = getCookieStore();
+  if (cookieStore) {
+    await cookieStore.set({
+      name: LANG_COOKIE_NAME,
+      value: lang,
+      path: "/",
+      expires: Date.now() + ONE_YEAR_MS,
+      sameSite: "lax",
+    });
+    return;
+  }
+
+  // biome-ignore lint/suspicious/noDocumentCookie: fallback for browsers without Cookie Store API
+  document.cookie = `${LANG_COOKIE_NAME}=${lang}; Path=/; Max-Age=31536000; SameSite=Lax`;
+}

--- a/src/locales/config-lang.ts
+++ b/src/locales/config-lang.ts
@@ -14,3 +14,9 @@ export const allLangs = [
 ];
 
 export const defaultLang = allLangs[0]; // Svenska
+
+export type AppLang = "sv" | "en";
+
+export function normalizeLang(value?: string | null): AppLang {
+  return value === "en" ? "en" : "sv";
+}

--- a/src/locales/i18n.ts
+++ b/src/locales/i18n.ts
@@ -1,33 +1,25 @@
 "use client";
 
 import i18n from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 
 import { defaultLang } from "./config-lang";
 import translationEn from "./langs/en.json";
 import translationSe from "./langs/sv.json";
 
-const lng =
-  (typeof window !== "undefined" && localStorage.getItem("i18nextLng")) ||
-  defaultLang.value;
-
-i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
-    resources: {
-      en: { translations: translationEn },
-      sv: { translations: translationSe },
-    },
-    lng,
-    fallbackLng: "sv",
-    debug: process.env.NODE_ENV === "development",
-    ns: ["translations"],
-    defaultNS: "translations",
-    interpolation: {
-      escapeValue: false,
-    },
-  });
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translations: translationEn },
+    sv: { translations: translationSe },
+  },
+  lng: defaultLang.value,
+  fallbackLng: defaultLang.value,
+  debug: process.env.NODE_ENV === "development",
+  ns: ["translations"],
+  defaultNS: "translations",
+  interpolation: {
+    escapeValue: false,
+  },
+});
 
 export default i18n;

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -3,13 +3,24 @@
     "home": "Home",
     "courses": "Courses",
     "about": "About us",
-    "gallery": "Gallery"
+    "gallery": "Gallery",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
   },
   "auth": {
     "signIn": "Sign in",
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "profileAndBook": "Profile & book",
+    "admin": "Admin"
   },
   "cart": {
     "title": "Cart"
+  },
+  "language": {
+    "switchTo": "Switch to {{language}}"
+  },
+  "mode": {
+    "light": "Light",
+    "dark": "Dark"
   }
 }

--- a/src/locales/langs/sv.json
+++ b/src/locales/langs/sv.json
@@ -3,13 +3,24 @@
     "home": "Hem",
     "courses": "Kurser",
     "about": "Om oss",
-    "gallery": "Galleri"
+    "gallery": "Galleri",
+    "openMenu": "Öppna meny",
+    "closeMenu": "Stäng meny"
   },
   "auth": {
     "signIn": "Logga in",
-    "signOut": "Logga ut"
+    "signOut": "Logga ut",
+    "profileAndBook": "Profil & boka",
+    "admin": "Admin"
   },
   "cart": {
     "title": "Varukorg"
+  },
+  "language": {
+    "switchTo": "Byt till {{language}}"
+  },
+  "mode": {
+    "light": "Ljust",
+    "dark": "Mörkt"
   }
 }

--- a/src/locales/localization-provider.tsx
+++ b/src/locales/localization-provider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
+import { writeClientLangCookie } from "./client-lang-cookie";
 import type { AppLang } from "./config-lang";
 import i18n from "./i18n";
 
@@ -21,7 +22,7 @@ export default function LocalizationProvider({ children, lang }: Props) {
 
   useEffect(() => {
     localStorage.setItem("i18nextLng", lang);
-    document.cookie = `i18nextLng=${lang}; Path=/; Max-Age=31536000; SameSite=Lax`;
+    void writeClientLangCookie(lang);
   }, [lang]);
 
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;

--- a/src/locales/localization-provider.tsx
+++ b/src/locales/localization-provider.tsx
@@ -1,12 +1,28 @@
 "use client";
 
+import { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
+import type { AppLang } from "./config-lang";
 import i18n from "./i18n";
 
 type Props = {
   children: React.ReactNode;
+  lang: AppLang;
 };
 
-export default function LocalizationProvider({ children }: Props) {
+export default function LocalizationProvider({ children, lang }: Props) {
+  const currentLang = (i18n.resolvedLanguage ?? i18n.language ?? "").slice(
+    0,
+    2,
+  );
+  if (currentLang !== lang) {
+    void i18n.changeLanguage(lang);
+  }
+
+  useEffect(() => {
+    localStorage.setItem("i18nextLng", lang);
+    document.cookie = `i18nextLng=${lang}; Path=/; Max-Age=31536000; SameSite=Lax`;
+  }, [lang]);
+
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }


### PR DESCRIPTION
## Beskrivning

Denna PR anpassar i18next så den använder och sparar cookie för språkval istället för localStorag, och ser till så switchern uppdaterar det och refreshar. Är testat på navbaren i denna PR. 

Vi behöver cookien för att kunna avgöra om fält ska hämtas från _en i databasen baserat på språk t.ex. Tänk på att det är även andra funktioner som t.ex getCourseName som kommer behöva få in valt språk som parameeter, vilket görs nu i görs i admin-delen. 



## Relaterade issues

Closes #292 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [x] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [x] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
