### PR TITLE
Faktura alternativ

### DIFF
--- a/prisma/migrations/20260712102603_paymethod_in_order/migration.sql
+++ b/prisma/migrations/20260712102603_paymethod_in_order/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "order" ADD COLUMN     "payMethod" INTEGER NOT NULL DEFAULT 1;

--- a/prisma/migrations/20260712110924_note_in_order/migration.sql
+++ b/prisma/migrations/20260712110924_note_in_order/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "order" ADD COLUMN     "note" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -448,6 +448,8 @@ model Order {
   status       OrderStatus        @default(PENDING_PAYMENT)
   statusEvents OrderStatusEvent[]
 
+  payMethod Int @default(1) // 1 = Faktura hela beloppet, 2 = 2 delbetalningar, 3 = 3 delbetalningar
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -450,6 +450,8 @@ model Order {
 
   payMethod Int @default(1) // 1 = Faktura hela beloppet, 2 = 2 delbetalningar, 3 = 3 delbetalningar
 
+  note String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/app/(admin)/admin/orders/OrdersView.tsx
+++ b/src/app/(admin)/admin/orders/OrdersView.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { formatDateToInputStr } from "@/lib/date-utils";
 import { formatPrice } from "@/lib/money";
 import { getOrderStatusLabel, type OrderStatus } from "@/lib/order-status";
+import { getPayMethodTxt } from "@/lib/tools";
 
 type OrderLite = {
   id: string;
@@ -31,6 +32,8 @@ type OrderLite = {
       }[]
     | null;
   totalPrice: unknown;
+  payMethod: number;
+  note: string | null;
   createdAt: string | Date;
   status?: OrderStatus;
 };
@@ -249,6 +252,9 @@ export default function OrdersView({
               <th className="p-3 text-left font-medium">Produkter</th>
               <th className="p-3 text-left font-medium">Total</th>
               <th className="p-3 text-left font-medium">Status</th>
+              <th className="p-3 text-left font-medium">
+                Betalningsalternativ
+              </th>
               <th className="p-3 text-left font-medium">Detaljer</th>
               <th className="p-3 text-left font-medium">Åtgärder</th>
             </tr>
@@ -345,6 +351,7 @@ export default function OrdersView({
                       {getStatusLabel(o.status || "PENDING_PAYMENT")}
                     </span>
                   </td>
+                  <td className="p-3">{getPayMethodTxt(o.payMethod, "sv")}</td>
                   <td className="p-3">
                     <Link
                       href={createOrderDetailHref(o.id)}

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -40,6 +40,8 @@ type OrderLite = {
   totalPrice: unknown;
   createdAt: string | Date;
   status?: OrderStatus;
+  payMethod: number;
+  note: string | null;
 };
 
 async function getOrders(): Promise<OrderLite[]> {

--- a/src/app/(admin)/admin/orders/view/view-client.tsx
+++ b/src/app/(admin)/admin/orders/view/view-client.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/date-utils";
 import { formatPrice } from "@/lib/money";
 import { getOrderStatusLabel, type OrderStatus } from "@/lib/order-status";
+import { getPayMethodTxt } from "@/lib/tools";
 
 type OrderItemLite = {
   id: string;
@@ -66,6 +67,8 @@ type OrderDetail = {
   status?: OrderStatus;
   orderItems?: OrderItemLite[];
   statusEvents?: StatusEventLite[];
+  payMethod: number;
+  note: string | null;
 };
 
 function calculateAge(dob: string | Date | null | undefined) {
@@ -201,21 +204,35 @@ export default function OrderDetailsClient() {
                 <span className="text-muted-foreground">Totalbelopp:</span>
                 <span className="font-bold text-lg">{formatPrice(total)}</span>
               </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Skapad:</span>
-                <span>{formatDateToInputStr(new Date(order.createdAt))}</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Uppdaterad:</span>
-                <span>{formatDateToInputStr(new Date(order.updatedAt))}</span>
-              </div>
-              <div className="pt-2 border-t">
-                <span className="text-muted-foreground block mb-1">
-                  Order ID:
+              <div className="">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Skapad:</span>
+                  <span>{formatDateToInputStr(new Date(order.createdAt))}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Uppdaterad:</span>
+                  <span>{formatDateToInputStr(new Date(order.updatedAt))}</span>
+                </div>
+                <div className="pt-2 border-t">
+                  <span className="text-muted-foreground block mb-1">
+                    Order ID:
+                  </span>
+                  <code className="text-[10px] bg-muted p-1 rounded block break-all mb-2">
+                    {order.id}
+                  </code>
+                </div>
+                <span className="text-muted-foreground mb-3">
+                  Betalningsalternativ:
                 </span>
-                <code className="text-[10px] bg-muted p-1 rounded block break-all">
-                  {order.id}
-                </code>
+                <br />
+                <span className="font-bold text-sm">
+                  {getPayMethodTxt(order.payMethod, "sv")}
+                </span>
+              </div>
+              <div className="">
+                <span className="text-muted-foreground mb-3">Notering:</span>
+                <br />
+                <span className="text-sm">{order.note}</span>
               </div>
             </div>
           </div>

--- a/src/app/(public)/checkout/CheckoutForm.tsx
+++ b/src/app/(public)/checkout/CheckoutForm.tsx
@@ -77,6 +77,7 @@ export default function CheckoutForm({
   const { t } = useTranslation();
   const router = useRouter();
   const [note, setNote] = useState("");
+  const [paymethod, setPaymethod] = useState("1");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Expanded items (each qty gets its own slot)
@@ -160,6 +161,7 @@ export default function CheckoutForm({
         items: orderItems,
         postalcode: userDetails?.postalCode || undefined,
         note,
+        paymethod: Number(paymethod),
       });
 
       toast.success(t("checkout.form.orderCreated"));
@@ -347,9 +349,13 @@ export default function CheckoutForm({
 
           <div className="space-y-2 pt-4 border-t">
             <Label htmlFor="paymethod" className="mb-4">
-              {t("checkout.form.method")}
+              {t("checkout.form.method")} ({paymethod})
             </Label>
-            <RadioGroup defaultValue="1" className="w-fit">
+            <RadioGroup
+              defaultValue="1"
+              className="w-fit"
+              onValueChange={(e) => setPaymethod(e)}
+            >
               <Field orientation="horizontal">
                 <RadioGroupItem value="1" id="paymethod-r1" />
                 <FieldContent>

--- a/src/app/(public)/checkout/CheckoutForm.tsx
+++ b/src/app/(public)/checkout/CheckoutForm.tsx
@@ -13,8 +13,15 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -336,6 +343,47 @@ export default function CheckoutForm({
                 </div>
               );
             })}
+          </div>
+
+          <div className="space-y-2 pt-4 border-t">
+            <Label htmlFor="paymethod" className="mb-4">
+              {t("checkout.form.method")}
+            </Label>
+            <RadioGroup defaultValue="1" className="w-fit">
+              <Field orientation="horizontal">
+                <RadioGroupItem value="1" id="paymethod-r1" />
+                <FieldContent>
+                  <FieldLabel htmlFor="desc-r1">
+                    {t("checkout.form.1")}
+                  </FieldLabel>
+                  <FieldDescription>
+                    {t("checkout.form.1description")}
+                  </FieldDescription>
+                </FieldContent>
+              </Field>
+              <Field orientation="horizontal">
+                <RadioGroupItem value="2" id="paymethod-r2" />
+                <FieldContent>
+                  <FieldLabel htmlFor="desc-r2">
+                    {t("checkout.form.2")}
+                  </FieldLabel>
+                  <FieldDescription>
+                    {t("checkout.form.2description")}
+                  </FieldDescription>
+                </FieldContent>
+              </Field>
+              <Field orientation="horizontal">
+                <RadioGroupItem value="3" id="paymethod-r3" />
+                <FieldContent>
+                  <FieldLabel htmlFor="desc-r3">
+                    {t("checkout.form.3")}
+                  </FieldLabel>
+                  <FieldDescription>
+                    {t("checkout.form.3description")}
+                  </FieldDescription>
+                </FieldContent>
+              </Field>
+            </RadioGroup>
           </div>
 
           <div className="space-y-2 pt-4 border-t">

--- a/src/app/(public)/checkout/success/page.tsx
+++ b/src/app/(public)/checkout/success/page.tsx
@@ -8,6 +8,7 @@ import { pick } from "@/lib/i18n/pick";
 import { formatPrice } from "@/lib/money";
 import { getOrderStatusLabel } from "@/lib/order-status";
 import { getOrderById } from "@/lib/orders";
+import { getPayMethodTxt } from "@/lib/tools";
 import { getDictionary } from "@/locales/get-dictionary";
 
 export const metadata: Metadata = {
@@ -90,6 +91,22 @@ export default async function Page({
                     <span className="text-foreground">
                       {formatDateToInputStr(order.createdAt)}
                     </span>
+                  </div>
+
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">
+                      {t.checkout.success.paymethod}
+                    </span>
+                    <span className="text-foreground">
+                      {getPayMethodTxt(order.payMethod, "sv")}
+                    </span>
+                  </div>
+
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">
+                      {t.checkout.success.note}
+                    </span>
+                    <span className="text-foreground">{order.note}</span>
                   </div>
                 </CardContent>
               </Card>

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { CircleIcon } from "lucide-react";
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/src/lib/actions/checkout.ts
+++ b/src/lib/actions/checkout.ts
@@ -18,11 +18,12 @@ export async function createCheckout(params: {
   items: CheckoutItem[];
   postalcode?: string;
   note?: string;
+  paymethod?: number;
 }) {
   const session = await getSessionData();
   if (!session) throw new Error("Unauthorized");
 
-  const { items, postalcode, note } = params;
+  const { items, postalcode, note, paymethod } = params;
   if (!Array.isArray(items) || items.length === 0) {
     throw new Error("No items provided");
   }
@@ -111,6 +112,7 @@ export async function createCheckout(params: {
         items: serverItems,
         postalcode,
         note,
+        paymethod,
       });
 
       return order;

--- a/src/lib/actions/checkout.ts
+++ b/src/lib/actions/checkout.ts
@@ -123,6 +123,9 @@ export async function createCheckout(params: {
   // Try to send confirmation email
   try {
     const fullOrder = await getOrderById(order.id);
+
+    // ev. fix: vi kanske ska skicka en kopia även till motionzone?
+
     if (fullOrder?.user.email) {
       const html = await generateOrderConfirmationHtml(fullOrder);
       await sendMail(
@@ -130,6 +133,25 @@ export async function createCheckout(params: {
         `Orderbekräftelse - Order #${order.id}`,
         html,
       );
+
+      fullOrder.orderItems.map(async (it) => {
+        if (
+          it.participant?.email !== fullOrder.user.email &&
+          it.participant?.email
+        ) {
+          // Här kan vi skicka till deltagaren med? ja.
+
+          const html = await generateOrderConfirmationHtml({
+            ...fullOrder,
+          });
+
+          await sendMail(
+            it.participant?.email,
+            `Orderbekräftelse, kopia till deltagare - Order #${order.id}`,
+            html,
+          );
+        }
+      });
     }
   } catch (emailError) {
     // We don't want to fail the checkout if the email fails, but we should log it

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -6,6 +6,7 @@ import { formatDateToInputStr, formatLongFriendlyDate } from "./date-utils";
 import { formatPrice } from "./money";
 import { getOrderStatusLabel } from "./order-status";
 import { dbToFormTime } from "./time-convert";
+import { getPayMethodTxt } from "./tools";
 
 const DEFAULT_FROM =
   process.env.EMAIL_FROM || "Motion Zone <no-reply@motionzoneworld.com>";
@@ -66,6 +67,8 @@ export async function generateOrderConfirmationHtml(order: {
   id: string;
   totalPrice: number;
   status: string;
+  payMethod: number;
+  note: string | null;
   createdAt: Date | string;
   user: { name: string; email: string };
   orderItems: {
@@ -100,6 +103,8 @@ export async function generateOrderConfirmationHtml(order: {
         <p><strong>Ordernummer:</strong> ${order.id}</p>
         <p><strong>Datum:</strong> ${formatDateToInputStr(order.createdAt)}</p>
         <p><strong>Status:</strong> ${getOrderStatusLabel(order.status, { PENDING_PAYMENT: "Inväntar betalning" })}</p>
+        <p><strong>Betalningsmetod:</strong> ${getPayMethodTxt(order.payMethod)}</p>
+        <p><strong>Notering:</strong> ${order.note}</p>
       </div>
 
       <table style="width: 100%; border-collapse: collapse;">

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -73,6 +73,7 @@ export async function generateOrderConfirmationHtml(order: {
   user: { name: string; email: string };
   orderItems: {
     product: { name: string };
+    participant?: { name: string } | null;
     count: number;
     price: number;
   }[];
@@ -83,7 +84,7 @@ export async function generateOrderConfirmationHtml(order: {
     <tr>
       <td style="padding: 10px; border-bottom: 1px solid #eee;">${
         item.product.name
-      }</td>
+      } ${item.participant?.name ? `(deltagare: ${item.participant.name})` : ` `}</td>
       <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: center;">${
         item.count
       }</td>

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -15,9 +15,10 @@ export async function createOrder(
     items: OrderItemInput[];
     postalcode?: string;
     note?: string; // optional note to include in first status event
+    paymethod?: number;
   },
 ) {
-  const { userId, items, postalcode, note } = params;
+  const { userId, items, postalcode, note, paymethod } = params;
 
   if (!items || items.length === 0) throw new Error("No items provided");
 
@@ -30,6 +31,8 @@ export async function createOrder(
     data: {
       userId,
       postalcode,
+      note,
+      payMethod: paymethod || 1,
       totalPrice: total,
       // default status is PENDING_PAYMENT per schema
     },

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -72,3 +72,18 @@ export const getVeckodag = (day: Weekday, lang: "sv" | "en" = "sv") => {
       return day; // Returnerar originalsträngen om ingen matchning hittas
   }
 };
+
+export function getPayMethodTxt(n: number, lang: "sv" | "en" = "sv") {
+  if (lang === "sv")
+    return n === 1
+      ? "Faktura, hela beloppet"
+      : n === 2
+        ? "Delbetalning x 2 + 45kr avgift / faktura"
+        : "Delbetalning x 3 + 45kr avgift / faktura";
+  if (lang === "en")
+    return n === 1
+      ? "Invoice, full amount"
+      : n === 2
+        ? "Installments x 2 + 45 SEK fee / invoice"
+        : "Installments x 3 + 45 SEK fee / invoice";
+}

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -200,6 +200,8 @@
       "thanks": "Thank you for your order, {{name}}.",
       "orderNumber": "Order number:",
       "status": "Status:",
+      "paymethod": "Payment method:",
+      "note": "Note:",
       "date": "Date:",
       "colProduct": "Product",
       "colUnitPrice": "Unit price",

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -184,7 +184,14 @@
       "errorTitle": "Something went wrong",
       "errorGeneric": "Something went wrong",
       "missingNameForProduct": "Enter a name for the participant on {{name}}",
-      "missingParticipantForProduct": "Select a participant for {{name}}"
+      "missingParticipantForProduct": "Select a participant for {{name}}",
+      "method": "Payment method:",
+      "1": "Invoice",
+      "1description": "Full amount",
+      "2": "Installments x 2",
+      "2description": "Two installments + 45 SEK fee per invoice",
+      "3": "Installments x 3",
+      "3description": "Three installments + 45 SEK fee per invoice"
     },
     "success": {
       "metaTitle": "Thank you for your order",

--- a/src/locales/langs/sv.json
+++ b/src/locales/langs/sv.json
@@ -184,7 +184,14 @@
       "errorTitle": "Ett fel uppstod",
       "errorGeneric": "Ett fel uppstod",
       "missingNameForProduct": "Ange namn för deltagare på {{name}}",
-      "missingParticipantForProduct": "Välj deltagare för {{name}}"
+      "missingParticipantForProduct": "Välj deltagare för {{name}}",
+      "method": "Betalningsmetod:",
+      "1": "Faktura",
+      "1description": "Hela beloppet",
+      "2": "Delbetalning x 2",
+      "2description": "Två delbetalningar + 45kr avgift / faktura",
+      "3": "Delbetalning x 3",
+      "3description": "Tre delbetalningar + 45kr avgift / faktura"
     },
     "success": {
       "metaTitle": "Tack för din beställning",

--- a/src/locales/langs/sv.json
+++ b/src/locales/langs/sv.json
@@ -200,6 +200,8 @@
       "thanks": "Tack för din beställning, {{name}}.",
       "orderNumber": "Ordernummer:",
       "status": "Status:",
+      "paymethod": "Betalningsmetod:",
+      "note": "Notering:",
       "date": "Datum:",
       "colProduct": "Produkt",
       "colUnitPrice": "Pris/st",


### PR DESCRIPTION
## Beskrivning

Lagt in 3 olika betalningsalternativ enligt önskemål. Dessa sparas i nytt fält i order i databasen. Den visas överallt där orderspec visas, dvs i mail och order-success, admin/order och detaljsidan för en order.

Passade också på att göra så mail skickas även till deltagaren när order är lagd. 

Lagt in fält för note då den verkade saknas med i order, nu visas även den på alla nämda ställen.

## Relaterade issues

Closes #336 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<img width="641" height="676" alt="image" src="https://github.com/user-attachments/assets/2ce64761-7985-46ae-811e-d07c4caa85eb" />

<img width="556" height="786" alt="image" src="https://github.com/user-attachments/assets/b4cdbf73-07a2-4d97-8328-d8cc277f8b16" />

<img width="648" height="875" alt="image" src="https://github.com/user-attachments/assets/3ea07307-77a8-44e5-90a3-9b8c64140b44" />

<img width="1086" height="519" alt="image" src="https://github.com/user-attachments/assets/df3f764e-aef9-4c55-9f04-c94f4a0d4afb" />

<img width="333" height="427" alt="image" src="https://github.com/user-attachments/assets/a1f9df2f-e0b0-48dc-895b-95647dee5a34" />


## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
