### PR TITLE
fix: async funktion till språkändringsknapp

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -27,12 +27,12 @@ export default function LanguageSwitcher() {
     void syncLang();
   }, []);
 
-  function handleChange(value: string) {
+  async function handleChange(value: string) {
     const nextLang = normalizeLang(value);
     setCurrentLang(nextLang);
     localStorage.setItem("i18nextLng", nextLang);
-    void writeClientLangCookie(nextLang);
-    void i18next.changeLanguage(nextLang);
+    await writeClientLangCookie(nextLang);
+    await i18next.changeLanguage(nextLang);
     router.refresh();
   }
 


### PR DESCRIPTION
## Beskrivning

Språk byttes inte korrekt när man tryckte på språkknappen i navbar för att funktionen som kördes inte var async

## Relaterade issues

Closes #297 