### PR TITLE
395 boka fler kurser & anmälan istället för köp nu

### DIFF
--- a/src/app/(public)/checkout/CheckoutForm.tsx
+++ b/src/app/(public)/checkout/CheckoutForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, InfoIcon, Sparkles } from "lucide-react";
+import { AlertTriangle, Info, InfoIcon, Sparkles } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -640,8 +640,13 @@ export default function CheckoutForm({
 
           <div className="space-y-2 pt-4 border-t">
             <Label htmlFor="paymethod" className="mb-4">
-              {t("checkout.form.method")} ({paymethod})
+              {t("checkout.form.method")}
             </Label>
+
+            <div className="flex items-center gap-2 text-xs text-muted-foreground bg-muted/40 p-2.5 rounded-md border border-border/50">
+              <Info className="inline" />
+              {t("checkout.form.methodInfo")}
+            </div>
             <RadioGroup
               defaultValue="1"
               className="w-fit"

--- a/src/app/(public)/checkout/page.tsx
+++ b/src/app/(public)/checkout/page.tsx
@@ -1,10 +1,17 @@
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+import { SearchIcon } from "lucide-react";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { getMyParticipants } from "@/lib/actions/participants";
 import { getSessionData } from "@/lib/actions/sessiondata";
 import { readCart } from "@/lib/cart";
@@ -111,6 +118,18 @@ export default async function Page() {
             <CardContent>
               <CartSummary />
             </CardContent>
+            <CardFooter className="pt-4 justify-center">
+              <Button
+                asChild
+                size="lg"
+                className="w-full sm:w-auto gap-2 shadow-sm transition-all hover:shadow-md"
+              >
+                <Link href="/courses">
+                  <SearchIcon className="h-4 w-4" />
+                  <span>{t.checkout.searchCourses}</span>
+                </Link>
+              </Button>
+            </CardFooter>
           </Card>
 
           {/* Checkout Form - Only if has items */}

--- a/src/app/(public)/courses/components/AddToCartButton.tsx
+++ b/src/app/(public)/courses/components/AddToCartButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ShoppingBag } from "lucide-react";
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { addToCart } from "@/lib/actions/cart";
+
+interface AddToCartButtonProps {
+  productId: string;
+  productName: string;
+  disabled?: boolean;
+  label: string;
+}
+
+export function AddToCartButton({
+  productId,
+  productName,
+  disabled,
+  label,
+}: AddToCartButtonProps) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(async () => {
+      const result = await addToCart({ productId });
+
+      if (result.success) {
+        toast.success(`${productName}`, {
+          description: "har lagts till i varukorgen",
+          icon: <ShoppingBag className="size-4" />,
+        });
+      } else {
+        toast.error("Kunde inte lägga till produkten", {
+          description: "Produkten är inte längre tillgänglig.",
+        });
+      }
+    });
+  }
+
+  return (
+    <Button
+      type="button"
+      disabled={disabled || isPending}
+      onClick={handleClick}
+      className="w-full bg-brand hover:bg-brand-light text-white font-medium transition-colors duration-200"
+    >
+      {isPending ? "Lägger till..." : label}
+    </Button>
+  );
+}

