### PR TITLE
351 bild på startsidan

### DIFF
--- a/prisma/migrations/20260725182737_image1_2_3_in_startpage/migration.sql
+++ b/prisma/migrations/20260725182737_image1_2_3_in_startpage/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "StartPageContent" ADD COLUMN     "image1" TEXT,
+ADD COLUMN     "image2" TEXT,
+ADD COLUMN     "image3" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -691,6 +691,13 @@ model StartPageContent {
   heroSubtext       String @default("Upplev dansen på ett helt nytt sätt. Vår studio erbjuder kurser för alla åldrar och nivåer med professionella instruktörer.")
   heroSubtext_en      String? @default("Discover dance in a new way. Our studio offers courses for all ages and levels with professional instructors.")
 
+
+  //Image section
+  image1 String?
+  image2 String?
+  image3 String?
+
+
   // Features section header
   featuresTitle   String @default("Varför Motion Zone?")
   featuresTitle_en   String? @default("Why Motion Zone?")

--- a/src/app/(admin)/admin/start/components/StartPageForm.tsx
+++ b/src/app/(admin)/admin/start/components/StartPageForm.tsx
@@ -43,29 +43,35 @@ const IMAGE_FIELDS = [
 ] as const satisfies ReadonlyArray<keyof FormValues>;
 
 async function resolveImageField(
-  current: string,
-  original: string,
+  current: string | undefined,
+  original: string | null | undefined,
 ): Promise<{ url: string; oldUrl: string | null }> {
-  // Case 1: user picked a new file — upload blob and replace
-  if (current.startsWith("blob:")) {
-    const res = await fetch(current);
+  const currentValue = current ?? "";
+  const originalValue = original ?? "";
+
+  // Fall 1: användaren valde en ny fil — ladda upp blob och ersätt
+  if (currentValue.startsWith("blob:")) {
+    const res = await fetch(currentValue);
     const blob = await res.blob();
     const uploaded = await uploadImageFromBlob(blob);
-    URL.revokeObjectURL(current);
-    // Queue old S3 URL for deletion if it changed
+    URL.revokeObjectURL(currentValue);
     const oldUrl =
-      original && original !== uploaded && original.startsWith("http")
-        ? original
+      originalValue &&
+      originalValue !== uploaded &&
+      originalValue.startsWith("http")
+        ? originalValue
         : null;
     return { url: uploaded, oldUrl };
   }
 
-  // Case 2: user cleared the image (reset to a local default path) — delete old S3 object
+  // Fall 2: användaren rensade bilden (eller inget valt) — ta bort gammal S3-bild om den fanns
   const oldUrl =
-    original && original !== current && original.startsWith("http")
-      ? original
+    originalValue &&
+    originalValue !== currentValue &&
+    originalValue.startsWith("http")
+      ? originalValue
       : null;
-  return { url: current, oldUrl };
+  return { url: currentValue, oldUrl };
 }
 
 async function removeOldImage(url: string) {
@@ -132,18 +138,25 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
       feature3Title_en: content.feature3Title_en ?? "",
       feature3Description: content.feature3Description ?? "",
       feature3Description_en: content.feature3Description_en ?? "",
+      image1: content.image1 ?? "",
+      image2: content.image2 ?? "",
+      image3: content.image3 ?? "",
     },
   });
