### PR TITLE
Visa alla kunduppgifter i adminelever

### DIFF
--- a/src/app/(admin)/admin/students/components/DetailsDialog.tsx
+++ b/src/app/(admin)/admin/students/components/DetailsDialog.tsx
@@ -1,4 +1,9 @@
-import { useState } from "react";
+"use client";
+
+import { List } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,19 +15,279 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import type { AdminStudentDetails } from "@/lib/actions/admin-students";
+import { getAdminStudentDetails } from "@/lib/actions/admin-students";
 
 interface Props {
   id: string;
   isParticipant: boolean;
 }
 
+function hasText(value: string | null | undefined) {
+  return Boolean(value?.trim());
+}
+
+function formatDate(value: string | null | undefined, includeTime = false) {
+  if (!value) return "";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString("sv-SE", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    ...(includeTime
+      ? {
+          hour: "2-digit",
+          minute: "2-digit",
+        }
+      : {}),
+  });
+}
+
+function ConsentBadge({ value }: { value: boolean | null | undefined }) {
+  if (value) return <Badge>Ja</Badge>;
+  return <Badge variant="outline">Nej</Badge>;
+}
+
+function DetailRow({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="grid gap-1 rounded border bg-muted/20 p-3 sm:grid-cols-[180px_1fr]">
+      <div className="text-muted-foreground text-sm">{label}</div>
+      <div className="min-w-0 break-words text-sm">{value}</div>
+    </div>
+  );
+}
+
+function OptionalTextRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  if (!hasText(value)) return null;
+  return <DetailRow label={label} value={value} />;
+}
+
+function OptionalDateRow({
+  label,
+  value,
+  includeTime = false,
+}: {
+  label: string;
+  value: string | null | undefined;
+  includeTime?: boolean;
+}) {
+  if (!value) return null;
+  return <DetailRow label={label} value={formatDate(value, includeTime)} />;
+}
+
+function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <h3 className="font-medium text-sm">{title}</h3>
+      <div className="space-y-2">{children}</div>
+    </section>
+  );
+}
+
+function LinkedUserDetails({
+  user,
+}: {
+  user: NonNullable<AdminStudentDetails["linkedUser"]>;
+}) {
+  return (
+    <DetailSection title="Kopplad användare">
+      <DetailRow label="Namn" value={user.name} />
+      <DetailRow label="E-post" value={user.email} />
+      <OptionalTextRow label="Förnamn" value={user.firstName} />
+      <OptionalTextRow label="Efternamn" value={user.lastName} />
+      <OptionalTextRow label="Telefon" value={user.phone} />
+      <OptionalTextRow label="Adress" value={user.address} />
+      <OptionalTextRow label="Postnummer" value={user.postalCode} />
+      <OptionalTextRow label="Ort" value={user.city} />
+      <OptionalDateRow label="Födelsedatum" value={user.dateOfBirth} />
+      <OptionalTextRow label="Bio" value={user.bio} />
+      <OptionalTextRow label="Bio (EN)" value={user.bioEn} />
+      <DetailRow
+        label="Tillåter bilder/filmer"
+        value={<ConsentBadge value={user.allowPhotoVideo} />}
+      />
+    </DetailSection>
+  );
+}
+
+function ParticipantCard({
+  participant,
+}: {
+  participant: AdminStudentDetails["addedParticipants"][number];
+}) {
+  return (
+    <div className="space-y-3 rounded border p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <h4 className="font-medium text-sm">{participant.name}</h4>
+        <Badge variant="secondary">Deltagare</Badge>
+      </div>
+      <div className="space-y-2">
+        <OptionalTextRow label="E-post" value={participant.email} />
+        <OptionalTextRow label="Telefon" value={participant.phone} />
+        <DetailRow
+          label="Tillåter bilder/filmer"
+          value={<ConsentBadge value={participant.allowPhotoVideo} />}
+        />
+        <OptionalDateRow
+          label="Skapad"
+          value={participant.createdAt}
+          includeTime
+        />
+        <OptionalDateRow
+          label="Uppdaterad"
+          value={participant.updatedAt}
+          includeTime
+        />
+      </div>
+      {participant.linkedUser ? (
+        <LinkedUserDetails user={participant.linkedUser} />
+      ) : null}
+    </div>
+  );
+}
+
+function AddedParticipantsList({
+  participants,
+}: {
+  participants: AdminStudentDetails["addedParticipants"];
+}) {
+  return (
+    <DetailSection title="Tillagda deltagare">
+      {participants.length > 0 ? (
+        participants.map((participant) => (
+          <ParticipantCard key={participant.id} participant={participant} />
+        ))
+      ) : (
+        <div className="text-muted-foreground text-sm">
+          Användaren har inte lagt till några deltagare.
+        </div>
+      )}
+    </DetailSection>
+  );
+}
+
+function StudentDetailsContent({ details }: { details: AdminStudentDetails }) {
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="secondary">
+          {details.type === "participant" ? "Deltagare" : "Användare"}
+        </Badge>
+        <span className="font-medium">{details.name}</span>
+      </div>
+
+      <DetailSection
+        title={details.type === "participant" ? "Deltagare" : "Användare"}
+      >
+        <DetailRow label="Namn" value={details.name} />
+        <OptionalTextRow label="E-post" value={details.email} />
+        <OptionalTextRow label="Telefon" value={details.phone} />
+        <OptionalTextRow label="Förnamn" value={details.firstName} />
+        <OptionalTextRow label="Efternamn" value={details.lastName} />
+        <OptionalTextRow label="Adress" value={details.address} />
+        <OptionalTextRow label="Postnummer" value={details.postalCode} />
+        <OptionalTextRow label="Ort" value={details.city} />
+        <OptionalDateRow label="Födelsedatum" value={details.dateOfBirth} />
+        <OptionalTextRow label="Bio" value={details.bio} />
+        <OptionalTextRow label="Bio (EN)" value={details.bioEn} />
+        <DetailRow
+          label="Tillåter bilder/filmer"
+          value={<ConsentBadge value={details.allowPhotoVideo} />}
+        />
+      </DetailSection>
+
+      {details.customer ? (
+        <DetailSection title="Köpare / ansvarig">
+          <DetailRow label="Namn" value={details.customer.name} />
+          <DetailRow label="E-post" value={details.customer.email} />
+        </DetailSection>
+      ) : null}
+
+      {details.linkedUser ? (
+        <LinkedUserDetails user={details.linkedUser} />
+      ) : null}
+
+      {details.type === "user" ? (
+        <AddedParticipantsList participants={details.addedParticipants} />
+      ) : null}
+
+      <DetailSection title="System">
+        <DetailRow
+          label="Typ"
+          value={details.type === "participant" ? "Deltagare" : "Användare"}
+        />
+        <DetailRow label="ID" value={details.id} />
+        <OptionalDateRow label="Skapad" value={details.createdAt} includeTime />
+        <OptionalDateRow
+          label="Uppdaterad"
+          value={details.updatedAt}
+          includeTime
+        />
+      </DetailSection>
+    </div>
+  );
+}
+
 export function DetailsDialog({ id, isParticipant }: Props) {
   const [open, setOpen] = useState(false);
+  const [details, setDetails] = useState<AdminStudentDetails | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let isCurrent = true;
+    setIsLoading(true);
+    setError(null);
+
+    getAdminStudentDetails({ id, isParticipant })
+      .then((result) => {
+        if (!isCurrent) return;
+
+        if (!result.success) {
+          setDetails(null);
+          setError(result.error);
+          return;
+        }
+
+        setDetails(result.details);
+      })
+      .catch(() => {
+        if (!isCurrent) return;
+        setDetails(null);
+        setError("Kunde inte hämta detaljer.");
+      })
+      .finally(() => {
+        if (isCurrent) setIsLoading(false);
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [open, id, isParticipant]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>Visa</Button>
+        <Button variant="ghost">
+          <List /> Visa
+        </Button>
       </DialogTrigger>
       <DialogContent className="max-h-[90dvh] min-w-0 overflow-x-hidden overflow-y-visible sm:max-w-4xl">
         <DialogHeader>
@@ -32,10 +297,21 @@ export function DetailsDialog({ id, isParticipant }: Props) {
           </DialogDescription>
         </DialogHeader>
         <div className="min-w-0 max-h-[65dvh] overflow-x-hidden overflow-y-auto pt-1 pr-1">
-          <ul>
-            <li>id: {id}</li>
-            <li>isParticipant: {isParticipant ? "true" : "false"}</li>
-          </ul>
+          {isLoading ? (
+            <div className="text-muted-foreground text-sm">
+              Hämtar detaljer...
+            </div>
+          ) : error ? (
+            <div className="rounded border border-destructive/40 bg-destructive/10 p-3 text-destructive text-sm">
+              {error}
+            </div>
+          ) : details ? (
+            <StudentDetailsContent details={details} />
+          ) : (
+            <div className="text-muted-foreground text-sm">
+              Inga detaljer hittades.
+            </div>
+          )}
         </div>
         <DialogFooter className="flex-row justify-between sm:justify-between">
           <DialogClose asChild>

--- a/src/app/(admin)/admin/students/components/DetailsDialog.tsx
+++ b/src/app/(admin)/admin/students/components/DetailsDialog.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+interface Props {
+  id: string;
+  isParticipant: boolean;
+}
+
+export function DetailsDialog({ id, isParticipant }: Props) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button>Visa</Button>
+      </DialogTrigger>
+      <DialogContent className="max-h-[90dvh] min-w-0 overflow-x-hidden overflow-y-visible sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Visar detaljer</DialogTitle>
+          <DialogDescription>
+            Här kan du se alla uppgifter som finns sparade för vald elev.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="min-w-0 max-h-[65dvh] overflow-x-hidden overflow-y-auto pt-1 pr-1">
+          <ul>
+            <li>id: {id}</li>
+            <li>isParticipant: {isParticipant ? "true" : "false"}</li>
+          </ul>
+        </div>
+        <DialogFooter className="flex-row justify-between sm:justify-between">
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              Stäng
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(admin)/admin/students/components/StudentTableClient.tsx
+++ b/src/app/(admin)/admin/students/components/StudentTableClient.tsx
@@ -652,8 +652,8 @@ export default function StudentTableClient({
                 <TableCell className="font-medium">{student.name}</TableCell>
                 <TableCell className="font-medium">
                   <DetailsDialog
-                    id={student.participant?.id ?? student.userId}
-                    isParticipant={!!student.participant}
+                    id={student.participantId ?? student.userId}
+                    isParticipant={!!student.participantId}
                   />
                 </TableCell>
                 <TableCell>{student.customerName ?? "-"}</TableCell>

--- a/src/app/(admin)/admin/students/components/StudentTableClient.tsx
+++ b/src/app/(admin)/admin/students/components/StudentTableClient.tsx
@@ -36,6 +36,7 @@ import {
 import { removeUserFromLesson } from "@/lib/actions/admin";
 import { adminUpdatePurchaseRemainingCount } from "@/lib/actions/admin-students";
 import type { StudentSummary } from "../page";
+import { DetailsDialog } from "./DetailsDialog";
 import { MailDialog } from "./MailDialog";
 import StudentUserEditDialog from "./StudentUserEditDialog";
 import type { SelectedStudent, StudentsSelectedType } from "./studentSelection";
@@ -627,6 +628,7 @@ export default function StudentTableClient({
                 />
               </TableHead>
               <TableHead>Namn</TableHead>
+              <TableHead>Detaljer</TableHead>
               <TableHead>Köpare</TableHead>
               <TableHead>Kurser</TableHead>
               <TableHead>Terminer</TableHead>
@@ -648,6 +650,12 @@ export default function StudentTableClient({
                   />
                 </TableCell>
                 <TableCell className="font-medium">{student.name}</TableCell>
+                <TableCell className="font-medium">
+                  <DetailsDialog
+                    id={student.participant?.id ?? student.userId}
+                    isParticipant={!!student.participant}
+                  />
+                </TableCell>
                 <TableCell>{student.customerName ?? "-"}</TableCell>
                 <TableCell>
                   <CoursesDialog student={student} />

--- a/src/app/(admin)/admin/students/components/StudentTableClient.tsx
+++ b/src/app/(admin)/admin/students/components/StudentTableClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useId, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 import EditParticipantForm from "@/components/EditParticipantForm";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -48,6 +49,14 @@ function getStudentEmail(student: StudentSummary) {
     student.participant?.email ||
     student.participant?.addedBy.email ||
     student.user.email
+  );
+}
+
+function getAllowPhotoVideo(student: StudentSummary) {
+  return (
+    student.participant?.allowPhotoVideo ??
+    student.user.details?.allowPhotoVideo ??
+    false
   );
 }
 
@@ -628,6 +637,7 @@ export default function StudentTableClient({
                 />
               </TableHead>
               <TableHead>Namn</TableHead>
+              <TableHead>Tillåter visas</TableHead>
               <TableHead>Detaljer</TableHead>
               <TableHead>Köpare</TableHead>
               <TableHead>Kurser</TableHead>
@@ -650,6 +660,13 @@ export default function StudentTableClient({
                   />
                 </TableCell>
                 <TableCell className="font-medium">{student.name}</TableCell>
+                <TableCell>
+                  {getAllowPhotoVideo(student) ? (
+                    <Badge variant="default">Ja</Badge>
+                  ) : (
+                    <Badge variant="destructive">Nej</Badge>
+                  )}
+                </TableCell>
                 <TableCell className="font-medium">
                   <DetailsDialog
                     id={student.participantId ?? student.userId}

--- a/src/app/(admin)/admin/students/page.tsx
+++ b/src/app/(admin)/admin/students/page.tsx
@@ -17,6 +17,7 @@ type StudentUserSummary = {
     address: string | null;
     postalCode: string | null;
     city: string | null;
+    allowPhotoVideo: boolean;
   } | null;
 };
 
@@ -96,6 +97,7 @@ type StudentPurchaseRow = Prisma.PurchaseGetPayload<{
             address: true;
             postalCode: true;
             city: true;
+            allowPhotoVideo: true;
           };
         };
       };
@@ -434,6 +436,7 @@ export default async function Page({
               address: true,
               postalCode: true,
               city: true,
+              allowPhotoVideo: true,
             },
           },
         },

--- a/src/app/(admin)/admin/students/page.tsx
+++ b/src/app/(admin)/admin/students/page.tsx
@@ -106,6 +106,7 @@ type StudentPurchaseRow = Prisma.PurchaseGetPayload<{
         name: true;
         email: true;
         phone: true;
+        userId: true;
         allowPhotoVideo: true;
         addedBy: {
           select: {
@@ -176,32 +177,34 @@ function buildStudentSummaries(
   >();
 
   for (const purchase of purchasesWithData) {
-    const studentKey = purchase.participantId
-      ? `participant:${purchase.participantId}`
+    const participant =
+      purchase.participant?.userId === purchase.userId
+        ? null
+        : purchase.participant;
+    const studentKey = participant
+      ? `participant:${participant.id}`
       : `user:${purchase.userId}`;
 
     const existing = studentMap.get(studentKey) ?? {
       studentKey,
       userId: purchase.user.id,
-      participantId: purchase.participant?.id ?? null,
-      name: purchase.participant?.name ?? purchase.user.name,
-      customerName: purchase.participant
-        ? purchase.participant.addedBy.name
-        : null,
+      participantId: participant?.id ?? null,
+      name: participant?.name ?? purchase.user.name,
+      customerName: participant ? participant.addedBy.name : null,
       user: {
         id: purchase.user.id,
         name: purchase.user.name,
         email: purchase.user.email,
         details: purchase.user.details,
       },
-      participant: purchase.participant
+      participant: participant
         ? {
-            id: purchase.participant.id,
-            name: purchase.participant.name,
-            email: purchase.participant.email,
-            phone: purchase.participant.phone,
-            allowPhotoVideo: purchase.participant.allowPhotoVideo,
-            addedBy: purchase.participant.addedBy,
+            id: participant.id,
+            name: participant.name,
+            email: participant.email,
+            phone: participant.phone,
+            allowPhotoVideo: participant.allowPhotoVideo,
+            addedBy: participant.addedBy,
           }
         : null,
       courses: [],
@@ -441,6 +444,7 @@ export default async function Page({
           name: true,
           email: true,
           phone: true,
+          userId: true,
           allowPhotoVideo: true,
           addedBy: {
             select: {

--- a/src/app/(admin)/admin/users/UsersView.tsx
+++ b/src/app/(admin)/admin/users/UsersView.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/select";
 import { adminSetRole } from "@/lib/actions/user-management";
 import { useSession } from "@/lib/session-provider";
+import { DetailsDialog } from "../students/components/DetailsDialog";
 import BanUserDialog from "./BanUserDialog";
 import EditUserDialog from "./EditUserDialog";
 
@@ -108,6 +109,7 @@ export default function UsersView({
               </th>
               <th className="p-3 text-left font-medium">Roll</th>
               <th className="p-3 text-left font-medium">Status</th>
+              <th className="p-3 text-left font-medium">Alla detaljer</th>
               <th className="p-3 text-left font-medium hidden lg:table-cell">
                 Registrerad
               </th>
@@ -166,6 +168,9 @@ export default function UsersView({
                         Aktiv
                       </Badge>
                     )}
+                  </td>
+                  <td>
+                    <DetailsDialog id={u.id} isParticipant={false} />
                   </td>
                   <td className="p-3 text-muted-foreground hidden lg:table-cell">
                     {new Date(u.createdAt).toLocaleDateString("sv-SE")}

--- a/src/lib/actions/admin-students.ts
+++ b/src/lib/actions/admin-students.ts
@@ -4,6 +4,285 @@ import { revalidatePath } from "next/cache";
 import prisma from "@/lib/prisma";
 import { isAdminRole } from "./admin";
 
+type AdminStudentLinkedUser = {
+  id: string;
+  name: string;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  phone: string | null;
+  address: string | null;
+  postalCode: string | null;
+  city: string | null;
+  dateOfBirth: string | null;
+  bio: string | null;
+  bioEn: string | null;
+  allowPhotoVideo: boolean | null;
+};
+
+type AdminStudentAddedParticipant = {
+  id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  allowPhotoVideo: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+  linkedUser: AdminStudentLinkedUser | null;
+};
+
+export type AdminStudentDetails = {
+  id: string;
+  type: "user" | "participant";
+  name: string;
+  email: string | null;
+  phone: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  address: string | null;
+  postalCode: string | null;
+  city: string | null;
+  dateOfBirth: string | null;
+  bio: string | null;
+  bioEn: string | null;
+  allowPhotoVideo: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+  customer: {
+    id: string;
+    name: string;
+    email: string;
+  } | null;
+  linkedUser: AdminStudentLinkedUser | null;
+  addedParticipants: AdminStudentAddedParticipant[];
+};
+
+function toIsoString(value: Date | null | undefined) {
+  return value ? value.toISOString() : null;
+}
+
+function mapLinkedUser(
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    details: {
+      firstName: string | null;
+      lastName: string | null;
+      phoneNumber: string | null;
+      address: string | null;
+      postalCode: string | null;
+      city: string | null;
+      dateOfBirth: Date | null;
+      bio: string | null;
+      bio_en: string | null;
+      allowPhotoVideo: boolean;
+    } | null;
+  } | null,
+): AdminStudentLinkedUser | null {
+  if (!user) return null;
+
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    firstName: user.details?.firstName ?? null,
+    lastName: user.details?.lastName ?? null,
+    phone: user.details?.phoneNumber ?? null,
+    address: user.details?.address ?? null,
+    postalCode: user.details?.postalCode ?? null,
+    city: user.details?.city ?? null,
+    dateOfBirth: toIsoString(user.details?.dateOfBirth),
+    bio: user.details?.bio ?? null,
+    bioEn: user.details?.bio_en ?? null,
+    allowPhotoVideo: user.details?.allowPhotoVideo ?? null,
+  };
+}
+
+export async function getAdminStudentDetails(input: {
+  id: string;
+  isParticipant: boolean;
+}): Promise<
+  | { success: true; details: AdminStudentDetails }
+  | { success: false; error: string }
+> {
+  const isAdmin = await isAdminRole();
+  if (!isAdmin) return { success: false, error: "Ingen behörighet." };
+
+  try {
+    if (input.isParticipant) {
+      const participant = await prisma.participant.findUnique({
+        where: { id: input.id },
+        select: {
+          id: true,
+          name: true,
+          email: true,
+          phone: true,
+          allowPhotoVideo: true,
+          createdAt: true,
+          updatedAt: true,
+          addedBy: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+              details: {
+                select: {
+                  firstName: true,
+                  lastName: true,
+                  phoneNumber: true,
+                  address: true,
+                  postalCode: true,
+                  city: true,
+                  dateOfBirth: true,
+                  bio: true,
+                  bio_en: true,
+                  allowPhotoVideo: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!participant) {
+        return { success: false, error: "Deltagaren hittades inte." };
+      }
+
+      return {
+        success: true,
+        details: {
+          id: participant.id,
+          type: "participant",
+          name: participant.name,
+          email: participant.email,
+          phone: participant.phone,
+          firstName: null,
+          lastName: null,
+          address: null,
+          postalCode: null,
+          city: null,
+          dateOfBirth: null,
+          bio: null,
+          bioEn: null,
+          allowPhotoVideo: participant.allowPhotoVideo,
+          createdAt: toIsoString(participant.createdAt),
+          updatedAt: toIsoString(participant.updatedAt),
+          customer: participant.addedBy,
+          linkedUser: mapLinkedUser(participant.user),
+          addedParticipants: [],
+        },
+      };
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: input.id },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        createdAt: true,
+        updatedAt: true,
+        details: {
+          select: {
+            firstName: true,
+            lastName: true,
+            phoneNumber: true,
+            address: true,
+            postalCode: true,
+            city: true,
+            dateOfBirth: true,
+            bio: true,
+            bio_en: true,
+            allowPhotoVideo: true,
+          },
+        },
+        addedParticipants: {
+          orderBy: { name: "asc" },
+          select: {
+            id: true,
+            name: true,
+            email: true,
+            phone: true,
+            allowPhotoVideo: true,
+            createdAt: true,
+            updatedAt: true,
+            user: {
+              select: {
+                id: true,
+                name: true,
+                email: true,
+                details: {
+                  select: {
+                    firstName: true,
+                    lastName: true,
+                    phoneNumber: true,
+                    address: true,
+                    postalCode: true,
+                    city: true,
+                    dateOfBirth: true,
+                    bio: true,
+                    bio_en: true,
+                    allowPhotoVideo: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!user) {
+      return { success: false, error: "Användaren hittades inte." };
+    }
+
+    return {
+      success: true,
+      details: {
+        id: user.id,
+        type: "user",
+        name: user.name,
+        email: user.email,
+        phone: user.details?.phoneNumber ?? null,
+        firstName: user.details?.firstName ?? null,
+        lastName: user.details?.lastName ?? null,
+        address: user.details?.address ?? null,
+        postalCode: user.details?.postalCode ?? null,
+        city: user.details?.city ?? null,
+        dateOfBirth: toIsoString(user.details?.dateOfBirth),
+        bio: user.details?.bio ?? null,
+        bioEn: user.details?.bio_en ?? null,
+        allowPhotoVideo: user.details?.allowPhotoVideo ?? false,
+        createdAt: toIsoString(user.createdAt),
+        updatedAt: toIsoString(user.updatedAt),
+        customer: null,
+        linkedUser: null,
+        addedParticipants: user.addedParticipants.map((participant) => ({
+          id: participant.id,
+          name: participant.name,
+          email: participant.email,
+          phone: participant.phone,
+          allowPhotoVideo: participant.allowPhotoVideo,
+          createdAt: toIsoString(participant.createdAt),
+          updatedAt: toIsoString(participant.updatedAt),
+          linkedUser: mapLinkedUser(participant.user),
+        })),
+      },
+    };
+  } catch (error) {
+    console.error("getAdminStudentDetails error:", error);
+    return { success: false, error: "Kunde inte hämta detaljer." };
+  }
+}
+
 export async function adminUpdatePurchaseRemainingCount(input: {
   purchaseId: string;
   purchaseItemId?: string;


### PR DESCRIPTION
## Beskrivning

Förbättrar hur vi skiljer på deltagare och användare något. Lägger till en knapp i tabellen för att visa alla uppgifter som går att hämta, inkl en köpares deltagare.  Visar också om en student går med på att visas i bilder i tabellen.


## Relaterade issues

Closes #330 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
