### PR TITLE
373 paket produkter

### DIFF
--- a/prisma/migrations/20260801174756_order_item_course_selection_and_autobook_max_courses_in_product/migration.sql
+++ b/prisma/migrations/20260801174756_order_item_course_selection_and_autobook_max_courses_in_product/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable
+ALTER TABLE "product" ADD COLUMN     "autobook" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "maxCourses" INTEGER;
+
+-- CreateTable
+CREATE TABLE "order_item_course_selection" (
+    "id" TEXT NOT NULL,
+    "orderItemId" TEXT NOT NULL,
+    "courseId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_item_course_selection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "order_item_course_selection_orderItemId_courseId_key" ON "order_item_course_selection"("orderItemId", "courseId");
+
+-- AddForeignKey
+ALTER TABLE "order_item_course_selection" ADD CONSTRAINT "order_item_course_selection_orderItemId_fkey" FOREIGN KEY ("orderItemId") REFERENCES "order_item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_item_course_selection" ADD CONSTRAINT "order_item_course_selection_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -293,7 +293,7 @@ model Product {
   courses ProductOnCourse[] // Här specificeras varje kurs och hur många tillfällen som man får tillgång till när man köper en produkt. Om klippkort sätts count till 0.
 
   expireFixedDate        DateTime? // Om den ska ha ett sista datum.
-  expireDaysFromPurchase Int? // Om det ska gälla en viss tid. Då kan expireDate
+  expireDaysFromPurchase Int? // Om det ska gälla en viss tid.
 
   type       ProductType @default(COURSE)
   // useTotalCount Boolean @default(false) // Tagit bort useTotalCount nu när type-logiken är fullt migrerad.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -241,6 +241,10 @@ model Course {
 
   purchaseItems PurchaseItem[]
 
+  orderItemsSelections OrderItemCourseSelection[]
+
+
+
   // terminId String? 
   // termin Termin? @relation(fields: [terminId], references: [id], onDelete: SetNull)
   // Detta är om man bara ska kunna ha en kurs på en termin.
@@ -309,7 +313,9 @@ model Product {
 
   imageURL String?
 
+  autobook Boolean @default(false) // Om kunden automatiskt ska bokas in eller inte (ej för klippkort eller paket med maxCourses)
 
+  maxCourses Int? // För paket där kunden får välja ur ett urval (urvalet är productOnCourse). Null är obegränsat och då kan kunden boka in sig på alla kurser som är kopplade viaa productOnCourse
 
   active Boolean @default(true) // Om produkten är aktiv (synlig för kunder)
 
@@ -443,6 +449,8 @@ model OrderItem {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  courseSelections OrderItemCourseSelection[]
+
   @@index([orderId])
   @@index([productId])
   @@index([participantId])
@@ -477,6 +485,23 @@ model Order {
   @@index([userId])
   @@map("order")
 }
+
+model OrderItemCourseSelection {
+  id          String    @id @default(uuid())
+
+  orderItemId String
+  orderItem   OrderItem @relation(fields: [orderItemId], references: [id], onDelete: Cascade)
+
+  courseId    String
+  course      Course    @relation(fields: [courseId], references: [id])
+
+  createdAt   DateTime  @default(now())
+
+  @@unique([orderItemId, courseId])
+  @@map("order_item_course_selection")
+}
+
+
 
 model Event {
   id String @id @default(uuid())

--- a/src/app/(admin)/admin/orders/OrdersView.tsx
+++ b/src/app/(admin)/admin/orders/OrdersView.tsx
@@ -11,6 +11,7 @@ import { formatPrice } from "@/lib/money";
 import { getOrderStatusLabel, type OrderStatus } from "@/lib/order-status";
 import { getPayMethodTxt } from "@/lib/tools";
 import DeleteOrderBtn from "./components/DeleteOrderBtn";
+import { OrderPackageDialog } from "./components/OrderPackageEditor";
 
 type OrderLite = {
   id: string;
@@ -26,13 +27,24 @@ type OrderLite = {
   orderItems?:
     | {
         id?: string;
-        product: { name: string };
+        product: {
+          name: string;
+          maxCourses?: number | null;
+          courses?:
+            | {
+                courseId: string;
+                courseName?: string | null;
+                course?: { id: string; name: string } | null;
+              }[]
+            | null;
+        };
         participant?: {
           id: string;
           dateOfBirth: string | Date | null;
           email: string;
           name: string;
         } | null;
+        courseSelections?: { course: { id: string; name: string } }[] | null;
       }[]
     | null;
   totalPrice: unknown;
@@ -50,6 +62,7 @@ export default function OrdersView({
   onMarkPaid,
   onCancel,
   onDelete,
+  onSavePackage,
 }: {
   orders: OrderLite[];
   defaultStatus: string;
@@ -58,6 +71,10 @@ export default function OrdersView({
   onMarkPaid: (formData: FormData) => void;
   onCancel: (formData: FormData) => void;
   onDelete: (orderId: string) => boolean | Promise<boolean>;
+  onSavePackage: (
+    orderItemId: string,
+    selectedCourseIds: string[],
+  ) => Promise<{ success: boolean }> | { success: boolean };
 }) {
   const sp = useSearchParams();
   const active = (sp.get("status")?.toUpperCase() || defaultStatus).toString();
@@ -239,6 +256,7 @@ export default function OrdersView({
               <th className="p-3 text-left font-medium">Beställare</th>
               <th className="p-3 text-left font-medium">Deltagare</th>
               <th className="p-3 text-left font-medium">Produkter</th>
+              <th className="p-3 text-left font-medium">Paket</th>
               <th className="p-3 text-left font-medium">Total</th>
               <th className="p-3 text-left font-medium">Status</th>
               <th className="p-3 text-left font-medium">
@@ -337,6 +355,80 @@ export default function OrdersView({
                           + {(o.orderItems?.length || 0) - 2} till...
                         </span>
                       )}
+                    </div>
+                  </td>
+                  <td className="p-3">
+                    <div className="flex flex-col gap-1 max-w-[260px]">
+                      {(o.orderItems ?? []).flatMap((oi) => {
+                        const courseOptions =
+                          oi.product.courses?.map((link) => ({
+                            courseId: link.courseId,
+                            courseName:
+                              link.courseName ??
+                              link.course?.name ??
+                              "Okänd kurs",
+                          })) ?? [];
+                        const selections =
+                          oi.courseSelections
+                            ?.map((sel) => sel.course.name)
+                            .filter(Boolean) ?? [];
+
+                        if (
+                          oi.product.maxCourses == null ||
+                          courseOptions.length === 0
+                        ) {
+                          return [
+                            <span
+                              key={`${oi.id}-empty`}
+                              className="text-[11px] text-muted-foreground italic"
+                            >
+                              {oi.product.maxCourses != null
+                                ? "Inga paketval tillgängliga"
+                                : "—"}
+                            </span>,
+                          ];
+                        }
+
+                        const selectedIds =
+                          oi.courseSelections?.map((sel) => sel.course.id) ??
+                          [];
+                        const canEdit = o.status !== "APPROVED";
+
+                        return [
+                          <div
+                            key={`${oi.id}-pack`}
+                            className="flex flex-col gap-1.5 rounded-md border bg-muted/30 p-2"
+                          >
+                            {selections.length === 0 ? (
+                              <span className="text-[11px] text-muted-foreground italic">
+                                Inga paketval sparade
+                              </span>
+                            ) : (
+                              selections.map((courseName) => (
+                                <span
+                                  key={`${oi.id}-${courseName}`}
+                                  className="truncate text-[11px]"
+                                >
+                                  {courseName}
+                                </span>
+                              ))
+                            )}
+                            <OrderPackageDialog
+                              orderItemId={oi.id ?? ""}
+                              productName={oi.product.name}
+                              maxCourses={oi.product.maxCourses}
+                              courses={courseOptions}
+                              selected={selectedIds}
+                              onSave={async (orderItemId, next) => {
+                                await onSavePackage(orderItemId, next);
+                              }}
+                              disabled={!canEdit}
+                              readOnlyMessage="Paketvalet går inte att ändra när ordern är godkänd."
+                              triggerLabel="Ändra paket"
+                            />
+                          </div>,
+                        ];
+                      })}
                     </div>
                   </td>
                   <td className="p-3 font-semibold">

--- a/src/app/(admin)/admin/orders/OrdersView.tsx
+++ b/src/app/(admin)/admin/orders/OrdersView.tsx
@@ -2,8 +2,9 @@
 
 import { CheckIcon, DollarSignIcon, XIcon } from "lucide-react";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
 import { PaginationBar } from "@/components/PaginationBar";
 import { Button } from "@/components/ui/button";
 import { calculateAge, formatDateToInputStr } from "@/lib/date-utils";
@@ -76,8 +77,11 @@ export default function OrdersView({
     selectedCourseIds: string[],
   ) => Promise<{ success: boolean }> | { success: boolean };
 }) {
+  const router = useRouter();
   const sp = useSearchParams();
   const active = (sp.get("status")?.toUpperCase() || defaultStatus).toString();
+  const [approvingOrderId, setApprovingOrderId] = useState<string | null>(null);
+  const [_, startTransition] = useTransition();
   const searchInput = sp.get("q")?.toLowerCase() || "";
   const participantId = sp.get("participantId") || "";
   const requestedPage = Math.max(1, Number(sp.get("page")) || 1);
@@ -174,6 +178,25 @@ export default function OrdersView({
   ];
 
   const getStatusLabel = (status: string) => getOrderStatusLabel(status);
+
+  const handleApprove = async (orderId: string) => {
+    const formData = new FormData();
+    formData.set("orderId", orderId);
+
+    setApprovingOrderId(orderId);
+
+    try {
+      await onApprove(formData);
+      router.refresh();
+    } catch (error) {
+      const message =
+        (error as { message?: string })?.message ||
+        "Kunde inte godkänna ordern.";
+      toast.error(message);
+    } finally {
+      setApprovingOrderId(null);
+    }
+  };
 
   const getStatusStyles = (status: string) => {
     switch (status) {
@@ -457,21 +480,22 @@ export default function OrdersView({
                       <div className="flex items-center gap-1.5">
                         {active !== "PENDING" &&
                           ["PAID"].includes(o.status || "") && (
-                            <form action={onApprove}>
-                              <input
-                                type="hidden"
-                                name="orderId"
-                                value={o.id}
-                              />
-                              <Button
-                                type="submit"
-                                size="sm"
-                                className="h-7 px-2.5 text-xs gap-1 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 shadow-none"
-                              >
-                                <CheckIcon className="h-3.5 w-3.5" />
-                                Godkänn
-                              </Button>
-                            </form>
+                            <Button
+                              type="button"
+                              size="sm"
+                              className="h-7 px-2.5 text-xs gap-1 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 shadow-none"
+                              disabled={approvingOrderId === o.id}
+                              onClick={() => {
+                                startTransition(() => {
+                                  void handleApprove(o.id);
+                                });
+                              }}
+                            >
+                              <CheckIcon className="h-3.5 w-3.5" />
+                              {approvingOrderId === o.id
+                                ? "Godkänner…"
+                                : "Godkänn"}
+                            </Button>
                           )}
 
                         {active !== "APPROVED" &&

--- a/src/app/(admin)/admin/orders/components/OrderPackageEditor.tsx
+++ b/src/app/(admin)/admin/orders/components/OrderPackageEditor.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { SelectPack } from "@/app/(public)/checkout/components/SelectPack";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+type CourseOption = {
+  courseId: string;
+  courseName: string;
+};
+
+type OrderPackageEditorProps = {
+  orderItemId: string;
+  productName: string;
+  maxCourses: number;
+  courses: CourseOption[];
+  selected: string[];
+  onSave: (orderItemId: string, selected: string[]) => Promise<void> | void;
+  isSaving?: boolean;
+  disabled?: boolean;
+  readOnlyMessage?: string;
+};
+
+export function OrderPackageEditor({
+  orderItemId,
+  productName,
+  maxCourses,
+  courses,
+  selected,
+  onSave,
+  isSaving = false,
+  disabled = false,
+  readOnlyMessage,
+}: OrderPackageEditorProps) {
+  const [draft, setDraft] = useState<string[]>(selected);
+
+  useEffect(() => {
+    setDraft(selected);
+  }, [selected]);
+
+  const handleSave = async () => {
+    await onSave(orderItemId, draft);
+  };
+
+  if (courses.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Paketval
+      </div>
+      {disabled ? (
+        <p className="text-xs text-muted-foreground">
+          {readOnlyMessage || `Paketet kan inte ändras för ${productName}.`}
+        </p>
+      ) : (
+        <>
+          <SelectPack
+            maxCourses={maxCourses}
+            courses={courses}
+            selected={draft}
+            onChange={setDraft}
+          />
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleSave}
+            disabled={isSaving}
+          >
+            {isSaving ? "Sparar…" : "Spara paketval"}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}
+
+type OrderPackageDialogProps = OrderPackageEditorProps & {
+  triggerLabel?: string;
+  triggerVariant?: "outline" | "secondary" | "ghost";
+};
+
+export function OrderPackageDialog({
+  orderItemId,
+  productName,
+  maxCourses,
+  courses,
+  selected,
+  onSave,
+  isSaving = false,
+  disabled = false,
+  readOnlyMessage,
+  triggerLabel = "Ändra paket",
+  triggerVariant = "outline",
+}: OrderPackageDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleSave = async (itemId: string, next: string[]) => {
+    await onSave(itemId, next);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant={triggerVariant}
+          size="sm"
+          className="h-7 px-2.5 text-xs"
+          disabled={disabled}
+        >
+          {disabled ? "Låst" : triggerLabel}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{productName}</DialogTitle>
+          <DialogDescription>
+            Välj {maxCourses} {maxCourses === 1 ? "kurs" : "kurser"} för detta
+            paket.
+          </DialogDescription>
+        </DialogHeader>
+        <OrderPackageEditor
+          orderItemId={orderItemId}
+          productName={productName}
+          maxCourses={maxCourses}
+          courses={courses}
+          selected={selected}
+          onSave={handleSave}
+          isSaving={isSaving}
+          disabled={disabled}
+          readOnlyMessage={readOnlyMessage}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -7,6 +7,7 @@ import {
   createPurchaseFromOrder,
   deleteOrder,
   markOrderPaid,
+  updateOrderItemCourseSelections,
 } from "@/lib/actions/orders";
 import prisma from "@/lib/prisma";
 import OrdersView from "./OrdersView";
@@ -32,13 +33,28 @@ type OrderLite = {
   orderItems?:
     | {
         id?: string;
-        product: { name: string };
+        product: {
+          name: string;
+          maxCourses?: number | null;
+          courses?:
+            | {
+                courseId: string;
+                courseName?: string | null;
+                course?: { id: string; name: string } | null;
+              }[]
+            | null;
+        };
         participant?: {
           id: string;
           name: string;
           email: string;
           dateOfBirth: string | Date | null;
         } | null;
+        courseSelections?:
+          | {
+              course: { id: string; name: string };
+            }[]
+          | null;
       }[]
     | null;
   totalPrice: unknown;
@@ -55,7 +71,21 @@ async function getOrders(): Promise<OrderLite[]> {
     orderBy: [{ createdAt: "desc" }],
     include: {
       user: { include: { details: true } },
-      orderItems: { include: { product: true, participant: true } },
+      orderItems: {
+        include: {
+          product: {
+            include: {
+              courses: {
+                include: { course: { select: { id: true, name: true } } },
+              },
+            },
+          },
+          participant: true,
+          courseSelections: {
+            include: { course: { select: { id: true, name: true } } },
+          },
+        },
+      },
     },
   })) as unknown as OrderLite[];
   return orders;
@@ -119,6 +149,22 @@ export default async function Page({
     return res.success;
   }
 
+  async function onSavePackage(
+    orderItemId: string,
+    selectedCourseIds: string[],
+  ): Promise<{ success: boolean }> {
+    "use server";
+
+    const result = await updateOrderItemCourseSelections(
+      orderItemId,
+      selectedCourseIds,
+    );
+    revalidatePath("/admin/orders");
+    revalidatePath("/admin/orders/view");
+
+    return { success: result.success };
+  }
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Ordrar</h1>
@@ -130,6 +176,7 @@ export default async function Page({
         onMarkPaid={onMarkPaid}
         onCancel={onCancel}
         onDelete={onDelete}
+        onSavePackage={onSavePackage}
       />
     </div>
   );

--- a/src/app/(admin)/admin/orders/view/view-client.tsx
+++ b/src/app/(admin)/admin/orders/view/view-client.tsx
@@ -4,7 +4,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState, useTransition } from "react";
-import { adminGetOrder, deleteOrder } from "@/lib/actions/orders";
+import { OrderPackageEditor } from "@/app/(admin)/admin/orders/components/OrderPackageEditor";
+import {
+  adminGetOrder,
+  deleteOrder,
+  updateOrderItemCourseSelections,
+} from "@/lib/actions/orders";
 import {
   formatDateToInputStr,
   formatLongFriendlyDateTime,
@@ -19,7 +24,17 @@ type OrderItemLite = {
   price: unknown;
   count: number;
   productId: string;
-  product?: { name?: string | null } | null;
+  product?: {
+    name?: string | null;
+    maxCourses?: number | null;
+    courses?:
+      | {
+          courseId: string;
+          courseName?: string | null;
+          course?: { name?: string | null } | null;
+        }[]
+      | null;
+  } | null;
   participant?: {
     name: string;
     email?: string | null;
@@ -27,6 +42,11 @@ type OrderItemLite = {
     phone?: string | null;
     allowPhotoVideo: boolean;
   } | null;
+  courseSelections?:
+    | {
+        course: { id: string; name: string };
+      }[]
+    | null;
 };
 
 type StatusEventLite = {
@@ -103,6 +123,11 @@ export default function OrderDetailsClient() {
   const [order, setOrder] = useState<OrderDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [packageSelections, setPackageSelections] = useState<
+    Record<string, string[]>
+  >({});
+  const [savingItemId, setSavingItemId] = useState<string | null>(null);
+  const [packageError, setPackageError] = useState<string | null>(null);
   const [_isPending, startTransition] = useTransition();
 
   const handleDelete = async () => {
@@ -131,6 +156,14 @@ export default function OrderDetailsClient() {
       try {
         const data = await adminGetOrder(orderId);
         setOrder(data);
+        setPackageSelections(
+          Object.fromEntries(
+            (data?.orderItems ?? []).map((it) => [
+              it.id,
+              (it.courseSelections ?? []).map((sel) => sel.course.id),
+            ]),
+          ),
+        );
         setError(null);
       } catch (e) {
         const msg =
@@ -139,6 +172,44 @@ export default function OrderDetailsClient() {
       }
     });
   }, [orderId]);
+
+  const handleSavePackage = async (
+    orderItemId: string,
+    selectedOverride?: string[],
+  ) => {
+    const selected = selectedOverride ?? packageSelections[orderItemId] ?? [];
+    setSavingItemId(orderItemId);
+    setPackageError(null);
+
+    try {
+      const result = await updateOrderItemCourseSelections(
+        orderItemId,
+        selected,
+      );
+
+      if (!result.success) {
+        throw new Error("Kunde inte spara paketvalet.");
+      }
+
+      const data = await adminGetOrder(orderId);
+      setOrder(data);
+      setPackageSelections(
+        Object.fromEntries(
+          (data?.orderItems ?? []).map((it) => [
+            it.id,
+            (it.courseSelections ?? []).map((sel) => sel.course.id),
+          ]),
+        ),
+      );
+    } catch (e) {
+      const msg =
+        (e as { message?: string })?.message ||
+        "Kunde inte uppdatera paketval.";
+      setPackageError(msg);
+    } finally {
+      setSavingItemId(null);
+    }
+  };
 
   if (!orderId) {
     return (
@@ -430,6 +501,13 @@ export default function OrderDetailsClient() {
               {(order.orderItems || []).map((it) => {
                 const unit = Number(it.price ?? 0);
                 const sum = unit * (it.count ?? 0);
+                const packCourses =
+                  it.product?.courses?.map((course) => ({
+                    courseId: course.courseId,
+                    courseName:
+                      course.courseName ?? course.course?.name ?? "Okänd kurs",
+                  })) ?? [];
+                const selectedPack = packageSelections[it.id] ?? [];
                 return (
                   <tr key={it.id} className="hover:bg-muted/30">
                     <td className="px-4 py-3">
@@ -461,6 +539,28 @@ export default function OrderDetailsClient() {
                             Kund själv
                           </span>
                         )}
+                        {it.product?.maxCourses != null &&
+                          packCourses.length > 0 && (
+                            <div className="mt-3 space-y-2 rounded-md border bg-muted/30 p-2">
+                              <OrderPackageEditor
+                                orderItemId={it.id}
+                                productName={it.product?.name ?? it.productId}
+                                maxCourses={it.product.maxCourses}
+                                courses={packCourses}
+                                selected={selectedPack}
+                                onSave={async (orderItemId, next) => {
+                                  setPackageSelections((prev) => ({
+                                    ...prev,
+                                    [orderItemId]: next,
+                                  }));
+                                  await handleSavePackage(orderItemId, next);
+                                }}
+                                isSaving={savingItemId === it.id}
+                                disabled={order.status === "APPROVED"}
+                                readOnlyMessage="Paketvalet går inte att ändra för en godkänd order."
+                              />
+                            </div>
+                          )}
                       </div>
                     </td>
                     <td className="px-4 py-3 text-right">
@@ -489,6 +589,12 @@ export default function OrderDetailsClient() {
       </div>
 
       {/* Status History */}
+      {packageError && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {packageError}
+        </div>
+      )}
+
       <div className="bg-card border rounded-lg shadow-sm overflow-hidden">
         <div className="bg-muted/50 px-4 py-3 border-b">
           <h2 className="font-semibold">Statushistorik & Logg</h2>

--- a/src/app/(admin)/admin/products/components/AddProductForm.tsx
+++ b/src/app/(admin)/admin/products/components/AddProductForm.tsx
@@ -295,7 +295,13 @@ export default function AddProductForm({
                   control={form.control}
                   name="maxCustomers"
                   render={({ field }) => (
-                    <FormItem>
+                    <FormItem
+                      className={
+                        form.watch("unlimitedCustomers") === true
+                          ? "hidden"
+                          : ""
+                      }
+                    >
                       <FormLabel>Max antal kunder:</FormLabel>
 
                       <FormControl>
@@ -358,7 +364,7 @@ export default function AddProductForm({
                         <Input
                           disabled={form.watch("clipcard") === false}
                           type="number"
-                          min="0"
+                          min="1"
                           step="1"
                           {...field}
                           value={
@@ -368,6 +374,10 @@ export default function AddProductForm({
                                 ? ""
                                 : String(field.value)
                           }
+                          onChange={(e) => {
+                            const parsed = Number(e.target.value);
+                            field.onChange(Number.isNaN(parsed) ? 1 : parsed);
+                          }}
                         />
                       </FormControl>
 

--- a/src/app/(admin)/admin/products/components/AddProductForm.tsx
+++ b/src/app/(admin)/admin/products/components/AddProductForm.tsx
@@ -71,6 +71,8 @@ export default function AddProductForm({
       unlimitedCustomers: true,
       maxCustomers: 1,
       categoryId: "",
+      autobook: false,
+      maxCourses: null,
     },
   });
 
@@ -101,10 +103,18 @@ export default function AddProductForm({
       }
     }
 
+    const normalizedMaxCourses =
+      typeof values.maxCourses === "number" &&
+      Number.isFinite(values.maxCourses) &&
+      values.maxCourses >= 1
+        ? Math.trunc(values.maxCourses)
+        : null;
+
     const payload = await formSchema.parseAsync({
       ...values,
       imageURL: finalImageURL,
       maxCustomers: values.unlimitedCustomers ? 0 : values.maxCustomers,
+      maxCourses: normalizedMaxCourses,
     });
 
     const res = await addNewProduct(payload);
@@ -116,6 +126,14 @@ export default function AddProductForm({
       toast.error(res.msg);
     }
   }
+
+  const clipcard = form.watch("clipcard");
+
+  useEffect(() => {
+    if (clipcard) {
+      form.setValue("autobook", false);
+    }
+  }, [clipcard, form.setValue]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
@@ -356,6 +374,75 @@ export default function AddProductForm({
                       <FormMessage />
                     </FormItem>
                   )}
+                />
+                <FormField
+                  control={form.control}
+                  name="autobook"
+                  render={({ field }) => (
+                    <FormItem
+                      className={form.watch("clipcard") ? "hidden" : ""}
+                    >
+                      <FormLabel>Autobokning</FormLabel>
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(
+                              checked === true && !form.watch("clipcard"),
+                            )
+                          }
+                          className="w-6 h-6"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="maxCourses"
+                  render={({ field }) => {
+                    const limitEnabled =
+                      field.value !== null && field.value !== undefined;
+
+                    return (
+                      <FormItem>
+                        <FormLabel>Begränsa antal valbara kurser</FormLabel>
+
+                        <div className="flex items-center gap-2 mb-2">
+                          <Checkbox
+                            checked={limitEnabled}
+                            onCheckedChange={(checked) => {
+                              if (checked === true) {
+                                field.onChange(1);
+                              } else {
+                                field.onChange(null); // Nollställ direkt, inte bara vid submit
+                              }
+                            }}
+                            className="w-6 h-6"
+                          />
+                          <span className="text-sm">Begränsa till:</span>
+                        </div>
+
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min="1"
+                            step="1"
+                            disabled={!limitEnabled}
+                            value={limitEnabled ? String(field.value) : ""}
+                            onChange={(e) => {
+                              const parsed = Number(e.target.value);
+                              field.onChange(Number.isNaN(parsed) ? 1 : parsed);
+                            }}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
                 />
 
                 {isBusy ? (

--- a/src/app/(admin)/admin/products/components/EditProductForm.tsx
+++ b/src/app/(admin)/admin/products/components/EditProductForm.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-/// JAG HÅLLER PÅ MED DETTA FORMULÄR SNART KLAR. fix.
-
 import { zodResolver } from "@hookform/resolvers/zod";
 import { DialogDescription } from "@radix-ui/react-dialog";
 import { Pencil, Save, X } from "lucide-react";
@@ -69,6 +67,8 @@ interface Props {
   initialLang?: "sv" | "en";
   categories: Category[];
   categoryId?: string;
+  autobook: boolean;
+  maxCourses: number | null;
 }
 
 export default function EditProductForm({
@@ -86,6 +86,8 @@ export default function EditProductForm({
   initialLang = "sv",
   categories,
   categoryId,
+  autobook,
+  maxCourses,
 }: Props) {
   const id = useId();
   const form = useForm<EditProductFormInput, unknown, EditProductFormOutput>({
@@ -103,6 +105,8 @@ export default function EditProductForm({
       maxCustomers: maxCustomers,
       categoryId: categoryId || undefined,
       imageURL: imageURL,
+      autobook: autobook,
+      maxCourses: maxCourses,
     },
   });
 
@@ -127,6 +131,8 @@ export default function EditProductForm({
       categoryId,
       maxCustomers,
       imageURL,
+      autobook,
+      maxCourses,
     });
   }, [
     isOpen,
@@ -142,9 +148,21 @@ export default function EditProductForm({
     clipCount,
     maxCustomers,
     imageURL,
+    autobook,
+    maxCourses,
   ]);
 
   const [formLang, setFormLang] = useState(initialLang);
+
+  const watchedClipcard = form.watch("clipcard");
+
+  // Klippkort och autobokning är ömsesidigt uteslutande.
+  // maxCourses ska INTE nollställas här - ett klippkort kan ha maxCourses.
+  useEffect(() => {
+    if (watchedClipcard) {
+      form.setValue("autobook", false);
+    }
+  }, [watchedClipcard, form.setValue]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const oldImageUrl = imageURL;
@@ -166,10 +184,18 @@ export default function EditProductForm({
 
     const stats = await getProductStats(productId);
 
+    const normalizedMaxCourses =
+      typeof values.maxCourses === "number" &&
+      Number.isFinite(values.maxCourses) &&
+      values.maxCourses >= 1
+        ? Math.trunc(values.maxCourses)
+        : null;
+
     const payload = await formSchema.parseAsync({
       ...values,
       imageURL: finalImageURL,
       maxCustomers: values.unlimitedCustomers ? 0 : values.maxCustomers,
+      maxCourses: normalizedMaxCourses,
     });
 
     if (!payload.unlimitedCustomers) {
@@ -188,6 +214,7 @@ export default function EditProductForm({
     }
 
     const res = await editProduct(productId, payload);
+
     if (res.success) {
       if (!!oldImageUrl && finalImageURL !== oldImageUrl) {
         // Ta bort gamla
@@ -374,7 +401,13 @@ export default function EditProductForm({
                   control={form.control}
                   name="maxCustomers"
                   render={({ field }) => (
-                    <FormItem>
+                    <FormItem
+                      className={
+                        form.watch("unlimitedCustomers") === true
+                          ? "hidden"
+                          : ""
+                      }
+                    >
                       <FormLabel>Max antal kunder:</FormLabel>
 
                       <FormControl>
@@ -436,7 +469,7 @@ export default function EditProductForm({
                         <Input
                           disabled={form.watch("clipcard") === false}
                           type="number"
-                          min="0"
+                          min="1"
                           step="1"
                           {...field}
                           value={
@@ -446,12 +479,86 @@ export default function EditProductForm({
                                 ? ""
                                 : String(field.value)
                           }
+                          onChange={(e) => {
+                            const parsed = Number(e.target.value);
+                            field.onChange(Number.isNaN(parsed) ? 1 : parsed);
+                          }}
                         />
                       </FormControl>
 
                       <FormMessage />
                     </FormItem>
                   )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="autobook"
+                  render={({ field }) => (
+                    <FormItem
+                      className={form.watch("clipcard") ? "hidden" : ""}
+                    >
+                      <FormLabel>Autobokning</FormLabel>
+                      <FormControl>
+                        <Checkbox
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(
+                              checked === true && !form.watch("clipcard"),
+                            )
+                          }
+                          className="w-6 h-6"
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="maxCourses"
+                  render={({ field }) => {
+                    const limitEnabled =
+                      field.value !== null && field.value !== undefined;
+
+                    return (
+                      <FormItem>
+                        <FormLabel>Begränsa antal valbara kurser</FormLabel>
+
+                        <div className="flex items-center gap-2 mb-2">
+                          <Checkbox
+                            checked={limitEnabled}
+                            onCheckedChange={(checked) => {
+                              if (checked === true) {
+                                field.onChange(1);
+                              } else {
+                                field.onChange(null);
+                              }
+                            }}
+                            className="w-6 h-6"
+                          />
+                          <span className="text-sm">Begränsa till:</span>
+                        </div>
+
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min="1"
+                            step="1"
+                            disabled={!limitEnabled}
+                            value={limitEnabled ? String(field.value) : ""}
+                            onChange={(e) => {
+                              const parsed = Number(e.target.value);
+                              field.onChange(Number.isNaN(parsed) ? 1 : parsed);
+                            }}
+                          />
+                        </FormControl>
+
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
                 />
 
                 {isBusy ? (

--- a/src/app/(admin)/admin/products/components/ProductItem.tsx
+++ b/src/app/(admin)/admin/products/components/ProductItem.tsx
@@ -74,7 +74,10 @@ export default async function ProductItem({ product, lang }: Props) {
             active={product.active}
           />
           <EditProductForm
+            initialLang={lang}
             categories={categories}
+            autobook={product.autobook ?? false}
+            maxCourses={product.maxCourses ?? null}
             categoryId={product.categoryId ?? ""}
             imageURL={product.imageURL ?? ""}
             unlimitedCustomers={product.unlimitedCustomers ?? false}

--- a/src/app/(public)/checkout/CheckoutForm.tsx
+++ b/src/app/(public)/checkout/CheckoutForm.tsx
@@ -30,19 +30,24 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import type { Product } from "@/generated/prisma/client";
 import { createCheckout } from "@/lib/actions/checkout";
 import {
   getOrCreateParticipant,
   type ParticipantData,
 } from "@/lib/actions/participants";
 import { formatDateToInputStr } from "@/lib/date-utils";
+import { SelectPack } from "./components/SelectPack";
 
-type CheckoutFormProps = {
+export type CheckoutFormProps = {
   items: {
+    product: Product;
     productId: string;
     name: string;
     qty: number;
     price: number;
+    /** Available courses for SelectPack (populated when maxCourses is set) */
+    courses: { courseId: string; courseName: string }[];
   }[];
   user: {
     id: string;
@@ -101,6 +106,19 @@ export default function CheckoutForm({
       flattenedItems.map((_, idx) => [
         `slot-${idx}`,
         { isSelf: idx === 0 }, // Default only THE first item in cart to self
+      ]),
+    ),
+  );
+
+  // Course selections per slot (for PACK products with maxCourses set)
+  // key: slot key, value: array of selected courseIds (length === maxCourses)
+  const [courseSelections, setCourseSelections] = useState<
+    Record<string, string[]>
+  >(
+    Object.fromEntries(
+      flattenedItems.map((it, idx) => [
+        `slot-${idx}`,
+        Array.from({ length: it.product.maxCourses ?? 0 }, () => ""),
       ]),
     ),
   );
@@ -212,11 +230,35 @@ export default function CheckoutForm({
           return;
         }
 
+        // Validate course selections for PACK products with maxCourses
+        const maxCourses = it.product.maxCourses;
+        let selectedCourseIds: string[] | undefined;
+        if (maxCourses != null) {
+          const picked = (courseSelections[key] ?? []).filter(Boolean);
+          if (picked.length !== maxCourses) {
+            toast.error(
+              `Du måste välja ${maxCourses} ${maxCourses === 1 ? "kurs" : "kurser"} för "${it.name}".`,
+            );
+            setIsSubmitting(false);
+            return;
+          }
+          // Check for duplicate selections
+          if (new Set(picked).size !== picked.length) {
+            toast.error(
+              `Du kan inte välja samma kurs flera gånger för "${it.name}".`,
+            );
+            setIsSubmitting(false);
+            return;
+          }
+          selectedCourseIds = picked;
+        }
+
         orderItems.push({
           productId: it.productId,
           count: 1, // We treat each as 1 count since we gave each a participant
           price: it.price,
           participantId,
+          selectedCourseIds,
         });
       }
 
@@ -264,6 +306,7 @@ export default function CheckoutForm({
                 !slot.isSelf && isNewForm
                   ? getDuplicateWarning(key, typedName, slots)
                   : null;
+              const maxCourses = it.product.maxCourses;
 
               return (
                 <div
@@ -502,6 +545,23 @@ export default function CheckoutForm({
                           </div>
                         </div>
                       )}
+                    </div>
+                  )}
+
+                  {/* Course selection for PACK products with maxCourses */}
+                  {maxCourses != null && it.courses.length > 0 && (
+                    <div className="pt-2 border-t border-dashed">
+                      <SelectPack
+                        maxCourses={maxCourses}
+                        courses={it.courses}
+                        selected={courseSelections[key] ?? []}
+                        onChange={(sel) =>
+                          setCourseSelections((prev) => ({
+                            ...prev,
+                            [key]: sel,
+                          }))
+                        }
+                      />
                     </div>
                   )}
                 </div>

--- a/src/app/(public)/checkout/components/SelectPack.tsx
+++ b/src/app/(public)/checkout/components/SelectPack.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface CourseOption {
+  courseId: string;
+  courseName: string;
+}
+
+interface SelectPackProps {
+  maxCourses: number;
+  courses: CourseOption[];
+  /** Array of length maxCourses – empty string means "not chosen yet" */
+  selected: string[];
+  onChange: (selected: string[]) => void;
+}
+
+export function SelectPack({
+  maxCourses,
+  courses,
+  selected,
+  onChange,
+}: SelectPackProps) {
+  // Ensure the array always has exactly maxCourses slots
+  const slots = Array.from({ length: maxCourses }, (_, i) => selected[i] ?? "");
+
+  const updateSlot = (index: number, value: string) => {
+    const next = [...slots];
+    next[index] = value;
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-3 pt-2">
+      <p className="text-sm text-muted-foreground">
+        Välj {maxCourses} {maxCourses === 1 ? "kurs" : "kurser"} du vill använda
+        ditt paket på:
+      </p>
+      <div className="grid gap-2">
+        {slots.map((currentValue, i) => {
+          // Other slots' chosen courseIds – used to disable already-picked courses
+          const otherSelected = slots.filter((v, idx) => idx !== i && v !== "");
+
+          return (
+            <div
+              key={`${i}-${currentValue}`}
+              className="flex items-center gap-2"
+            >
+              <span className="w-6 shrink-0 text-center text-sm font-medium text-muted-foreground">
+                {i + 1}.
+              </span>
+              <Select
+                value={currentValue || undefined}
+                onValueChange={(val) => updateSlot(i, val)}
+              >
+                <SelectTrigger className="flex-1">
+                  <SelectValue placeholder="Välj en kurs…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {courses.map((c) => (
+                    <SelectItem
+                      key={c.courseId}
+                      value={c.courseId}
+                      disabled={otherSelected.includes(c.courseId)}
+                    >
+                      {c.courseName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(public)/checkout/page.tsx
+++ b/src/app/(public)/checkout/page.tsx
@@ -33,19 +33,36 @@ export default async function Page() {
     const ids = cart.items.map((i) => i.productId);
     const products = await prisma.product.findMany({
       where: { id: { in: ids }, active: true },
-      select: { id: true, name: true, name_en: true, price: true },
+      include: {
+        courses: {
+          include: { course: true },
+        },
+      },
     });
 
     const byId = new Map(products.map((p) => [p.id, p]));
 
-    const items = cart.items.map((it) => {
+    const items = cart.items.flatMap((it) => {
       const p = byId.get(it.productId);
-      return {
-        productId: it.productId,
-        name: p ? (pick(p, "name", lang) as string) : t.common.unknown,
-        qty: it.qty,
-        price: p?.price ?? 0,
-      };
+
+      if (!p) {
+        return [];
+      }
+
+      return [
+        {
+          product: p,
+          productId: it.productId,
+          name: pick(p, "name", lang) as string,
+          qty: it.qty,
+          price: p.price,
+          // Courses available for SelectPack (only relevant when maxCourses is set)
+          courses: p.courses.map((pc) => ({
+            courseId: pc.courseId,
+            courseName: pick(pc.course, "name", lang) as string,
+          })),
+        },
+      ];
     });
 
     const userDetails = await prisma.userDetails.findUnique({

--- a/src/app/(public)/checkout/success/page.tsx
+++ b/src/app/(public)/checkout/success/page.tsx
@@ -134,12 +134,13 @@ export default async function Page({
                     const productName = it.product
                       ? (pick(it.product, "name", lang) as string)
                       : it.productId;
+                    const selections = it.courseSelections ?? [];
                     return (
                       <div
                         key={it.id}
                         className="grid grid-cols-4 gap-2 px-6 py-3 border-b border-border text-sm"
                       >
-                        <span>
+                        <span className="col-span-2">
                           {productName}
                           <span className="block text-xs text-muted-foreground">
                             {it.participant?.name
@@ -152,12 +153,22 @@ export default async function Page({
                                   t.checkout.success.participantSelf,
                                 )}
                           </span>
+                          {selections.length > 0 && (
+                            <ul className="mt-1 space-y-0.5">
+                              {selections.map((s) => (
+                                <li
+                                  key={s.courseId}
+                                  className="text-xs text-muted-foreground flex items-center gap-1"
+                                >
+                                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-brand shrink-0" />
+                                  {s.course.name}
+                                </li>
+                              ))}
+                            </ul>
+                          )}
                         </span>
                         <span className="text-right text-muted-foreground">
                           {formatPrice(unit, lang)}
-                        </span>
-                        <span className="text-right text-muted-foreground">
-                          {it.count}
                         </span>
                         <span className="text-right font-medium text-foreground">
                           {formatPrice(sum, lang)}
@@ -165,6 +176,7 @@ export default async function Page({
                       </div>
                     );
                   })}
+
                   <div className="grid grid-cols-4 gap-2 px-6 py-3 font-semibold text-foreground">
                     <span className="col-span-3 text-right">
                       {t.checkout.success.total}

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -760,6 +760,8 @@ export async function addNewProduct(
         totalCount: validated.clipCount,
         imageURL: validated.imageURL,
         categoryId: validCategory,
+        autobook: validated.autobook,
+        maxCourses: validated.maxCourses,
       },
     });
 

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -840,6 +840,8 @@ export async function editProduct(
         totalCount: validated.clipCount,
         imageURL: validated.imageURL,
         categoryId: validCategory,
+        autobook: validated.autobook,
+        maxCourses: validated.maxCourses,
       },
     });
 
@@ -1016,7 +1018,6 @@ export async function isCourseInProduct(
 }
 
 export type PrismaTx = Prisma.TransactionClient;
-
 // Uppdaterar product.type baserat på om det är klippkort eller hur många kurser som är kopplade.
 export async function updateProductType(
   productId: string,
@@ -1029,6 +1030,8 @@ export async function updateProductType(
     select: {
       id: true,
       type: true,
+      autobook: true,
+      maxCourses: true,
       courses: { select: { courseId: true } },
     },
   });
@@ -1044,10 +1047,23 @@ export async function updateProductType(
       ? "PACK"
       : "COURSE";
 
-  if (product.type !== nextType) {
+  // Autobokning och kursbegränsning är bara tillåtet på klippkort om det
+  // finns exakt 1 kopplad kurs. Fler kurser gör kombinationen ogiltig, så
+  // vi nollställer dem tyst här istället för att blockera anropet.
+  const shouldClearAutobookSettings =
+    nextType === "CLIP" &&
+    product.courses.length > 1 &&
+    (product.autobook || product.maxCourses !== null);
+
+  const typeChanged = product.type !== nextType;
+
+  if (typeChanged || shouldClearAutobookSettings) {
     await client.product.update({
       where: { id: product.id },
-      data: { type: nextType },
+      data: {
+        ...(typeChanged ? { type: nextType } : {}),
+        ...(shouldClearAutobookSettings ? { autobook: false } : {}),
+      },
     });
   }
 

--- a/src/lib/actions/checkout.ts
+++ b/src/lib/actions/checkout.ts
@@ -12,6 +12,8 @@ export type CheckoutItem = {
   productId: string;
   count: number;
   participantId?: string | null;
+  /** Required when product.maxCourses is set – the courses the customer chose */
+  selectedCourseIds?: string[];
 };
 
 export async function createCheckout(params: {
@@ -34,6 +36,7 @@ export async function createCheckout(params: {
     count: number;
     participantId?: string | null;
     price: number;
+    selectedCourseIds?: string[];
   }[] = [];
 
   // Gör en transaction här då.
@@ -59,6 +62,34 @@ export async function createCheckout(params: {
             productId: itm.productId,
           });
           throw new Error("Kunde inte verifiera tillgänglighet just nu.");
+        }
+
+        // Server-side validation of course selections for products with maxCourses
+        if (p.maxCourses != null) {
+          const selected = itm.selectedCourseIds ?? [];
+          if (selected.length !== p.maxCourses) {
+            throw new Error(
+              `Du måste välja exakt ${p.maxCourses} kurser för "${p.name}".`,
+            );
+          }
+          if (new Set(selected).size !== selected.length) {
+            throw new Error(
+              `Du kan inte välja samma kurs flera gånger för "${p.name}".`,
+            );
+          }
+          // Verify all selected courses actually belong to this product
+          const linkedCourses = await tx.productOnCourse.findMany({
+            where: { productId: p.id },
+            select: { courseId: true },
+          });
+          const validIds = new Set(linkedCourses.map((c) => c.courseId));
+          for (const cId of selected) {
+            if (!validIds.has(cId)) {
+              throw new Error(
+                `En vald kurs tillhör inte produkten "${p.name}". Vänligen ladda om sidan och försök igen.`,
+              );
+            }
+          }
         }
 
         if (
@@ -104,6 +135,7 @@ export async function createCheckout(params: {
           count: itm.count,
           participantId: itm.participantId,
           price: p.price,
+          selectedCourseIds: itm.selectedCourseIds,
         });
       }
 

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -22,7 +22,25 @@ export async function updateOrderStatus(
   const adminUserId = await requireAdmin();
 
   return prisma.$transaction(async (tx) => {
-    const current = await tx.order.findUnique({ where: { id: orderId } });
+    const current = await tx.order.findUnique({
+      where: { id: orderId },
+      include: {
+        orderItems: {
+          include: {
+            product: {
+              include: {
+                courses: {
+                  select: { courseId: true },
+                },
+              },
+            },
+            courseSelections: {
+              select: { courseId: true },
+            },
+          },
+        },
+      },
+    });
 
     if (!current) throw new Error("Order not found");
     if (current.status === toStatus) return { success: true };
@@ -31,6 +49,43 @@ export async function updateOrderStatus(
       ["APPROVED", "PAID"].includes(current.status)
     ) {
       throw new Error("Kan inte avbryta en redan godkänd eller betald order.");
+    }
+
+    if (toStatus === "APPROVED") {
+      for (const item of current.orderItems) {
+        const maxCourses = item.product.maxCourses;
+        if (maxCourses == null) continue;
+
+        const selectedCourseIds = item.courseSelections.map(
+          (sel) => sel.courseId,
+        );
+        const uniqueSelectedIds = new Set(selectedCourseIds);
+
+        if (selectedCourseIds.length !== maxCourses) {
+          throw new Error(
+            `Du måste välja exakt ${maxCourses} olika kurser för "${item.product.name}" innan ordern kan godkännas.`,
+          );
+        }
+
+        if (uniqueSelectedIds.size !== selectedCourseIds.length) {
+          throw new Error(
+            `Du måste välja olika kurser för "${item.product.name}" innan ordern kan godkännas.`,
+          );
+        }
+
+        const validCourseIds = new Set(
+          item.product.courses.map((link) => link.courseId),
+        );
+        const invalidCourseId = selectedCourseIds.find(
+          (courseId) => !validCourseIds.has(courseId),
+        );
+
+        if (invalidCourseId) {
+          throw new Error(
+            `En vald kurs i "${item.product.name}" finns inte kopplad till produkten och kan därför inte godkännas.`,
+          );
+        }
+      }
     }
 
     const updated = await tx.order.update({

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -78,12 +78,99 @@ export async function adminGetOrder(orderId: string) {
     where: { id },
     include: {
       user: { include: { details: true } },
-      orderItems: { include: { product: true, participant: true } },
+      orderItems: {
+        include: {
+          product: {
+            include: {
+              courses: {
+                include: { course: { select: { id: true, name: true } } },
+              },
+            },
+          },
+          participant: true,
+          courseSelections: {
+            include: { course: { select: { id: true, name: true } } },
+          },
+        },
+      },
       statusEvents: {
         include: { changedBy: true },
         orderBy: { createdAt: "asc" },
       },
     },
+  });
+}
+
+export async function updateOrderItemCourseSelections(
+  orderItemId: string,
+  selectedCourseIds: string[],
+) {
+  await requireAdmin();
+
+  const id = orderItemId?.trim();
+  if (!id) throw new Error("Giltigt orderItemId saknas.");
+
+  const normalized = Array.from(
+    new Set((selectedCourseIds ?? []).filter(Boolean).map((x) => x.trim())),
+  );
+
+  return prisma.$transaction(async (tx) => {
+    const orderItem = await tx.orderItem.findUnique({
+      where: { id },
+      include: {
+        product: {
+          include: {
+            courses: { select: { courseId: true } },
+          },
+        },
+      },
+    });
+
+    if (!orderItem) throw new Error("Orderitem hittades inte.");
+    if (orderItem.product.maxCourses == null) {
+      throw new Error("Den här produkten är inte ett paket med kursval.");
+    }
+
+    const maxCourses = orderItem.product.maxCourses;
+    if (normalized.length !== maxCourses) {
+      throw new Error(
+        `Du måste välja exakt ${maxCourses} ${maxCourses === 1 ? "kurs" : "kurser"}.`,
+      );
+    }
+
+    const validCourseIds = new Set(
+      orderItem.product.courses.map((link) => link.courseId),
+    );
+
+    for (const courseId of normalized) {
+      if (!validCourseIds.has(courseId)) {
+        throw new Error(
+          "En vald kurs finns inte kopplad till produkten och kan därför inte sparas.",
+        );
+      }
+    }
+
+    await tx.orderItemCourseSelection.deleteMany({
+      where: { orderItemId: id },
+    });
+
+    if (normalized.length > 0) {
+      await tx.orderItemCourseSelection.createMany({
+        data: normalized.map((courseId) => ({
+          orderItemId: id,
+          courseId,
+        })),
+        skipDuplicates: true,
+      });
+    }
+
+    revalidatePath("/admin/orders");
+    revalidatePath("/admin/orders/view");
+
+    return {
+      success: true,
+      selectedCourseIds: normalized,
+    };
   });
 }
 
@@ -114,6 +201,13 @@ export async function createPurchaseFromOrder(orderId: string) {
         orderItems: {
           include: {
             participant: true,
+            courseSelections: {
+              include: {
+                course: {
+                  select: { name: true },
+                },
+              },
+            },
             product: {
               include: {
                 courses: true,
@@ -155,8 +249,18 @@ export async function createPurchaseFromOrder(orderId: string) {
         },
       });
 
+      const selectedCourseIds = new Set(
+        (orderItem.courseSelections ?? []).map((sel) => sel.courseId),
+      );
+      const coursesToCreate =
+        orderItem.product.maxCourses != null && selectedCourseIds.size > 0
+          ? orderItem.product.courses.filter((pc) =>
+              selectedCourseIds.has(pc.courseId),
+            )
+          : orderItem.product.courses;
+
       // 4. Skapa PurchaseItems för kurserna i denna produkt
-      const itemPromises = orderItem.product.courses.map((pc) =>
+      const itemPromises = coursesToCreate.map((pc) =>
         tx.purchaseItem.create({
           data: {
             purchaseId: purchase.id,

--- a/src/lib/actions/server-actions.ts
+++ b/src/lib/actions/server-actions.ts
@@ -443,7 +443,18 @@ export async function autobook(purchaseItemId: string): Promise<Booking[]> {
     const purchaseItem = await prisma.purchaseItem.findUnique({
       where: { id: purchaseItemId },
       include: {
-        purchase: true,
+        purchase: {
+          include: {
+            product: {
+              select: {
+                autobook: true,
+                maxCourses: true,
+                type: true,
+                courses: { select: { courseId: true } },
+              },
+            },
+          },
+        },
         course: true,
       },
     });
@@ -452,6 +463,30 @@ export async function autobook(purchaseItemId: string): Promise<Booking[]> {
     const purchase = purchaseItem.purchase;
     const course = purchaseItem.course;
     const participantId = purchase.participantId;
+    const product = purchase.product;
+
+    // 1. Produkten måste ha autobokning aktiverad.
+    if (!product.autobook) return [];
+
+    // 2. Klippkort med fler än 1 kopplad kurs stödjer inte autobokning.
+    // (autobook borde redan vara false i det läget via updateProductType,
+    // men vi dubbelkollar här som ett extra säkerhetsnät.)
+    if (product.type === "CLIP" && product.courses.length > 1) return [];
+
+    // 3. Om produkten begränsar antal valbara kurser (maxCourses satt),
+    // autoboka bara den/de kurser kunden faktiskt valde vid köpet.
+    if (product.maxCourses !== null) {
+      const selection = await prisma.orderItemCourseSelection.findUnique({
+        where: {
+          orderItemId_courseId: {
+            orderItemId: purchaseItem.orderItemId,
+            courseId: course.id,
+          },
+        },
+        select: { id: true },
+      });
+      if (!selection) return [];
+    }
 
     // Säkerhetscheck: admin får boka för andra, övriga bara för sina egna köp.
     const isAdmin = sessionUser.role === "admin";

--- a/src/lib/actions/server-actions.ts
+++ b/src/lib/actions/server-actions.ts
@@ -68,31 +68,56 @@ export async function getUserLessons(): Promise<{
   if (!user) return { success: false, msg: "No valid user session" };
 
   try {
-    // 1. Hitta alla courseId som användaren har köpt (där det finns klipp kvar)
-    // Inkludera både där användaren har köpt själv, och där användaren är deltagare på någon annans köp.
+    // 1. Find all purchaseItems the user has access to
     const userPurchases = await prisma.purchaseItem.findMany({
       where: {
         OR: [
           { purchase: { userId: user.id } },
           { purchase: { participant: { userId: user.id } } },
         ],
-        // remainingCount: { gt: 0 }, // fixed: Lektionerna skall synas ändå, så detta får kollas i boka-delen istället.
       },
-      select: { courseId: true },
+      select: {
+        courseId: true,
+        orderItemId: true,
+        orderItem: {
+          select: {
+            id: true,
+            product: { select: { maxCourses: true } },
+            courseSelections: { select: { courseId: true } },
+          },
+        },
+      },
     });
 
-    const courseIds = userPurchases.map((p) => p.courseId);
+    if (userPurchases.length === 0) {
+      return { success: true, msg: "Inga aktiva kurser hittades", lessons: [] };
+    }
 
+    // 2. Build the set of courseIds the user can access.
+    //    For products with maxCourses set, only include courses from OrderItemCourseSelection.
+    //    For all other products, include the purchaseItem's own courseId.
+    const courseIdSet = new Set<string>();
+    for (const pi of userPurchases) {
+      const maxCourses = pi.orderItem?.product?.maxCourses;
+      if (maxCourses != null) {
+        // Only courses the customer explicitly chose
+        for (const sel of pi.orderItem?.courseSelections ?? []) {
+          courseIdSet.add(sel.courseId);
+        }
+      } else {
+        courseIdSet.add(pi.courseId);
+      }
+    }
+
+    const courseIds = Array.from(courseIdSet);
     if (courseIds.length === 0) {
       return { success: true, msg: "Inga aktiva kurser hittades", lessons: [] };
     }
 
-    // 2. Hämta alla lektioner för dessa kurser
+    // 3. Fetch all lessons for these courses
     const lessons = await prisma.lesson.findMany({
       where: {
         courseId: { in: courseIds },
-        // cancelled: false, // Vi visar nog bara lektioner som inte är inställda. Fel.
-        // startTime: { gte: new Date() } // Valfritt: Visa bara framtida lektioner. Nej man kanske vill se sina tidigare boknignar.
       },
       include: { course: true },
       orderBy: { startTime: "asc" },

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -71,6 +71,11 @@ type OrderForEmail = {
     participant?: { name: string } | null;
     count: number;
     price: number;
+    courseSelections?:
+      | {
+          course?: { name?: string | null } | null;
+        }[]
+      | null;
   }[];
 };
 
@@ -79,6 +84,20 @@ type OrderForEmail = {
  * @param order The order data (with user and orderItems)
  * @returns HTML string
  */
+function getCourseSelectionSummary(item: OrderForEmail["orderItems"][number]) {
+  const selections = item.courseSelections ?? [];
+  const names = selections
+    .map((sel) => sel.course?.name)
+    .filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    );
+
+  if (names.length === 0) return "";
+
+  return `<div style="margin-top: 6px; font-size: 12px; color: #555;">Paket: ${names.join(", ")}</div>`;
+}
+
 export async function generateOrderConfirmationHtml(order: OrderForEmail) {
   const itemsHtml = order.orderItems
     .map(
@@ -86,7 +105,9 @@ export async function generateOrderConfirmationHtml(order: OrderForEmail) {
     <tr>
       <td style="padding: 10px; border-bottom: 1px solid #eee;">${
         item.product.name
-      } ${item.participant?.name ? `(deltagare: ${item.participant.name})` : ` `}</td>
+      } ${item.participant?.name ? `(deltagare: ${item.participant.name})` : ` `}
+        ${getCourseSelectionSummary(item)}
+      </td>
       <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: center;">${
         item.count
       }</td>
@@ -155,7 +176,9 @@ export async function generateOrderApprovedHtml(order: OrderForEmail) {
     <tr>
       <td style="padding: 10px; border-bottom: 1px solid #eee;">${
         item.product.name
-      } ${item.participant?.name ? `(deltagare: ${item.participant.name})` : ` `}</td>
+      } ${item.participant?.name ? `(deltagare: ${item.participant.name})` : ` `}
+        ${getCourseSelectionSummary(item)}
+      </td>
       <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: center;">${
         item.count
       }</td>

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -116,7 +116,13 @@ export async function getOrderById(orderId: string) {
     include: {
       user: true,
       orderItems: {
-        include: { product: true, participant: true },
+        include: {
+          product: true,
+          participant: true,
+          courseSelections: {
+            include: { course: { select: { id: true, name: true } } },
+          },
+        },
       },
     },
   });

--- a/src/lib/orders.ts
+++ b/src/lib/orders.ts
@@ -6,6 +6,8 @@ export type OrderItemInput = {
   count: number;
   price: number; // unit price in currency minor unit (or use decimal number)
   participantId?: string | null;
+  /** Populated for PACK products with maxCourses – saved as OrderItemCourseSelection */
+  selectedCourseIds?: string[];
 };
 
 export async function createOrder(
@@ -48,6 +50,51 @@ export async function createOrder(
     })),
     skipDuplicates: true,
   });
+
+  // Save course selections (OrderItemCourseSelection) for PACK products with maxCourses
+  const itemsWithCourses = items.filter(
+    (it) => it.selectedCourseIds && it.selectedCourseIds.length > 0,
+  );
+
+  if (itemsWithCourses.length > 0) {
+    // Fetch back the created orderItems to get their IDs
+    const createdOrderItems = await tx.orderItem.findMany({
+      where: { orderId: orderResult.id },
+      select: { id: true, productId: true },
+    });
+
+    // Build a map productId → orderItemId (one-to-one here since we split by participant)
+    // If same productId appears multiple times we match in order
+    const productIdToOrderItemIds = new Map<string, string[]>();
+    for (const oi of createdOrderItems) {
+      const existing = productIdToOrderItemIds.get(oi.productId) ?? [];
+      existing.push(oi.id);
+      productIdToOrderItemIds.set(oi.productId, existing);
+    }
+    // Track consumption index per productId to handle qty > 1 correctly
+    const consumedIndex = new Map<string, number>();
+
+    const courseSelectionRows: { orderItemId: string; courseId: string }[] = [];
+    for (const it of itemsWithCourses) {
+      const available = productIdToOrderItemIds.get(it.productId) ?? [];
+      const idx = consumedIndex.get(it.productId) ?? 0;
+      const orderItemId = available[idx];
+      consumedIndex.set(it.productId, idx + 1);
+
+      if (!orderItemId) continue;
+
+      for (const courseId of it.selectedCourseIds ?? []) {
+        courseSelectionRows.push({ orderItemId, courseId });
+      }
+    }
+
+    if (courseSelectionRows.length > 0) {
+      await tx.orderItemCourseSelection.createMany({
+        data: courseSelectionRows,
+        skipDuplicates: true,
+      });
+    }
+  }
 
   // Seed first status event (from null -> PENDING_PAYMENT)
   await tx.orderStatusEvent.create({

--- a/src/validations/adminforms.ts
+++ b/src/validations/adminforms.ts
@@ -173,6 +173,8 @@ export const adminProductSchema = z
       .nonnegative("Priset får inte vara negativt"),
     clipcard: z.coerce.boolean().optional(), //Det riktig engelska ordet är clipboard, men jag gillade det inte.
     clipCount: z.coerce.number().int().nonnegative(),
+    autobook: z.coerce.boolean(),
+    maxCourses: z.coerce.number().int().min(1).nullable(),
   })
   .superRefine((data, ctx) => {
     if (data.clipcard && data.clipCount < 1) {


### PR DESCRIPTION
## Beskrivning

Denna PR löser att vissa produkter som säljs som paket ska ge tillgång till ett valfritt antal kurser av alla kurser. 
Kunden väljer nu i kassan innan order görs vilka kurser de vill att paketet ska ge tillgång till, vilket sen kan ändras av admin i admin/orders fram tills att kursen är skapad (godkänd). 
Det blev då också naturligt att ge varje produkt ett autobook-fält, så admin kan ställa in för varje produkt om en kund ska autobokas när ordern är godkänd (från aktuellt datum och framåt så långt klippen räcker).

Valen kommer stå med i orderspec och i mail som skickas.

Valen kontrolleras att de är giltiga innan en order kan godkännas. En godkänd order kan inte ändra valen i efterhand.




## Relaterade issues

Closes #373 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [x] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [x] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<img width="1647" height="610" alt="image" src="https://github.com/user-attachments/assets/f083f5d9-dfd9-455a-a661-21c5451718a7" />

<img width="717" height="798" alt="image" src="https://github.com/user-attachments/assets/840333e8-704a-4b98-ab71-1bb14b1b3f45" />


## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
