### PR TITLE
BUG sluttid i bokningskalender, fel tid visas i admin/students

### DIFF
--- a/src/app/(admin)/admin/students/components/StudentTableClient.tsx
+++ b/src/app/(admin)/admin/students/components/StudentTableClient.tsx
@@ -218,8 +218,8 @@ function BookingsDialog({ student }: { student: StudentSummary }) {
               <div className="space-y-1 text-sm">
                 <div className="font-medium">{booking.courseName}</div>
                 <div className="text-muted-foreground">
-                  {formatFriendlyDateTime(new Date(booking.startTime))} -{" "}
-                  {dbToFormTime(new Date(booking.endTime))}
+                  {formatFriendlyDateTime(booking.startTime, "sv-SE")} -{" "}
+                  {dbToFormTime(booking.endTime)}
                 </div>
               </div>
               <Button

--- a/src/app/(admin)/admin/students/page.tsx
+++ b/src/app/(admin)/admin/students/page.tsx
@@ -40,8 +40,8 @@ type StudentBookingSummary = {
   lessonId: string;
   purchaseItemId: string;
   courseName: string;
-  startTime: string;
-  endTime: string;
+  startTime: Date;
+  endTime: Date;
 };
 
 type StudentPurchaseItemSummary = {
@@ -236,8 +236,8 @@ function buildStudentSummaries(
             lessonId: booking.lessonId,
             purchaseItemId: item.id,
             courseName: item.course.name,
-            startTime: formatDateToInputStr(booking.lesson.startTime),
-            endTime: formatDateToInputStr(booking.lesson.endTime),
+            startTime: booking.lesson.startTime,
+            endTime: booking.lesson.endTime,
           });
         }
 
@@ -272,7 +272,9 @@ function buildStudentSummaries(
         a.name.localeCompare(b.name, "sv"),
       ),
       bookings: Array.from(bookingMap.values()).sort((a, b) =>
-        a.startTime.localeCompare(b.startTime),
+        formatDateToInputStr(a.startTime).localeCompare(
+          formatDateToInputStr(b.startTime),
+        ),
       ),
       purchases: student.purchases.sort((a, b) =>
         a.product.name.localeCompare(b.product.name, "sv"),

--- a/src/app/(public)/user/components/BookingCal.tsx
+++ b/src/app/(public)/user/components/BookingCal.tsx
@@ -29,6 +29,7 @@ import {
   formatFriendlyDateTime,
 } from "@/lib/date-utils";
 import { pick } from "@/lib/i18n/pick";
+import { dbToFormTime } from "@/lib/time-convert";
 import type { AppLang } from "@/locales/config-lang";
 import { normalizeLang } from "@/locales/config-lang";
 import BookBtn from "./BookBtn";
@@ -274,7 +275,8 @@ export default function BookingCal({
                   >
                     <div className="flex-1 min-w-0 pr-3">
                       <p className="font-semibold">
-                        {formatFriendlyDateTime(lesson.startTime, dateLocale)}
+                        {formatFriendlyDateTime(lesson.startTime, dateLocale)} -{" "}
+                        {dbToFormTime(lesson.endTime)}
                       </p>
                       <p className="text-sm text-muted-foreground">
                         {pick(lesson.course, "name", lang) as string}{" "}

--- a/src/app/(public)/user/page.tsx
+++ b/src/app/(public)/user/page.tsx
@@ -30,6 +30,7 @@ import { getSessionData } from "@/lib/actions/sessiondata";
 import { formatFriendlyDateTime } from "@/lib/date-utils";
 import { pick } from "@/lib/i18n/pick";
 import prisma from "@/lib/prisma";
+import { dbToFormTime } from "@/lib/time-convert";
 import { getDictionary } from "@/locales/get-dictionary";
 import { AutobookBtn } from "./AutobookBtn";
 import BookingCal from "./components/BookingCal";
@@ -239,7 +240,8 @@ export default async function Page() {
                                             {formatFriendlyDateTime(
                                               b.lesson.startTime,
                                               dateLocale,
-                                            )}
+                                            )}{" "}
+                                            - {dbToFormTime(b.lesson.endTime)}
                                           </p>
                                         </div>
 


### PR DESCRIPTION
…/students bookings

## Beskrivning

Lagt till slut-tid i bokningskalendern på profilsidan. Ändrat så rätt tider visas i admin/students bokningar.

## Relaterade issues



## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