--- a/src/app/(public)/courses/components/AddToCartButton.tsx
+++ b/src/app/(public)/courses/components/AddToCartButton.tsx
@@ -11,6 +11,7 @@ interface AddToCartButtonProps {
   productName: string;
   disabled?: boolean;
   label: string;
+  lang: "sv" | "en";
 }
 
 export function AddToCartButton({
@@ -18,22 +19,35 @@ export function AddToCartButton({
   productName,
   disabled,
   label,
+  lang = "sv",
 }: AddToCartButtonProps) {
   const [isPending, startTransition] = useTransition();
 
   function handleClick() {
     startTransition(async () => {
-      const result = await addToCart({ productId });
+      const result = await addToCart({
+        productId: productId,
+        redirectTo: "/checkout",
+      });
 
       if (result.success) {
         toast.success(`${productName}`, {
-          description: "har lagts till i varukorgen",
+          description:
+            lang === "sv" ? "har lagts till i varukorgen" : "added to cart",
           icon: <ShoppingBag className="size-4" />,
         });
       } else {
-        toast.error("Kunde inte lägga till produkten", {
-          description: "Produkten är inte längre tillgänglig.",
-        });
+        toast.error(
+          lang === "sv"
+            ? "Kunde inte lägga till produkten"
+            : "Could not add product",
+          {
+            description:
+              lang === "sv"
+                ? "Produkten är inte längre tillgänglig."
+                : "The product is no longer available.",
+          },
+        );
       }
     });
   }
@@ -45,7 +59,7 @@ export function AddToCartButton({
       onClick={handleClick}
       className="w-full bg-brand hover:bg-brand-light text-white font-medium transition-colors duration-200"
     >
-      {isPending ? "Lägger till..." : label}
+      {isPending ? (lang === "sv" ? "Lägger till..." : "Adding...") : label}
     </Button>
   );
 }

--- a/src/app/(public)/courses/page.tsx
+++ b/src/app/(public)/courses/page.tsx
@@ -22,7 +22,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+
 import {
   Card,
   CardContent,
@@ -31,7 +31,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import type { Prisma } from "@/generated/prisma/client";
-import { addToCart } from "@/lib/actions/cart";
+
 import { getCategories } from "@/lib/actions/category-actions";
 import { getProductStats } from "@/lib/actions/purchase-actions";
 import { getStyles } from "@/lib/actions/style-actions";
@@ -42,6 +42,7 @@ import prisma from "@/lib/prisma";
 import { dbToFormTime } from "@/lib/time-convert";
 import { getCourseName, getVeckodag } from "@/lib/tools";
 import { getDictionary } from "@/locales/get-dictionary";
+import { AddToCartButton } from "./components/AddToCartButton";
 import { CourseInfoDialog } from "./components/CourseInfoDialog";
 import { CoursesFilter } from "./components/CoursesFilter";
 import { InfoDialog } from "./components/InfoDialog";
@@ -95,6 +96,7 @@ export const metadata: Metadata = {
 export default async function Page({ searchParams }: Props) {
   const sp = await searchParams;
   const { lang, t } = await getDictionary();
+
   const publicStyles = (await getStyles(lang)).filter((style) => style.active);
   const categories = await getCategories();
   const linkedCourseFilter: Prisma.CourseWhereInput = {
@@ -650,24 +652,12 @@ export default async function Page({ searchParams }: Props) {
                     </CardContent>
 
                     <CardFooter className="pt-4 border-t">
-                      <form
-                        action={async () => {
-                          "use server";
-                          await addToCart({
-                            productId: p.id,
-                            redirectTo: "/checkout",
-                          });
-                        }}
-                        className="w-full"
-                      >
-                        <Button
-                          type="submit"
-                          disabled={p.spotsLeft === 0}
-                          className="w-full bg-brand hover:bg-brand-light text-white font-medium transition-colors duration-200"
-                        >
-                          {t.coursesPage.buyNow}
-                        </Button>
-                      </form>
+                      <AddToCartButton
+                        productId={p.id}
+                        productName={pick(p, "name", lang) as string}
+                        disabled={p.spotsLeft === 0}
+                        label={t.coursesPage.buyNow}
+                      />
                     </CardFooter>
                   </Card>
                 );

--- a/src/app/(public)/courses/page.tsx
+++ b/src/app/(public)/courses/page.tsx
@@ -657,6 +657,7 @@ export default async function Page({ searchParams }: Props) {
                         productName={pick(p, "name", lang) as string}
                         disabled={p.spotsLeft === 0}
                         label={t.coursesPage.buyNow}
+                        lang={lang}
                       />
                     </CardFooter>
                   </Card>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { CookieConsent } from "@/components/CookieConsent";
 import NavBar from "@/components/Navbar";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { getCart } from "@/lib/actions/cart";
 import { getCategories } from "@/lib/actions/category-actions";
 import { auth } from "@/lib/auth";
 import { SessionProvider } from "@/lib/session-provider";
@@ -61,6 +62,8 @@ export default async function RootLayout({
 
   const categories = await getCategories();
 
+  const cartCount = await getCart();
+
   return (
     <html
       lang={lang}
@@ -85,7 +88,12 @@ export default async function RootLayout({
               >
                 Hoppa till huvudinnehållet
               </a>
-              <NavBar categories={categories ?? []} />
+              <NavBar
+                categories={categories ?? []}
+                cartCount={cartCount.items
+                  .map((item) => item.qty)
+                  .reduce((a, b) => a + b, 0)}
+              />
               {children}
               <CookieConsent />
               <Toaster richColors position="top-center" />

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -2,35 +2,16 @@
 
 import { ShoppingCart } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getCart } from "@/lib/actions/cart";
 
 interface CartIconProps {
   showLabel?: boolean;
   onClick?: () => void;
+  count: number;
 }
 
-export default function CartIcon({ showLabel, onClick }: CartIconProps) {
-  const [count, setCount] = useState(0);
-  const pathname = usePathname();
+export default function CartIcon({ showLabel, onClick, count }: CartIconProps) {
   const { t } = useTranslation();
-
-  useEffect(() => {
-    async function fetchCount() {
-      const cart = await getCart();
-      const total = cart.items.reduce((sum, item) => sum + item.qty, 0);
-      setCount(total);
-    }
-    // Fetch cart count on mount and when pathname changes
-    if (pathname) fetchCount();
-
-    // Listen for custom cart updates
-    const handleCartUpdate = () => fetchCount();
-    window.addEventListener("cart-updated", handleCartUpdate);
-    return () => window.removeEventListener("cart-updated", handleCartUpdate);
-  }, [pathname]);
 
   return (
     <Link
@@ -39,7 +20,7 @@ export default function CartIcon({ showLabel, onClick }: CartIconProps) {
       className="relative flex items-center gap-2 text-muted-foreground hover:text-brand transition-colors"
     >
       <span className="relative">
-        <ShoppingCart className="w-5 h-5" />
+        <ShoppingCart className="w-7 h-7" />
         {count > 0 && (
           <span className="absolute -top-2 -right-2 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold rounded-full bg-brand text-white shadow-sm">
             {count > 99 ? "99+" : count}

--- a/src/components/CartIcon.tsx
+++ b/src/components/CartIcon.tsx
@@ -20,9 +20,9 @@ export default function CartIcon({ showLabel, onClick, count }: CartIconProps) {
       className="relative flex items-center gap-2 text-muted-foreground hover:text-brand transition-colors"
     >
       <span className="relative">
-        <ShoppingCart className="w-7 h-7" />
+        <ShoppingCart className="w-6 h-6" />
         {count > 0 && (
-          <span className="absolute -top-2 -right-2 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold rounded-full bg-brand text-white shadow-sm">
+          <span className="absolute -top-2 -right-2 flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[12px] font-bold rounded-full bg-brand/50 text-white shadow-sm">
             {count > 99 ? "99+" : count}
           </span>
         )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -21,6 +21,7 @@ import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "./ui/sheet";
 
 interface NavBarProps {
   categories: Category[];
+  cartCount: number;
 }
 
 interface NavLink {
@@ -30,7 +31,7 @@ interface NavLink {
   categoryId: string | null;
 }
 
-export default function NavBar({ categories }: NavBarProps) {
+export default function NavBar({ categories, cartCount }: NavBarProps) {
   const [sheetOpen, setSheetOpen] = useState(false);
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -202,7 +203,7 @@ export default function NavBar({ categories }: NavBarProps) {
         {/* Desktop Actions (visas först från xl:) */}
         <div className="hidden lg:flex items-center gap-3 shrink-0">
           <div className="hover:scale-110 transition-transform duration-200 mr-1">
-            <CartIcon />
+            <CartIcon count={cartCount} />
           </div>
           <ModeToggle />
           <LanguageSwitcher />
@@ -212,7 +213,7 @@ export default function NavBar({ categories }: NavBarProps) {
         {/* Mobile / Tablet Actions (upp till xl:) */}
         <div className="lg:hidden flex items-center gap-2">
           <div className="hover:scale-110 transition-transform duration-200 mr-1">
-            <CartIcon />
+            <CartIcon count={cartCount} />
           </div>
           <ModeToggle />
           <LanguageSwitcher />

--- a/src/lib/actions/cart.ts
+++ b/src/lib/actions/cart.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { clearCart, readCart, writeCart } from "@/lib/cart";
 import { formatDateToInputStr } from "../date-utils";
@@ -10,8 +11,9 @@ export async function addToCart(params: {
   productId: string;
   qty?: number;
   redirectTo?: string;
-}) {
+}): Promise<{ success: boolean }> {
   const { productId, qty = 1, redirectTo } = params;
+
   if (!productId) throw new Error("productId required");
 
   // Block adding inactive products to cart
@@ -20,7 +22,7 @@ export async function addToCart(params: {
     select: { active: true },
   });
   if (!product || !product.active) {
-    throw new Error("Produkten är inte tillgänglig.");
+    return { success: false };
   }
 
   const cart = await readCart();
@@ -33,7 +35,11 @@ export async function addToCart(params: {
   cart.updatedAt = formatDateToInputStr(new Date());
   await writeCart(cart);
 
+  revalidatePath("/", "layout");
+
   if (redirectTo) redirect(redirectTo);
+
+  return { success: true };
 }
 
 export async function updateCart(params: { productId: string; qty: number }) {

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -144,6 +144,7 @@
   },
   "checkout": {
     "title": "Cart",
+    "searchCourses": "Find more courses or products",
     "subtitleHasItems": "Review your order",
     "subtitleEmpty": "Your cart is empty",
     "yourProducts": "Your products",
@@ -194,6 +195,7 @@
       "duplicateUseExisting": "Use '{{name}}' already saved",
       "duplicateUseSelf": "Mark as \"Myself\" instead",
       "method": "Payment method:",
+      "methodInfo": "You'll be charged after your purchase is approved, it can take around 2 weeks",
       "1": "Invoice",
       "1description": "Full amount",
       "2": "Installments x 2",

--- a/src/locales/langs/en.json
+++ b/src/locales/langs/en.json
@@ -69,7 +69,7 @@
     "lessonCountUnlimited": "Unlimited",
     "lessonCountClip": "{{count}} (clips)",
     "period": "Period: {{from}} - {{to}}",
-    "buyNow": "Buy now →",
+    "buyNow": "Enroll →",
     "noProducts": "No products match the current filters.",
     "filter": {
       "title": "Filter",
@@ -195,7 +195,7 @@
       "duplicateUseExisting": "Use '{{name}}' already saved",
       "duplicateUseSelf": "Mark as \"Myself\" instead",
       "method": "Payment method:",
-      "methodInfo": "You'll be charged after your purchase is approved, it can take around 2 weeks",
+      "methodInfo": "Your invoice will be sent after the first lesson, and it can take around two weeks to arrive.",
       "1": "Invoice",
       "1description": "Full amount",
       "2": "Installments x 2",

--- a/src/locales/langs/sv.json
+++ b/src/locales/langs/sv.json
@@ -69,7 +69,7 @@
     "lessonCountUnlimited": "Obegränsat",
     "lessonCountClip": "{{count}} (klipp)",
     "period": "Period: {{from}} - {{to}}",
-    "buyNow": "Köp nu →",
+    "buyNow": "Anmälan →",
     "noProducts": "Inga produkter hittades med nuvarande filter.",
     "filter": {
       "title": "Filter",
@@ -195,7 +195,7 @@
       "duplicateUseExisting": "Använd '{{name}}' som redan finns",
       "duplicateUseSelf": "Markera som \"Jag själv\" istället",
       "method": "Betalningsmetod:",
-      "methodInfo": "Fakturan skickas efter att ordern har blivit godkänd, det kan ta runt 2 veckor.",
+      "methodInfo": "Obs! Fakturan skickas efter första lektionen och kan ta upp till två veckor innan den kommer.”",
       "1": "Faktura",
       "1description": "Hela beloppet",
       "2": "Delbetalning x 2",

--- a/src/locales/langs/sv.json
+++ b/src/locales/langs/sv.json
@@ -144,6 +144,7 @@
   },
   "checkout": {
     "title": "Varukorg",
+    "searchCourses": "Hitta fler kurser eller produkter",
     "subtitleHasItems": "Granska din beställning",
     "subtitleEmpty": "Din varukorg är tom",
     "yourProducts": "Dina produkter",
@@ -194,6 +195,7 @@
       "duplicateUseExisting": "Använd '{{name}}' som redan finns",
       "duplicateUseSelf": "Markera som \"Jag själv\" istället",
       "method": "Betalningsmetod:",
+      "methodInfo": "Fakturan skickas efter att ordern har blivit godkänd, det kan ta runt 2 veckor.",
       "1": "Faktura",
       "1description": "Hela beloppet",
       "2": "Delbetalning x 2",


### PR DESCRIPTION
## Beskrivning

Denna PR ändrar hur CartIcon läser in cartitems från cookies så den uppdateras rätt ifall man inte kör redirect. En del style ändringar och en "hitta fler kurser" knapp i checkout.

## Relaterade issues

Closes #395 

Closes #391 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
