### PR TITLE
Hiding email for teachers in course info

### DIFF
--- a/src/app/(public)/courses/components/CourseInfoDialog.tsx
+++ b/src/app/(public)/courses/components/CourseInfoDialog.tsx
@@ -110,9 +110,6 @@ export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
               )}
               <div className="space-y-1">
                 <p>{course.teacher.name}</p>
-                <p className="text-xs text-muted-foreground">
-                  {course.teacher.email}
-                </p>
                 {course.teacher.teacherProfile?.description && (
                   <p className="text-muted-foreground whitespace-pre-line mt-1 leading-relaxed">
                     {


### PR DESCRIPTION
## Beskrivning

Visar ej mail i kursinforutan i produkter där läraren visas. 
Det var det enda stället jag hittade i publika sidor där mailen syns.



## Relaterade issues

Closes #328 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
