### PR TITLE
Rätt email i mailutskick

### DIFF
--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -122,7 +122,7 @@ export async function generateOrderConfirmationHtml(order: {
       </table>
 
       <p style="margin-top: 20px;">
-        Om du har några frågor om din beställning, är du välkommen att kontakta oss på <a href="mailto:info@motionzoneworld.com">info@motionzoneworld.com</a>.
+        Om du har några frågor om din beställning, är du välkommen att kontakta oss på <a href="mailto:motionzonevaxjo@gmail.com">motionzonevaxjo@gmail.com</a>.
       </p>
 
       <p>Med vänliga hälsningar,<br/>Motion Zone Teamet</p>
@@ -177,7 +177,7 @@ export async function generateBookingCancelledHtml(
           ? `<p><strong>Meddelande från oss:</strong><br/>${lesson.message} <br/><br/> ${lesson.message_en}</p>`
           : ""
       }
-      <p>Om du har några frågor är du välkommen att kontakta oss på <a href="mailto:info@motionzoneworld.com">info@motionzoneworld.com</a>.</p>
+      <p>Om du har några frågor är du välkommen att kontakta oss på <a href="mailto:motionzonevaxjo@gmail.com">motionzonevaxjo@gmail.com</a>.</p>
 
       <p>Med vänliga hälsningar,<br/>Motion Zone Teamet</p>
 


### PR DESCRIPTION
## Beskrivning

Ändrar till motionzonevaxjo@gmail.com i mailutskicken. 
Vi bör också ha en vidarebefordran via deras info@motionzoneworld.com mail, men kodmässigt är det rätt nu.

## Relaterade issues

Closes #327 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