+
+  const OPTIONAL_IMAGE_FIELDS = ["image1", "image2", "image3"] as const;
 
   async function onSubmit(values: FormValues) {
     setIsPending(true);
     try {
-      // Resolve all image fields that are blob URLs
-      const originals: Record<string, string> = {
+      const originals: Record<string, string | null | undefined> = {
         heroImage: content.heroImage,
         feature1Image: content.feature1Image,
         feature2Image: content.feature2Image,
         feature3Image: content.feature3Image,
+        image1: content.image1,
+        image2: content.image2,
+        image3: content.image3,
       };
 
       const resolved = { ...values };
@@ -158,10 +171,18 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
         if (oldUrl) toDelete.push(oldUrl);
       }
 
+      for (const field of OPTIONAL_IMAGE_FIELDS) {
+        const { url, oldUrl } = await resolveImageField(
+          values[field],
+          originals[field],
+        );
+        resolved[field] = url || undefined;
+        if (oldUrl) toDelete.push(oldUrl);
+      }
+
       const result = await updateStartPageContent(resolved);
 
       if (result.success) {
-        // Best-effort cleanup of replaced S3 images
         await Promise.all(toDelete.map(removeOldImage));
         toast.success(result.msg);
         router.refresh();
@@ -326,6 +347,46 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
 
                 {/*  */}
               </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ── Bildsektion ───────────────────────────────────────────────── */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Bildsektion</CardTitle>
+            <FormDescription>
+              Visas som en egen sektion på startsidan, en bild per rad. Valfritt
+              att fylla i — lämna tomt om du inte vill visa någon bild där.
+            </FormDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              {(["image1", "image2", "image3"] as const).map(
+                (fieldName, index) => (
+                  <FormField
+                    key={fieldName}
+                    control={form.control}
+                    name={fieldName}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Bild {index + 1}</FormLabel>
+                        <FormControl>
+                          <ImageInput
+                            previewClassName="h-48 w-full object-cover rounded"
+                            value={field.value ?? ""}
+                            onChange={field.onChange}
+                            onBlur={field.onBlur}
+                            name={field.name}
+                            defaultValue=""
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                ),
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -7,6 +7,7 @@ import prisma from "@/lib/prisma";
 import Events from "./start/Events";
 import Features from "./start/Features";
 import Hero from "./start/Hero";
+import ImageSection from "./start/ImageSection";
 
 const SITE_URL = process.env.SITE_URL ?? "http://localhost:3000";
 
@@ -94,6 +95,7 @@ export default async function Page() {
     <div className="flex-1 bg-background">
       <JsonLd data={[organizationLd, localBusinessLd]} />
       <Hero content={startPageContent} />
+      <ImageSection content={startPageContent} />
       <Features content={startPageContent} />
       <Events events={events} />
       <StudioLocation />

--- a/src/app/(public)/start/Events.tsx
+++ b/src/app/(public)/start/Events.tsx
@@ -6,6 +6,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import Lightbox from "yet-another-react-lightbox";
+import Captions from "yet-another-react-lightbox/plugins/captions";
+import "yet-another-react-lightbox/plugins/captions.css";
+import "yet-another-react-lightbox/styles.css";
 import { Button } from "@/components/ui/button";
 import type { Event } from "@/generated/prisma/client";
 import { formatDateToInputStr } from "@/lib/date-utils";
@@ -32,11 +36,18 @@ const accentGradients = [
   },
 ];
 
+// Captions-pluginet renderar ren text, inte HTML — så vi strippar taggarna
+// från det sanerade TipTap-innehållet innan det skickas till lightboxen.
+function stripHtml(html: string): string {
+  return DOMPurify.sanitize(html, { ALLOWED_TAGS: [] }).trim();
+}
+
 export default function Events({ events }: EventsProps) {
   const { t, i18n } = useTranslation();
   const lang: AppLang = normalizeLang(i18n.language);
   const _dateLocale = lang === "en" ? "en-GB" : "sv-SE";
   const [currentEventIndex, setCurrentEventIndex] = useState(0);
+  const [lightboxOpen, setLightboxOpen] = useState(false);
   const isSameDay = (a: Date, b: Date) =>
     a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
@@ -69,6 +80,32 @@ export default function Events({ events }: EventsProps) {
 
   const currentEvent = events[currentEventIndex];
   const accent = accentGradients[currentEventIndex % accentGradients.length];
+
+  const eventTitle = pick(currentEvent, "headline", lang) as string;
+  const eventDescriptionText = stripHtml(
+    pick(currentEvent, "description", lang) as string,
+  );
+
+  const eventDateText = `${formatDateToInputStr(currentEvent.startDate)}${
+    currentEvent.endDate &&
+    !isSameDay(currentEvent.endDate, currentEvent.startDate)
+      ? ` - ${formatDateToInputStr(currentEvent.endDate)}`
+      : ""
+  }`;
+
+  const eventDescription = [eventDescriptionText, eventDateText]
+    .filter(Boolean)
+    .join(" · ");
+
+  const slides = currentEvent.imageURL
+    ? [
+        {
+          src: currentEvent.imageURL,
+          title: eventTitle,
+          description: eventDescription || undefined,
+        },
+      ]
+    : [];
 
   return (
     <section
@@ -111,16 +148,21 @@ export default function Events({ events }: EventsProps) {
                 <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-white/20 to-transparent z-10" />
 
                 {currentEvent.imageURL && (
-                  <div className="relative overflow-hidden h-52">
+                  <button
+                    type="button"
+                    onClick={() => setLightboxOpen(true)}
+                    className="relative overflow-hidden h-52 w-full cursor-zoom-in"
+                    aria-label="Visa bilden i full storlek"
+                  >
                     <Image
                       src={currentEvent.imageURL}
-                      alt={pick(currentEvent, "headline", lang) as string}
+                      alt={eventTitle}
                       width={500}
                       height={300}
                       className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-110"
                     />
                     <div className="absolute inset-0 bg-linear-to-t from-slate-900/80 via-transparent to-transparent opacity-60" />
-                  </div>
+                  </button>
                 )}
 
                 <div className="p-6 relative space-y-4">
@@ -130,7 +172,7 @@ export default function Events({ events }: EventsProps) {
                   />
 
                   <h3 className="text-xl font-bold text-foreground">
-                    {pick(currentEvent, "headline", lang) as string}
+                    {eventTitle}
                   </h3>
 
                   <div className="text-muted-foreground text-sm leading-relaxed">
@@ -202,6 +244,14 @@ export default function Events({ events }: EventsProps) {
           )}
         </div>
       </div>
+
+      <Lightbox
+        open={lightboxOpen}
+        close={() => setLightboxOpen(false)}
+        slides={slides}
+        plugins={[Captions]}
+        captions={{ descriptionTextAlign: "center", descriptionMaxLines: 3 }}
+      />
     </section>
   );
 }

--- a/src/app/(public)/start/ImageSection.tsx
+++ b/src/app/(public)/start/ImageSection.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import Lightbox from "yet-another-react-lightbox";
+import "yet-another-react-lightbox/styles.css";
+import type { StartPageContent } from "@/generated/prisma/client";
+
+type ImageSectionProps = {
+  content: StartPageContent;
+};
+
+const cardAccents = [
+  {
+    accentVar: "var(--color-brand)",
+    accentGradient: "from-violet-600 via-brand to-brand-secondary",
+  },
+  {
+    accentVar: "var(--color-brand-secondary)",
+    accentGradient: "from-cyan-500 via-brand-secondary to-blue-600",
+  },
+  {
+    accentVar: "var(--color-brand)",
+    accentGradient: "from-brand-secondary via-purple-500 to-brand",
+  },
+] as const;
+
+export default function ImageSection({ content }: ImageSectionProps) {
+  const images = [content.image1, content.image2, content.image3].filter(
+    (src): src is string => Boolean(src),
+  );
+
+  const [lightboxIndex, setLightboxIndex] = useState(-1);
+
+  if (images.length === 0) return null;
+
+  const slides = images.map((src) => ({ src }));
+
+  return (
+    <>
+      <section
+        className="py-14 md:py-20 relative overflow-hidden"
+        style={{ background: "var(--background)" }}
+      >
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute top-1/3 left-1/3 w-96 h-96 rounded-full bg-brand/5 blur-[120px]" />
+          <div className="absolute bottom-1/4 right-1/3 w-96 h-96 rounded-full bg-brand-secondary/5 blur-[120px]" />
+        </div>
+
+        <div className="max-w-4xl mx-auto px-6 md:px-12 relative z-10 space-y-10">
+          {images.map((src, index) => {
+            const accent = cardAccents[index % cardAccents.length];
+            return (
+              <div key={src} className="group relative">
+                <div
+                  className={`absolute -inset-1 bg-linear-to-r ${accent.accentGradient} rounded-2xl blur-lg opacity-20 group-hover:opacity-50 transition duration-500`}
+                />
+
+                <button
+                  type="button"
+                  onClick={() => setLightboxIndex(index)}
+                  className="relative w-full text-left backdrop-blur-xl bg-card/60 border border-white/10 rounded-2xl shadow-2xl overflow-hidden transform transition-all duration-500 group-hover:scale-[1.01] cursor-zoom-in"
+                  aria-label="Visa bilden i full storlek"
+                >
+                  <div className="relative w-full aspect-[16/10] md:aspect-[16/9]">
+                    <Image
+                      src={src}
+                      alt=""
+                      fill
+                      sizes="(max-width: 768px) 100vw, 768px"
+                      className="object-cover transition-transform duration-700 group-hover:scale-105"
+                    />
+                    <div className="absolute inset-0 bg-linear-to-t from-slate-900/40 via-transparent to-transparent" />
+                  </div>
+
+                  <div className="absolute top-0 left-0 right-0 h-px bg-linear-to-r from-transparent via-white/20 to-transparent" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <Lightbox
+        open={lightboxIndex >= 0}
+        close={() => setLightboxIndex(-1)}
+        index={lightboxIndex}
+        slides={slides}
+      />
+    </>
+  );
+}

--- a/src/lib/actions/start-page-actions.ts
+++ b/src/lib/actions/start-page-actions.ts
@@ -59,6 +59,11 @@ const defaults: Omit<StartPageContent, "updatedAt"> = {
 
   feature3Title_en: "Modern studios",
   feature3Description_en: "Our studios have great sound for music and mirrors.",
+
+  // Image section (NYTT)
+  image1: null,
+  image2: null,
+  image3: null,
 };
 
 export async function getStartPageContent(): Promise<StartPageContent> {

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -293,4 +293,9 @@ export const adminStartPageSchema = z.object({
   feature2Description_en: z.string().min(1, "Beskrivning måste anges."),
   feature3Title_en: z.string().min(1, "Titel måste anges."),
   feature3Description_en: z.string().min(1, "Beskrivning måste anges."),
+
+  // Image section (NYTT)
+  image1: z.string().optional(),
+  image2: z.string().optional(),
+  image3: z.string().optional(),
 });


### PR DESCRIPTION
## Beskrivning

Lägger in möjligheten att lägga till 3st bilder på startsidan via admin/startsida, med liknande style som de andra och med lightbox.
Lägger också in lightbox i events på startsidan.

## Relaterade issues

Closes #352 
Closes #351 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
