### PR TITLE
Gör språkväljaren i alla formulär sticky, bättre kontroll i formulär och egna fält för _en

### DIFF
--- a/src/app/(admin)/admin/courses/forms/AddCourseForm.tsx
+++ b/src/app/(admin)/admin/courses/forms/AddCourseForm.tsx
@@ -127,14 +127,17 @@ export default function AddCourseForm({
 
         <Card>
           <CardContent>
-            <div className="p2 text-sm">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
-
             <Form {...form}>
               <form
                 onSubmit={form.handleSubmit(onSubmit)}

--- a/src/app/(admin)/admin/courses/forms/AddCourseForm.tsx
+++ b/src/app/(admin)/admin/courses/forms/AddCourseForm.tsx
@@ -104,12 +104,21 @@ export default function AddCourseForm({
   const maxAgeTrim: string = String(maxAgeValue ?? "").trim();
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
 
   useEffect(() => {
     if (!isOpen) {
       setFormLang(initialLang);
     }
   }, [initialLang, isOpen]);
+
+  useEffect(() => {
+    if (errors.name || errors.description || errors.level) {
+      setFormLang("sv");
+    } else if (errors.name_en || errors.description_en || errors.level_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
@@ -145,11 +154,24 @@ export default function AddCourseForm({
               >
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "name_en" : "name"}
-                  key={`name-${formLang}`}
+                  name="name"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Kursnamn ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Kursnamn (sv)</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="name_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Kursnamn (en)</FormLabel>
                       <FormControl>
                         <Input {...field} />
                       </FormControl>
@@ -202,11 +224,30 @@ export default function AddCourseForm({
 
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "description_en" : "description"}
-                  key={`description-${formLang}`}
+                  name="description"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Beskrivning ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (sv)</FormLabel>
+
+                      <FormControl>
+                        <RichTextEditor
+                          value={field.value || ""}
+                          onChange={field.onChange}
+                          placeholder="Skriv kursbeskrivning..."
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (en)</FormLabel>
 
                       <FormControl>
                         <RichTextEditor
@@ -313,11 +354,26 @@ export default function AddCourseForm({
 
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "level_en" : "level"}
-                  key={`level-${formLang}`}
+                  name="level"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Nivå ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Nivå (sv)</FormLabel>
+
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="level_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Nivå (en)</FormLabel>
 
                       <FormControl>
                         <Input {...field} />

--- a/src/app/(admin)/admin/courses/forms/AddCourseForm.tsx
+++ b/src/app/(admin)/admin/courses/forms/AddCourseForm.tsx
@@ -107,18 +107,18 @@ export default function AddCourseForm({
   const errors = form.formState.errors;
 
   useEffect(() => {
-    if (!isOpen) {
-      setFormLang(initialLang);
-    }
-  }, [initialLang, isOpen]);
-
-  useEffect(() => {
     if (errors.name || errors.description || errors.level) {
       setFormLang("sv");
     } else if (errors.name_en || errors.description_en || errors.level_en) {
       setFormLang("en");
     }
   }, [errors]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFormLang(initialLang);
+    }
+  }, [initialLang, isOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>

--- a/src/app/(admin)/admin/courses/forms/EditCourseForm.tsx
+++ b/src/app/(admin)/admin/courses/forms/EditCourseForm.tsx
@@ -126,7 +126,15 @@ export default function EditCourseForm({ course, styles, teachers }: Props) {
   const maxAgeTrim: string = String(maxAgeValue ?? "").trim();
   const [formLang, setFormLang] = useState("sv");
 
-  const _key = crypto.randomUUID();
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.name || errors.description || errors.level) {
+      setFormLang("sv");
+    } else if (errors.name_en || errors.description_en || errors.level_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
@@ -144,12 +152,16 @@ export default function EditCourseForm({ course, styles, teachers }: Props) {
 
         <Card>
           <CardContent>
-            <div className="p2 text-sm">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e)}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
 
             <Form {...form}>
@@ -159,11 +171,24 @@ export default function EditCourseForm({ course, styles, teachers }: Props) {
               >
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "name_en" : "name"}
-                  key={`name-${formLang}`}
+                  name="name"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Kursnamn ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Kursnamn (sv)</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="name_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Kursnamn (en)</FormLabel>
                       <FormControl>
                         <Input {...field} />
                       </FormControl>
@@ -215,11 +240,30 @@ export default function EditCourseForm({ course, styles, teachers }: Props) {
 
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "description_en" : "description"}
-                  key={`description-${formLang}`}
+                  name="description"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Beskrivning ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (sv)</FormLabel>
+
+                      <FormControl>
+                        <RichTextEditor
+                          value={field.value || ""}
+                          onChange={field.onChange}
+                          placeholder="Skriv kursbeskrivning..."
+                        />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (en)</FormLabel>
 
                       <FormControl>
                         <RichTextEditor
@@ -326,11 +370,26 @@ export default function EditCourseForm({ course, styles, teachers }: Props) {
 
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "level_en" : "level"}
-                  key={`level-${formLang}`}
+                  name="level"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Nivå ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Nivå (sv)</FormLabel>
+
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="level_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Nivå (en)</FormLabel>
 
                       <FormControl>
                         <Input {...field} />

--- a/src/app/(admin)/admin/events/components/EditEventForm.tsx
+++ b/src/app/(admin)/admin/events/components/EditEventForm.tsx
@@ -130,6 +130,7 @@ export default function EditEventForm({
   );
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
 
   useEffect(() => {
     if (isOpen) {
@@ -137,15 +138,27 @@ export default function EditEventForm({
     }
   }, [initialLang, isOpen]);
 
+  useEffect(() => {
+    if (errors.headline || errors.description) {
+      setFormLang("sv");
+    } else if (errors.headline_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
+
   return (
     <Card>
       <CardContent>
-        <div className="p2 text-sm">
-          Formulärspråk:{" "}
-          <LanguageSwitcherInput
-            value={formLang ?? "sv"}
-            setValue={(e) => setFormLang(e)}
-          />
+        <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+          <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+            <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+              Språk:
+            </span>
+            <LanguageSwitcherInput
+              value={formLang ?? "sv"}
+              setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+            />
+          </div>
         </div>
 
         <Form {...form}>
@@ -168,11 +181,10 @@ export default function EditEventForm({
 
             <FormField
               control={form.control}
-              name={formLang === "en" ? "headline_en" : "headline"}
-              key={`headline-${formLang}`}
+              name="headline"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Rubrik ({formLang})</FormLabel>
+                <FormItem className={formLang === "en" ? "hidden" : ""}>
+                  <FormLabel>Rubrik (sv)</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -183,16 +195,47 @@ export default function EditEventForm({
 
             <FormField
               control={form.control}
-              name={formLang === "en" ? "description_en" : "description"}
-              key={`description-${formLang}`}
+              name="headline_en"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Beskrivning ({formLang})</FormLabel>
+                <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                  <FormLabel>Rubrik (en)</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem className={formLang === "en" ? "hidden" : ""}>
+                  <FormLabel>Beskrivning (sv)</FormLabel>
                   <FormControl>
                     <RichTextEditor
                       value={field.value || ""}
                       onChange={field.onChange}
                       placeholder="Skriv eventbeskrivning..."
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description_en"
+              render={({ field }) => (
+                <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                  <FormLabel>Beskrivning (en)</FormLabel>
+                  <FormControl>
+                    <RichTextEditor
+                      value={field.value || ""}
+                      onChange={field.onChange}
+                      placeholder="Write event description..."
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/app/(admin)/admin/events/components/NewEventForm.tsx
+++ b/src/app/(admin)/admin/events/components/NewEventForm.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -87,16 +87,29 @@ export default function NewEventForm({ onSuccess, initialLang = "sv" }: Props) {
   const [hasEndDate, sethasEndDate] = useState<boolean>(false);
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.headline || errors.description) {
+      setFormLang("sv");
+    } else if (errors.headline_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   return (
     <Card>
       <CardContent>
-        <div className="p2 text-sm">
-          Formulärspråk:{" "}
-          <LanguageSwitcherInput
-            value={formLang ?? "sv"}
-            setValue={(e) => setFormLang(e)}
-          />
+        <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+          <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+            <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+              Språk:
+            </span>
+            <LanguageSwitcherInput
+              value={formLang ?? "sv"}
+              setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+            />
+          </div>
         </div>
 
         <Form {...form}>
@@ -106,11 +119,10 @@ export default function NewEventForm({ onSuccess, initialLang = "sv" }: Props) {
           >
             <FormField
               control={form.control}
-              name={formLang === "en" ? "headline_en" : "headline"}
-              key={`headline-${formLang}`}
+              name="headline"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Rubrik ({formLang})</FormLabel>
+                <FormItem className={formLang === "en" ? "hidden" : ""}>
+                  <FormLabel>Rubrik (sv)</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
@@ -121,16 +133,47 @@ export default function NewEventForm({ onSuccess, initialLang = "sv" }: Props) {
 
             <FormField
               control={form.control}
-              name={formLang === "en" ? "description_en" : "description"}
-              key={`description-${formLang}`}
+              name="headline_en"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Beskrivning ({formLang})</FormLabel>
+                <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                  <FormLabel>Rubrik (en)</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem className={formLang === "en" ? "hidden" : ""}>
+                  <FormLabel>Beskrivning (sv)</FormLabel>
                   <FormControl>
                     <RichTextEditor
                       value={field.value || ""}
                       onChange={field.onChange}
                       placeholder="Skriv eventbeskrivning..."
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="description_en"
+              render={({ field }) => (
+                <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                  <FormLabel>Beskrivning (en)</FormLabel>
+                  <FormControl>
+                    <RichTextEditor
+                      value={field.value || ""}
+                      onChange={field.onChange}
+                      placeholder="Write event description..."
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/app/(admin)/admin/gallery/MediaAdmin.tsx
+++ b/src/app/(admin)/admin/gallery/MediaAdmin.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -325,6 +325,16 @@ export default function MediaAdmin({
     }
   };
 
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.title || errors.description) {
+      setFormLang("sv");
+    } else if (errors.title_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
+
   return (
     <div className="w-full bg-background p-4 text-foreground">
       <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
@@ -618,12 +628,16 @@ export default function MediaAdmin({
             </DialogDescription>
           </DialogHeader>
 
-          <div className="text-sm">
-            Formulärspråk:{" "}
-            <LanguageSwitcherInput
-              value={formLang ?? "sv"}
-              setValue={(value) => setFormLang(value)}
-            />
+          <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+            <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+              <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                Språk:
+              </span>
+              <LanguageSwitcherInput
+                value={formLang ?? "sv"}
+                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+              />
+            </div>
           </div>
 
           <Form {...form}>
@@ -677,17 +691,19 @@ export default function MediaAdmin({
 
               <FormField
                 control={form.control}
-                name={formLang === "en" ? "title_en" : "title"}
-                key={`title-${formLang}`}
+                name="title"
                 render={({ field }) => (
-                  <FormItem>
+                  <FormItem className={formLang === "en" ? "hidden" : ""}>
                     <FormLabel>
+                      {" "}
                       {currentType === "IMAGE" ? "Rubrik" : "Titel"} ({formLang}
                       )
                     </FormLabel>
+
                     <FormControl>
                       <Input {...field} value={field.value ?? ""} />
                     </FormControl>
+
                     <FormMessage />
                   </FormItem>
                 )}
@@ -695,14 +711,51 @@ export default function MediaAdmin({
 
               <FormField
                 control={form.control}
-                name={formLang === "en" ? "description_en" : "description"}
-                key={`description-${formLang}`}
+                name="title_en"
                 render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Beskrivning ({formLang})</FormLabel>
+                  <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                    <FormLabel>
+                      {" "}
+                      {currentType === "IMAGE" ? "Rubrik" : "Titel"} ({formLang}
+                      )
+                    </FormLabel>
+
+                    <FormControl>
+                      <Input {...field} value={field.value ?? ""} />
+                    </FormControl>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem className={formLang === "en" ? "hidden" : ""}>
+                    <FormLabel>Beskrivning (sv)</FormLabel>
+
                     <FormControl>
                       <Textarea {...field} value={field.value ?? ""} rows={3} />
                     </FormControl>
+
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description_en"
+                render={({ field }) => (
+                  <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                    <FormLabel>Beskrivning (en)</FormLabel>
+
+                    <FormControl>
+                      <Textarea {...field} value={field.value ?? ""} rows={3} />
+                    </FormControl>
+
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/app/(admin)/admin/lectures/components/EditLesson.tsx
+++ b/src/app/(admin)/admin/lectures/components/EditLesson.tsx
@@ -87,6 +87,15 @@ export function EditLessonBtn({ lesson }: { lesson: Lesson }) {
   }
 
   const [formLang, setFormLang] = useState<string>("sv");
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.message) {
+      setFormLang("sv");
+    } else if (errors.message_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(e) => setIsOpen(e)}>
@@ -102,12 +111,16 @@ export function EditLessonBtn({ lesson }: { lesson: Lesson }) {
           <DialogDescription></DialogDescription>
         </DialogHeader>
 
-        <div className="p2 text-sm">
-          Formulärspråk:{" "}
-          <LanguageSwitcherInput
-            value={formLang ?? "sv"}
-            setValue={(e) => setFormLang(e)}
-          />
+        <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+          <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+            <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+              Språk:
+            </span>
+            <LanguageSwitcherInput
+              value={formLang ?? "sv"}
+              setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+            />
+          </div>
         </div>
 
         <Form {...form}>
@@ -117,11 +130,24 @@ export function EditLessonBtn({ lesson }: { lesson: Lesson }) {
           >
             <FormField
               control={form.control}
-              name={formLang === "en" ? "message_en" : "message"}
-              key={`message-${formLang}`}
+              name="message"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Meddelande ({formLang})</FormLabel>
+                <FormItem className={formLang === "en" ? "hidden" : ""}>
+                  <FormLabel>Meddelande (sv)</FormLabel>
+                  <FormControl>
+                    <Textarea {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="message_en"
+              render={({ field }) => (
+                <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                  <FormLabel>Meddelande (en)</FormLabel>
                   <FormControl>
                     <Textarea {...field} />
                   </FormControl>

--- a/src/app/(admin)/admin/legal/components/LegalPageForm.tsx
+++ b/src/app/(admin)/admin/legal/components/LegalPageForm.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Save } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -50,6 +50,15 @@ export function LegalPageForm({
   });
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.title || errors.content) {
+      setFormLang("sv");
+    } else if (errors.title_en || errors.content_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   async function onSubmit(values: z.infer<typeof adminLegalPageSchema>) {
     setIsPending(true);
@@ -77,22 +86,25 @@ export function LegalPageForm({
   return (
     <div>
       {" "}
-      <div className="p2 text-sm">
-        Formulärspråk:{" "}
-        <LanguageSwitcherInput
-          value={formLang ?? "sv"}
-          setValue={(e) => setFormLang(e)}
-        />
+      <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+          <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+            Språk:
+          </span>
+          <LanguageSwitcherInput
+            value={formLang ?? "sv"}
+            setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+          />
+        </div>
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
           <FormField
             control={form.control}
-            name={formLang === "en" ? "title_en" : "title"}
-            key={`title-${formLang}`}
+            name="title"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Titel ({formLang})</FormLabel>
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Titel (sv)</FormLabel>
                 <FormControl>
                   <Input placeholder="t.ex. Integritetspolicy" {...field} />
                 </FormControl>
@@ -103,16 +115,47 @@ export function LegalPageForm({
 
           <FormField
             control={form.control}
-            name={formLang === "en" ? "content_en" : "content"}
-            key={`content-${formLang}`}
+            name="title_en"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Innehåll ({formLang})</FormLabel>
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Titel (en)</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g. Privacy policy" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="content"
+            render={({ field }) => (
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Innehåll (sv)</FormLabel>
                 <FormControl>
                   <RichTextEditor
                     value={field.value || ""}
                     onChange={field.onChange}
                     placeholder="Skriv sidans innehåll..."
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="content_en"
+            render={({ field }) => (
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Innehåll (en)</FormLabel>
+                <FormControl>
+                  <RichTextEditor
+                    value={field.value || ""}
+                    onChange={field.onChange}
+                    placeholder="Write page content..."
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/app/(admin)/admin/products/components/AddCoursesToProductForm.tsx
+++ b/src/app/(admin)/admin/products/components/AddCoursesToProductForm.tsx
@@ -144,12 +144,16 @@ export default function AddCoursesToProductForm({
 
         <Card>
           <CardContent>
-            <div className="p2 text-sm my-2">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
             <Form {...form}>
               <form

--- a/src/app/(admin)/admin/products/components/AddProductForm.tsx
+++ b/src/app/(admin)/admin/products/components/AddProductForm.tsx
@@ -75,6 +75,7 @@ export default function AddProductForm({
   });
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
 
   const router = useRouter();
 
@@ -82,8 +83,19 @@ export default function AddProductForm({
   const isBusy = form.formState.isSubmitting || form.formState.isValidating;
 
   useEffect(() => {
-    if (!isOpen) form.reset();
-  }, [isOpen, form]);
+    if (!isOpen) {
+      form.reset();
+      setFormLang(initialLang);
+    }
+  }, [isOpen, form, initialLang]);
+
+  useEffect(() => {
+    if (errors.name || errors.description) {
+      setFormLang("sv");
+    } else if (errors.name_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     let finalImageURL = values.imageURL ?? "";
@@ -136,12 +148,16 @@ export default function AddProductForm({
 
         <Card>
           <CardContent>
-            <div className="p2 text-sm my-2">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
             <Form {...form}>
               <form
@@ -150,13 +166,26 @@ export default function AddProductForm({
               >
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "name_en" : "name"}
-                  key={`name-${formLang}`}
+                  name="name"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Namn ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Namn (sv)</FormLabel>
                       <FormControl>
                         <Input placeholder="Namnge produkten" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="name_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Namn (en)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Name the product" {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -194,16 +223,33 @@ export default function AddProductForm({
 
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "description_en" : "description"}
-                  key={`description-${formLang}`}
+                  name="description"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Beskrivning ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (sv)</FormLabel>
                       <FormControl>
                         <RichTextEditor
                           value={field.value || ""}
                           onChange={field.onChange}
                           placeholder="Skriv produktbeskrivning..."
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (en)</FormLabel>
+                      <FormControl>
+                        <RichTextEditor
+                          value={field.value || ""}
+                          onChange={field.onChange}
+                          placeholder="Write product description..."
                         />
                       </FormControl>
                       <FormMessage />

--- a/src/app/(admin)/admin/products/components/EditProductForm.tsx
+++ b/src/app/(admin)/admin/products/components/EditProductForm.tsx
@@ -145,6 +145,21 @@ export default function EditProductForm({
   ]);
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFormLang(initialLang);
+    }
+  }, [initialLang, isOpen]);
+
+  useEffect(() => {
+    if (errors.name || errors.description) {
+      setFormLang("sv");
+    } else if (errors.name_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const oldImageUrl = imageURL;
@@ -233,12 +248,16 @@ export default function EditProductForm({
 
         <Card>
           <CardContent>
-            <div className="p2 text-sm my-2">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
             <Form {...form}>
               <form
@@ -247,13 +266,26 @@ export default function EditProductForm({
               >
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "name_en" : "name"}
-                  key={`name-${formLang}`}
+                  name="name"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Namn ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Namn (sv)</FormLabel>
                       <FormControl>
                         <Input placeholder="Namnge produkten" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="name_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Namn (en)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Name the product" {...field} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -291,16 +323,33 @@ export default function EditProductForm({
 
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "description_en" : "description"}
-                  key={`description-${formLang}`}
+                  name="description"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Beskrivning ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (sv)</FormLabel>
                       <FormControl>
                         <RichTextEditor
                           value={field.value || ""}
                           onChange={field.onChange}
                           placeholder="Skriv produktbeskrivning..."
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="description_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Beskrivning (en)</FormLabel>
+                      <FormControl>
+                        <RichTextEditor
+                          value={field.value || ""}
+                          onChange={field.onChange}
+                          placeholder="Write product description..."
                         />
                       </FormControl>
                       <FormMessage />

--- a/src/app/(admin)/admin/products/components/ManageCategoryDialog.tsx
+++ b/src/app/(admin)/admin/products/components/ManageCategoryDialog.tsx
@@ -12,7 +12,7 @@ import {
   X,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -120,6 +120,16 @@ export default function ManageCategoriesDialog({ categories }: Props) {
     }
     setPendingDelete(null);
   }
+
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.name) {
+      setFormLang("sv");
+    } else if (errors.name_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   return (
     <Dialog
@@ -243,7 +253,7 @@ export default function ManageCategoriesDialog({ categories }: Props) {
               })}
             </div>
 
-            <div className={`rounded-lg border-t pt-4 mt-2`}>
+            <div>
               {editingCategory && (
                 <div className="flex items-center justify-between mb-3 rounded-md bg-brand/10 border border-brand/30 px-3 py-2">
                   <p className="text-sm font-medium text-brand">
@@ -261,12 +271,16 @@ export default function ManageCategoriesDialog({ categories }: Props) {
                 </div>
               )}
 
-              <div className="text-sm my-2">
-                Formulärspråk:{" "}
-                <LanguageSwitcherInput
-                  value={formLang}
-                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-                />
+              <div className="sticky  z-50 flex justify-end pointer-events-none ">
+                <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+                  <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                    Språk:
+                  </span>
+                  <LanguageSwitcherInput
+                    value={formLang ?? "sv"}
+                    setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                  />
+                </div>
               </div>
 
               <Form {...form}>
@@ -276,13 +290,26 @@ export default function ManageCategoriesDialog({ categories }: Props) {
                 >
                   <FormField
                     control={form.control}
-                    name={formLang === "en" ? "name_en" : "name"}
-                    key={`name-${formLang}`}
+                    name="name"
                     render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Namn ({formLang})</FormLabel>
+                      <FormItem className={formLang === "en" ? "hidden" : ""}>
+                        <FormLabel>Kursnamn (sv)</FormLabel>
                         <FormControl>
-                          <Input placeholder="T.ex. Balett" {...field} />
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="name_en"
+                    render={({ field }) => (
+                      <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                        <FormLabel>Kursnamn (en)</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/src/app/(admin)/admin/start/components/StartPageForm.tsx
+++ b/src/app/(admin)/admin/start/components/StartPageForm.tsx
@@ -3,11 +3,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Save } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
 import ImageInput from "@/components/ImageInput";
+import LanguageSwitcherInput from "@/components/LanguageSwitcherInput";
 import Loader from "@/components/Loader";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -29,7 +30,7 @@ import { adminStartPageSchema } from "@/validations/adminforms";
 
 type StartPageFormProps = {
   content: StartPageContent;
-  lang: "sv" | "en";
+  lang: "sv" | "en"; // används nu bara som initialt värde för formLang
 };
 
 type FormValues = z.infer<typeof adminStartPageSchema>;
@@ -104,6 +105,7 @@ const IMAGE_DEFAULTS = {
 export function StartPageForm({ content, lang }: StartPageFormProps) {
   const router = useRouter();
   const [isPending, setIsPending] = useState(false);
+  const [formLang, setFormLang] = useState<"sv" | "en">(lang);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(adminStartPageSchema),
@@ -155,6 +157,25 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
       image3Description_en: content.image3Description_en ?? "",
     },
   });
+
+  const errors = form.formState.errors;
+
+  // Byt automatiskt till det språk som har valideringsfel, precis som i AddCourseForm.
+  // Generisk variant (utan att räkna upp varje fältpar): sv-fel pfrioriteras,
+  // annars visas en om det bara finns fel på _en-fält.
+  useEffect(() => {
+    const errorKeys = Object.keys(errors);
+    if (errorKeys.length === 0) return;
+
+    const hasSvError = errorKeys.some((key) => !key.endsWith("_en"));
+    const hasEnError = errorKeys.some((key) => key.endsWith("_en"));
+
+    if (hasSvError) {
+      setFormLang("sv");
+    } else if (hasEnError) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   const OPTIONAL_IMAGE_FIELDS = ["image1", "image2", "image3"] as const;
 
@@ -211,6 +232,18 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <div className="sticky top-40 z-40 flex justify-end pointer-events-none">
+          <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+            <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+              Språk:
+            </span>
+            <LanguageSwitcherInput
+              value={formLang ?? "sv"}
+              setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+            />
+          </div>
+        </div>
+
         {/* ── Hero ──────────────────────────────────────────────────────── */}
         <Card>
           <CardHeader>
@@ -218,10 +251,6 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {/* Left column – background image preview */}
-
-              {/* do this so i get some space */}
-
               <FormField
                 control={form.control}
                 name="heroImage"
@@ -243,16 +272,15 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                 )}
               />
 
-              {/* Right column – all text fields */}
               <div className="space-y-4">
                 <FormField
                   control={form.control}
-                  name={lang === "en" ? "heroLabel_en" : "heroLabel"}
-                  key={`heroLabel-${lang}`}
+                  name={formLang === "en" ? "heroLabel_en" : "heroLabel"}
+                  key={`heroLabel-${formLang}`}
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel>
-                        Etikett (liten text ovan rubriken) ({lang}){" "}
+                        Etikett (liten text ovan rubriken) ({formLang}){" "}
                       </FormLabel>
                       <FormControl>
                         <Input
@@ -265,20 +293,16 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                   )}
                 />
 
-                {/*  */}
-
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                  {/*  */}
-
                   <FormField
                     control={form.control}
                     name={
-                      lang === "en" ? "heroTitleLine1_en" : "heroTitleLine1"
+                      formLang === "en" ? "heroTitleLine1_en" : "heroTitleLine1"
                     }
-                    key={`heroTitleLine1-${lang}`}
+                    key={`heroTitleLine1-${formLang}`}
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Rubrik – del 1 ({lang})</FormLabel>
+                        <FormLabel>Rubrik – del 1 ({formLang})</FormLabel>
                         <FormControl>
                           <Input placeholder="Dans är" {...field} />
                         </FormControl>
@@ -287,17 +311,17 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                     )}
                   />
 
-                  {/*  */}
-
                   <FormField
                     control={form.control}
                     name={
-                      lang === "en" ? "heroTitleAccent_en" : "heroTitleAccent"
+                      formLang === "en"
+                        ? "heroTitleAccent_en"
+                        : "heroTitleAccent"
                     }
-                    key={`heroTitleAccent-${lang}`}
+                    key={`heroTitleAccent-${formLang}`}
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Rubrik – accent ({lang})</FormLabel>
+                        <FormLabel>Rubrik – accent ({formLang})</FormLabel>
                         <FormControl>
                           <Input placeholder="Passion" {...field} />
                         </FormControl>
@@ -306,17 +330,15 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                     )}
                   />
 
-                  {/*  */}
-
                   <FormField
                     control={form.control}
                     name={
-                      lang === "en" ? "heroTitleLine2_en" : "heroTitleLine2"
+                      formLang === "en" ? "heroTitleLine2_en" : "heroTitleLine2"
                     }
-                    key={`heroTitleLine2-${lang}`}
+                    key={`heroTitleLine2-${formLang}`}
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel>Rubrik – del 2 ({lang})</FormLabel>
+                        <FormLabel>Rubrik – del 2 ({formLang})</FormLabel>
                         <FormControl>
                           <Input placeholder="Och Livet i Rörelse" {...field} />
                         </FormControl>
@@ -325,8 +347,6 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                     )}
                   />
                 </div>
-
-                {/*  */}
 
                 <FormDescription>
                   Visas som:{" "}
@@ -339,15 +359,13 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                   </em>
                 </FormDescription>
 
-                {/*  */}
-
                 <FormField
                   control={form.control}
-                  name={lang === "en" ? "heroSubtext_en" : "heroSubtext"}
-                  key={`heroSubtext-${lang}`}
+                  name={formLang === "en" ? "heroSubtext_en" : "heroSubtext"}
+                  key={`heroSubtext-${formLang}`}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Brödtext ({lang})</FormLabel>
+                      <FormLabel>Brödtext ({formLang})</FormLabel>
                       <FormControl>
                         <Textarea rows={3} {...field} />
                       </FormControl>
@@ -355,14 +373,11 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                     </FormItem>
                   )}
                 />
-
-                {/*  */}
               </div>
             </div>
           </CardContent>
         </Card>
 
-        {/* ── Bildsektion ───────────────────────────────────────────────── */}
         {/* ── Bildsektion ───────────────────────────────────────────────── */}
         <Card>
           <CardHeader>
@@ -434,14 +449,14 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                     <FormField
                       control={form.control}
                       name={
-                        lang === "en"
+                        formLang === "en"
                           ? item.headlineFieldEn
                           : item.headlineField
                       }
-                      key={`${item.headlineField}-${lang}`}
+                      key={`${item.headlineField}-${formLang}`}
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Rubrik ({lang}, valfritt)</FormLabel>
+                          <FormLabel>Rubrik ({formLang}, valfritt)</FormLabel>
                           <FormControl>
                             <Input
                               {...field}
@@ -456,11 +471,15 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
 
                     <FormField
                       control={form.control}
-                      name={lang === "en" ? item.descFieldEn : item.descField}
-                      key={`${item.descField}-${lang}`}
+                      name={
+                        formLang === "en" ? item.descFieldEn : item.descField
+                      }
+                      key={`${item.descField}-${formLang}`}
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Beskrivning ({lang}, valfritt)</FormLabel>
+                          <FormLabel>
+                            Beskrivning ({formLang}, valfritt)
+                          </FormLabel>
                           <FormControl>
                             <Textarea
                               rows={2}
@@ -480,22 +499,19 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
         </Card>
 
         {/* ── Features ──────────────────────────────────────────────────── */}
-
         <Card>
           <CardHeader>
             <CardTitle>Features-sektion</CardTitle>
           </CardHeader>
           <CardContent className="space-y-6">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {/*  */}
-
               <FormField
                 control={form.control}
-                name={lang === "en" ? "featuresTitle_en" : "featuresTitle"}
-                key={`featuresTitle-${lang}`}
+                name={formLang === "en" ? "featuresTitle_en" : "featuresTitle"}
+                key={`featuresTitle-${formLang}`}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Sektionens titel ({lang})</FormLabel>
+                    <FormLabel>Sektionens titel ({formLang})</FormLabel>
                     <FormControl>
                       <Input placeholder="Varför Motion Zone?" {...field} />
                     </FormControl>
@@ -504,15 +520,15 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                 )}
               />
 
-              {/*  */}
-
               <FormField
                 control={form.control}
-                name={lang === "en" ? "featuresSubtext_en" : "featuresSubtext"}
-                key={`featuresSubtext-${lang}`}
+                name={
+                  formLang === "en" ? "featuresSubtext_en" : "featuresSubtext"
+                }
+                key={`featuresSubtext-${formLang}`}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Sektionens underrubrik ({lang})</FormLabel>
+                    <FormLabel>Sektionens underrubrik ({formLang})</FormLabel>
                     <FormControl>
                       <Input {...field} />
                     </FormControl>
@@ -520,11 +536,8 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                   </FormItem>
                 )}
               />
-
-              {/*  */}
             </div>
 
-            {/* Feature cards – horizontal grid on wider screens */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {(
                 [
@@ -538,8 +551,6 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                     <CardTitle className="text-base">{label}</CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-4">
-                    {/*  */}
-
                     <FormField
                       control={form.control}
                       name={`feature${n}Image`}
@@ -561,16 +572,14 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                       )}
                     />
 
-                    {/*  */}
-
                     <FormField
                       control={form.control}
                       name={`feature${n}Title`}
                       render={({ field }) => (
                         <FormItem
-                          className={`${lang === "sv" ? "" : "hidden"}`}
+                          className={`${formLang === "sv" ? "" : "hidden"}`}
                         >
-                          <FormLabel>Titel ({lang})</FormLabel>
+                          <FormLabel>Titel ({formLang})</FormLabel>
                           <FormControl>
                             <Input {...field} />
                           </FormControl>
@@ -583,9 +592,9 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                       name={`feature${n}Title_en`}
                       render={({ field }) => (
                         <FormItem
-                          className={`${lang === "sv" ? "hidden" : ""}`}
+                          className={`${formLang === "sv" ? "hidden" : ""}`}
                         >
-                          <FormLabel>Titel ({lang})</FormLabel>
+                          <FormLabel>Titel ({formLang})</FormLabel>
                           <FormControl>
                             <Input {...field} />
                           </FormControl>
@@ -594,16 +603,14 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                       )}
                     />
 
-                    {/*  */}
-
                     <FormField
                       control={form.control}
                       name={`feature${n}Description`}
                       render={({ field }) => (
                         <FormItem
-                          className={`${lang === "sv" ? "" : "hidden"}`}
+                          className={`${formLang === "sv" ? "" : "hidden"}`}
                         >
-                          <FormLabel>Beskrivning ({lang})</FormLabel>
+                          <FormLabel>Beskrivning ({formLang})</FormLabel>
                           <FormControl>
                             <Textarea rows={2} {...field} />
                           </FormControl>
@@ -617,9 +624,9 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                       name={`feature${n}Description_en`}
                       render={({ field }) => (
                         <FormItem
-                          className={`${lang === "sv" ? "hidden" : ""}`}
+                          className={`${formLang === "sv" ? "hidden" : ""}`}
                         >
-                          <FormLabel>Beskrivning ({lang})</FormLabel>
+                          <FormLabel>Beskrivning ({formLang})</FormLabel>
                           <FormControl>
                             <Textarea rows={2} {...field} />
                           </FormControl>
@@ -627,8 +634,6 @@ export function StartPageForm({ content, lang }: StartPageFormProps) {
                         </FormItem>
                       )}
                     />
-
-                    {/*  */}
                   </CardContent>
                 </Card>
               ))}

--- a/src/app/(admin)/admin/start/page.tsx
+++ b/src/app/(admin)/admin/start/page.tsx
@@ -1,6 +1,5 @@
 import { requireAdmin } from "@/lib/actions/admin";
 import { getStartPageContent } from "@/lib/actions/start-page-actions";
-import AdminLanguageSwitch from "../components/AdminLanguageSwitch";
 import { StartPageForm } from "./components/StartPageForm";
 
 export default async function Page({
@@ -23,12 +22,6 @@ export default async function Page({
       <div className="flex items-center justify-between gap-2">
         <div>
           <span className="font-bold text-2xl">Startsidan</span>
-          <div className="space-y-0">
-            <div className="mt-3 text-sm w-fit">Formulärspråk:</div>
-            <div className="w-fit">
-              <AdminLanguageSwitch value={lang ?? "sv"} />
-            </div>
-          </div>
         </div>
       </div>
       <StartPageForm lang={lang} content={content} />

--- a/src/app/(admin)/admin/studios/components/StudioForm.tsx
+++ b/src/app/(admin)/admin/studios/components/StudioForm.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus, Save } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -55,6 +55,15 @@ export function StudioForm({
   });
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.name || errors.description) {
+      setFormLang("sv");
+    } else if (errors.name_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   async function onSubmit(values: z.infer<typeof adminStudioSchema>) {
     setIsPending(true);
@@ -124,22 +133,25 @@ export function StudioForm({
 
   return (
     <div>
-      <div className="p2 text-sm my-2">
-        Formulärspråk:{" "}
-        <LanguageSwitcherInput
-          value={formLang ?? "sv"}
-          setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-        />
+      <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+          <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+            Språk:
+          </span>
+          <LanguageSwitcherInput
+            value={formLang ?? "sv"}
+            setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+          />
+        </div>
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
           <FormField
             control={form.control}
-            name={formLang === "en" ? "name_en" : "name"}
-            key={`name-${formLang}`}
+            name="name"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Namn ({formLang})</FormLabel>
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Namn (sv)</FormLabel>
                 <FormControl>
                   <Input placeholder="t.ex. Studio 1" {...field} />
                 </FormControl>
@@ -150,16 +162,47 @@ export function StudioForm({
 
           <FormField
             control={form.control}
-            name={formLang === "en" ? "description_en" : "description"}
-            key={`description-${formLang}`}
+            name="name_en"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Beskrivning ({formLang})</FormLabel>
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Namn (en)</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g. Studio 1" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Beskrivning (sv)</FormLabel>
                 <FormControl>
                   <RichTextEditor
                     value={field.value || ""}
                     onChange={field.onChange}
                     placeholder="Skriv beskrivning..."
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Beskrivning (en)</FormLabel>
+                <FormControl>
+                  <RichTextEditor
+                    value={field.value || ""}
+                    onChange={field.onChange}
+                    placeholder="Write description..."
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/app/(admin)/admin/styles/components/StylesForm.tsx
+++ b/src/app/(admin)/admin/styles/components/StylesForm.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus, Save } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type z from "zod";
@@ -55,6 +55,15 @@ export function StylesForm({
   });
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.name || errors.description) {
+      setFormLang("sv");
+    } else if (errors.name_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   async function onSubmit(values: z.infer<typeof adminStyleSchema>) {
     setIsPending(true);
@@ -124,22 +133,25 @@ export function StylesForm({
 
   return (
     <div>
-      <div className="p2 text-sm my-2">
-        Formulärspråk:{" "}
-        <LanguageSwitcherInput
-          value={formLang ?? "sv"}
-          setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-        />
+      <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+          <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+            Språk:
+          </span>
+          <LanguageSwitcherInput
+            value={formLang ?? "sv"}
+            setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+          />
+        </div>
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
           <FormField
             control={form.control}
-            name={formLang === "en" ? "name_en" : "name"}
-            key={`name-${formLang}`}
+            name="name"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Namn ({formLang})</FormLabel>
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Namn (sv)</FormLabel>
                 <FormControl>
                   <Input placeholder="t.ex Latino" {...field} />
                 </FormControl>
@@ -150,16 +162,47 @@ export function StylesForm({
 
           <FormField
             control={form.control}
-            name={formLang === "en" ? "description_en" : "description"}
-            key={`description-${formLang}`}
+            name="name_en"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Beskrivning ({formLang})</FormLabel>
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Namn (en)</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g. Latin" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Beskrivning (sv)</FormLabel>
                 <FormControl>
                   <RichTextEditor
                     value={field.value || ""}
                     onChange={field.onChange}
                     placeholder="Skriv beskrivning..."
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Beskrivning (en)</FormLabel>
+                <FormControl>
+                  <RichTextEditor
+                    value={field.value || ""}
+                    onChange={field.onChange}
+                    placeholder="Write description..."
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/app/(admin)/admin/teachers/teacher-form.tsx
+++ b/src/app/(admin)/admin/teachers/teacher-form.tsx
@@ -73,6 +73,15 @@ export function TeacherForm({
   });
 
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.specialty || errors.description) {
+      setFormLang("sv");
+    } else if (errors.specialty_en || errors.description_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   const selectedUserId = form.watch("userId");
   const selectedUser = availableUsers.find(
@@ -160,12 +169,16 @@ export function TeacherForm({
 
   return (
     <div>
-      <div className="p2 text-sm my-2">
-        Formulärspråk:{" "}
-        <LanguageSwitcherInput
-          value={formLang ?? "sv"}
-          setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-        />
+      <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+        <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+          <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+            Språk:
+          </span>
+          <LanguageSwitcherInput
+            value={formLang ?? "sv"}
+            setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+          />
+        </div>
       </div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
@@ -200,11 +213,10 @@ export function TeacherForm({
 
           <FormField
             control={form.control}
-            name={formLang === "en" ? "specialty_en" : "specialty"}
-            key={`specialty-${formLang}`}
+            name="specialty"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Specialitet ({formLang})</FormLabel>
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Specialitet (sv)</FormLabel>
                 <FormControl>
                   <Input
                     placeholder="t.ex. Balett & Modern dans"
@@ -222,16 +234,54 @@ export function TeacherForm({
 
           <FormField
             control={form.control}
-            name={formLang === "en" ? "description_en" : "description"}
-            key={`description-${formLang}`}
+            name="specialty_en"
             render={({ field }) => (
-              <FormItem>
-                <FormLabel>Beskrivning ({formLang})</FormLabel>
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Specialitet (en)</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="e.g. Ballet & Contemporary dance"
+                    {...field}
+                    value={field.value || ""}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Short description of what the teacher teaches.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem className={formLang === "en" ? "hidden" : ""}>
+                <FormLabel>Beskrivning (sv)</FormLabel>
                 <FormControl>
                   <RichTextEditor
                     value={field.value || ""}
                     onChange={field.onChange}
                     placeholder="Skriv lärarens biografi..."
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                <FormLabel>Beskrivning (en)</FormLabel>
+                <FormControl>
+                  <RichTextEditor
+                    value={field.value || ""}
+                    onChange={field.onChange}
+                    placeholder="Write the teacher biography..."
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/app/(admin)/admin/termin/forms/AddCourseToSchemaForm.tsx
+++ b/src/app/(admin)/admin/termin/forms/AddCourseToSchemaForm.tsx
@@ -153,12 +153,16 @@ export default function AddCourseToSchemaForm({
             <CardDescription></CardDescription>
           </CardHeader>
           <CardContent>
-            <div className="p2 text-sm my-2">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex border-2 items-center gap-2 rounded-full border-brand/70 bg-background/50 pl-3 pr-2.5 py-2.5 shadow-sm backdrop-blur-sm mr-2">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
             <Form {...form}>
               <form

--- a/src/app/(admin)/admin/termin/forms/AddTerminForm.tsx
+++ b/src/app/(admin)/admin/termin/forms/AddTerminForm.tsx
@@ -54,6 +54,15 @@ export default function AddTerminForm({
     },
   });
   const [formLang, setFormLang] = useState(initialLang);
+  const errors = form.formState.errors;
+
+  useEffect(() => {
+    if (errors.name) {
+      setFormLang("sv");
+    } else if (errors.name_en) {
+      setFormLang("en");
+    }
+  }, [errors]);
 
   const router = useRouter();
 
@@ -99,12 +108,16 @@ export default function AddTerminForm({
 
         <Card>
           <CardContent>
-            <div className="p2 text-sm my-2">
-              Formulärspråk:{" "}
-              <LanguageSwitcherInput
-                value={formLang ?? "sv"}
-                setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-              />
+            <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+              <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Språk:
+                </span>
+                <LanguageSwitcherInput
+                  value={formLang ?? "sv"}
+                  setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+                />
+              </div>
             </div>
             <Form {...form}>
               <form
@@ -113,11 +126,24 @@ export default function AddTerminForm({
               >
                 <FormField
                   control={form.control}
-                  name={formLang === "en" ? "name_en" : "name"}
-                  key={`name-${formLang}`}
+                  name="name"
                   render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Namn ({formLang})</FormLabel>
+                    <FormItem className={formLang === "en" ? "hidden" : ""}>
+                      <FormLabel>Namn (sv)</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="name_en"
+                  render={({ field }) => (
+                    <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                      <FormLabel>Namn (en)</FormLabel>
                       <FormControl>
                         <Input {...field} />
                       </FormControl>

--- a/src/app/(admin)/admin/termin/forms/EditTerminFormUI.tsx
+++ b/src/app/(admin)/admin/termin/forms/EditTerminFormUI.tsx
@@ -125,12 +125,16 @@ export function EditTerminFormUI({
   return (
     <Card>
       <CardContent>
-        <div className="p2 text-sm my-2">
-          Formulärspråk:{" "}
-          <LanguageSwitcherInput
-            value={formLang ?? "sv"}
-            setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
-          />
+        <div className="sticky top-4 z-50 flex justify-end pointer-events-none -mb-6">
+          <div className="pointer-events-auto flex items-center gap-2 rounded-full border border-brand/70 bg-background/50 px-3 py-2 shadow-sm backdrop-blur-sm">
+            <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+              Språk:
+            </span>
+            <LanguageSwitcherInput
+              value={formLang ?? "sv"}
+              setValue={(e) => setFormLang(e === "en" ? "en" : "sv")}
+            />
+          </div>
         </div>
         <Form {...form}>
           <form
@@ -139,11 +143,24 @@ export function EditTerminFormUI({
           >
             <FormField
               control={form.control}
-              name={formLang === "en" ? "name_en" : "name"}
-              key={`name-${formLang}`}
+              name="name"
               render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Namn ({formLang})</FormLabel>
+                <FormItem className={formLang === "en" ? "hidden" : ""}>
+                  <FormLabel>Namn (sv)</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="name_en"
+              render={({ field }) => (
+                <FormItem className={formLang === "sv" ? "hidden" : ""}>
+                  <FormLabel>Namn (en)</FormLabel>
                   <FormControl>
                     <Input {...field} />
                   </FormControl>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -44,7 +44,7 @@ export default function LanguageSwitcher() {
   }
 
   return (
-    <div className="flex items-center gap-1 rounded-lg border border-brand/20 p-0.5">
+    <div className="flex items-center justify-center gap-1 rounded-lg border border-brand/20 bg-muted/40 p-1">
       {allLangs.map((lang) => {
         const isActive = currentLang === lang.value;
         return (
@@ -54,13 +54,13 @@ export default function LanguageSwitcher() {
             disabled={isLoading}
             onClick={() => handleChange(lang.value)}
             title={lang.label}
-            className={`flex items-center justify-center w-8 h-7 rounded-md text-xs font-medium transition-all duration-200 ${
+            className={`flex items-center justify-center w-9 h-7 rounded-md text-xs font-medium transition-all duration-200 ${
               isLoading
                 ? "bg-gray-800 text-gray-500"
                 : isActive
-                  ? "bg-brand/10 scale-105"
-                  : "opacity-50 hover:opacity-100 hover:bg-brand/5"
-            } `}
+                  ? "bg-brand text-white shadow-sm scale-105"
+                  : "text-muted-foreground opacity-60 hover:opacity-100 hover:bg-brand/10"
+            }`}
             aria-label={t("language.switchTo", { language: lang.label })}
             aria-pressed={isActive}
           >

--- a/src/components/LanguageSwitcherInput.tsx
+++ b/src/components/LanguageSwitcherInput.tsx
@@ -13,7 +13,7 @@ export default function LanguageSwitcherInput({ value, setValue }: Props) {
   }
 
   return (
-    <div className="flex items-center gap-1 rounded-lg border border-brand/20 p-0.5">
+    <div className="flex items-center justify-center gap-1 p-1 rounded-lg border border-brand/20 bg-muted/40">
       {allLangs.map((lang) => {
         const isActive = value === lang.value;
         return (
@@ -22,10 +22,10 @@ export default function LanguageSwitcherInput({ value, setValue }: Props) {
             type="button"
             onClick={() => handleChange(lang.value)}
             title={lang.label}
-            className={`flex items-center justify-center w-8 h-7 rounded-md text-xs font-medium transition-all duration-200 ${
+            className={`flex items-center justify-center w-9 h-7 rounded-md text-xs font-medium transition-all duration-200 ${
               isActive
-                ? "bg-brand/10 scale-105"
-                : "opacity-50 hover:opacity-100 hover:bg-brand/5"
+                ? "bg-brand text-white shadow-sm scale-105"
+                : "text-muted-foreground opacity-60 hover:opacity-100 hover:bg-brand/10"
             }`}
             aria-label={`Byt till ${lang.label}`}
             aria-pressed={isActive}


### PR DESCRIPTION
## Beskrivning

Denna PR gör språkväljaren sticky i alla formulär så det blir enklare att byta språk även när man är längre ner i formulär. Den inför också en koll om ett formulärfel uppstår på ett visst språk och växlar då till det språket. Vi ändrat också från att ha en och samma input och bara switcha name till att ha egna inputs för _en fälten men gömma de baserat på lang (då det kan ha orskat felet som gjorde att engelska namn ej sparaades för kunden). 



## Relaterade issues

Closes #379 
Closes #375 
Closes #376 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [x] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
