### PR TITLE
isPaid i order

### DIFF
--- a/prisma/migrations/20260817182332_is_paid_in_order/migration.sql
+++ b/prisma/migrations/20260817182332_is_paid_in_order/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "order" ADD COLUMN     "isPaid" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "paidAt" TIMESTAMP(3);
+
+UPDATE "order"
+SET "isPaid" = true,
+    "paidAt" = COALESCE("paidAt", "updatedAt"),
+    "status" = 'APPROVED'
+WHERE "status" = 'PAID';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -473,6 +473,8 @@ model Order {
 
   // Order status lifecycle
   status       OrderStatus        @default(PENDING_PAYMENT)
+  isPaid       Boolean            @default(false)
+  paidAt       DateTime?
   statusEvents OrderStatusEvent[]
 
   payMethod Int @default(1) // 1 = Faktura hela beloppet, 2 = 2 delbetalningar, 3 = 3 delbetalningar
@@ -549,8 +551,8 @@ enum OrderStatus {
   CREATED
   PENDING_PAYMENT
   AWAITING_APPROVAL
-  PAID
   APPROVED
+  PAID
   COMPLETED
   CANCELLED
 }

--- a/src/app/(admin)/admin/orders/OrdersView.tsx
+++ b/src/app/(admin)/admin/orders/OrdersView.tsx
@@ -15,6 +15,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import type { Course } from "@/generated/prisma/client";
 import { calculateAge, formatDateToInputStr } from "@/lib/date-utils";
 import { formatPrice } from "@/lib/money";
@@ -26,6 +33,8 @@ import { OrderPackageDialog } from "./components/OrderPackageEditor";
 type OrderLite = {
   id: string;
   userId: string;
+  isPaid?: boolean;
+  paidAt?: string | Date | null;
   user?: {
     email?: string | null;
     details?: {
@@ -64,6 +73,7 @@ export default function OrdersView({
   pageSize,
   onApprove,
   onMarkPaid,
+  onTogglePaid,
   onCancel,
   onDelete,
   onSavePackage,
@@ -73,6 +83,7 @@ export default function OrdersView({
   pageSize: number;
   onApprove: (formData: FormData) => void;
   onMarkPaid: (formData: FormData) => void;
+  onTogglePaid: (orderId: string, paid: boolean) => void | Promise<void>;
   onCancel: (formData: FormData) => void;
   onDelete: (orderId: string) => boolean | Promise<boolean>;
   onSavePackage: (
@@ -85,6 +96,11 @@ export default function OrdersView({
   const router = useRouter();
   const sp = useSearchParams();
   const active = (sp.get("status")?.toUpperCase() || defaultStatus).toString();
+  const paidFilterParam = sp.get("paid")?.toUpperCase();
+  const paidFilter =
+    paidFilterParam === "PAID" || paidFilterParam === "UNPAID"
+      ? paidFilterParam
+      : "ALL";
   const [approvingOrderId, setApprovingOrderId] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
@@ -135,14 +151,12 @@ export default function OrdersView({
       ALL: 0,
       PENDING: 0,
       APPROVED: 0,
-      PAID: 0,
       CANCELLED: 0,
     };
     for (const o of orders) {
       const st = String(o.status || "PENDING_PAYMENT");
       if (st === "PENDING_PAYMENT") acc.PENDING += 1;
       else if (st === "APPROVED") acc.APPROVED += 1;
-      else if (st === "PAID") acc.PAID += 1;
       else if (st === "CANCELLED") acc.CANCELLED += 1;
       acc.ALL += 1;
     }
@@ -183,8 +197,14 @@ export default function OrdersView({
       );
     }
 
+    if (paidFilter === "PAID") {
+      result = result.filter((o) => o.isPaid);
+    } else if (paidFilter === "UNPAID") {
+      result = result.filter((o) => !o.isPaid);
+    }
+
     return result;
-  }, [orders, active, searchInput, participantId]);
+  }, [orders, active, searchInput, participantId, paidFilter]);
 
   const totalFiltered = filtered.length;
   const totalPages = Math.max(1, Math.ceil(totalFiltered / pageSize));
@@ -202,8 +222,7 @@ export default function OrdersView({
   const tabs = [
     { id: "ALL", label: "Alla" },
     { id: "PENDING", label: "Väntar" },
-    { id: "PAID", label: "Betalda" },
-    { id: "APPROVED", label: "Godkända" },
+    { id: "APPROVED", label: "Beviljade" },
     { id: "CANCELLED", label: "Avbrutna" },
   ];
 
@@ -219,7 +238,7 @@ export default function OrdersView({
       });
 
       if (hasUnselectedPackage) {
-        toast.error("Kan inte godkänna ordern: Minst ett paketval saknas.");
+        toast.error("Kan inte bevilja ordern: Minst ett paketval saknas.");
         return;
       }
 
@@ -247,8 +266,6 @@ export default function OrdersView({
         return "bg-amber-500/10 text-amber-500";
       case "APPROVED":
         return "bg-emerald-500/10 text-emerald-500";
-      case "PAID":
-        return "bg-blue-500/10 text-blue-500";
       case "CANCELLED":
         return "bg-rose-500/10 text-rose-500";
       default:
@@ -256,14 +273,31 @@ export default function OrdersView({
     }
   };
 
+  const updatePaidFilter = (value: string) => {
+    const params = new URLSearchParams(sp.toString());
+    params.delete("page");
+    if (value === "ALL") {
+      params.delete("paid");
+    } else {
+      params.set("paid", value);
+    }
+    const query = params.toString();
+    router.push(query ? `/admin/orders?${query}` : "/admin/orders");
+  };
+
   return (
     <>
       <div className="flex flex-col md:flex-row gap-4 items-center justify-between">
-        <div className="flex gap-3 text-sm flex-wrap">
-          <form action="/admin/orders" method="GET" className="contents">
+        <div className="flex flex-col gap-2 text-sm">
+          <form
+            action="/admin/orders"
+            method="GET"
+            className="flex flex-wrap gap-2"
+          >
             <input type="hidden" name="page" value="1" />
             <input type="hidden" name="q" value={searchInput} />
             <input type="hidden" name="participantId" value={participantId} />
+            <input type="hidden" name="paid" value={paidFilter} />
             {tabs.map((t) => (
               <button
                 key={t.id}
@@ -299,12 +333,26 @@ export default function OrdersView({
               </Button>
             </div>
           ) : null}
+          <div className="flex items-center gap-2 text-sm md:w-auto">
+            <span className="text-muted-foreground">Visa</span>
+            <Select value={paidFilter} onValueChange={updatePaidFilter}>
+              <SelectTrigger size="sm" className="w-full bg-card md:w-32">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="end">
+                <SelectItem value="ALL">Alla</SelectItem>
+                <SelectItem value="PAID">Betalda</SelectItem>
+                <SelectItem value="UNPAID">Obetalda</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
           <form
             action="/admin/orders"
             method="GET"
             className="relative w-full md:w-64"
           >
             <input type="hidden" name="status" value={active} />
+            <input type="hidden" name="paid" value={paidFilter} />
             <input type="hidden" name="page" value="1" />
             <input
               name="q"
@@ -327,11 +375,12 @@ export default function OrdersView({
               <th className="p-3 text-left font-medium">Paket</th>
               <th className="p-3 text-left font-medium">Total</th>
               <th className="p-3 text-left font-medium">Status</th>
+              <th className="p-3 text-left font-medium">Betald</th>
               <th className="p-3 text-left font-medium">
                 Betalningsalternativ
               </th>
               <th className="p-3 text-left font-medium">Detaljer</th>
-              <th className="p-3 text-left font-medium min-w-[260px]">
+              <th className="p-3 text-left font-medium min-w-[190px]">
                 Åtgärder
               </th>
             </tr>
@@ -340,7 +389,7 @@ export default function OrdersView({
             {paginatedOrders.length === 0 && (
               <tr>
                 <td
-                  colSpan={10}
+                  colSpan={11}
                   className="p-6 text-center text-muted-foreground"
                 >
                   Inga ordrar hittades för valt filter.
@@ -348,6 +397,9 @@ export default function OrdersView({
               </tr>
             )}
             {paginatedOrders.map((o) => {
+              const canMarkPaid = ["PENDING_PAYMENT", "APPROVED"].includes(
+                o.status || "",
+              );
               const participants = Array.from(
                 new Map(
                   (o.orderItems ?? []) // Ensure o.orderItems is an array
@@ -522,6 +574,37 @@ export default function OrdersView({
                       {getOrderStatusLabel(o.status || "PENDING_PAYMENT")}
                     </span>
                   </td>
+                  {/* Betald-kolumn: separat från status */}
+                  <td className="p-3">
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        const newPaid = !o.isPaid;
+                        try {
+                          await onTogglePaid(o.id, newPaid);
+                          toast.success(
+                            newPaid
+                              ? "Markerad som betald"
+                              : "Betalning borttagen",
+                          );
+                        } catch {
+                          toast.error("Kunde inte uppdatera betalningsstatus.");
+                        }
+                      }}
+                      className={`px-2 py-0.5 rounded text-[10px] font-bold uppercase transition-colors ${
+                        o.isPaid
+                          ? "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400"
+                          : "bg-muted text-muted-foreground hover:bg-muted/80"
+                      }`}
+                      title={
+                        o.isPaid
+                          ? "Klicka för att ta bort betalning"
+                          : "Klicka för att markera som betald"
+                      }
+                    >
+                      {o.isPaid ? "Betald" : "Ej betald"}
+                    </button>
+                  </td>
                   <td className="p-3">{getPayMethodTxt(o.payMethod, "sv")}</td>
                   <td className="p-3">
                     <Link
@@ -532,8 +615,8 @@ export default function OrdersView({
                     </Link>
                   </td>
                   <td className="p-3">
-                    <div className="flex items-center justify-end gap-1.5 flex-wrap">
-                      <div className="flex items-center gap-1.5">
+                    <div className="grid w-[168px] grid-cols-2 gap-1.5">
+                      <div className="contents">
                         {/* Bekräftelsedialog för paket med ofullständigt (men giltigt) kursval */}
 
                         {/* Bekräftelsedialog för paket med ofullständigt kursval */}
@@ -554,7 +637,7 @@ export default function OrdersView({
                               <DialogDescription className="pt-2">
                                 Följande paket har färre valda kurser än vad som
                                 ingår. Kunden förlorar de ej valda platserna om
-                                du godkänner.
+                                du beviljar.
                               </DialogDescription>
                             </DialogHeader>
 
@@ -611,54 +694,49 @@ export default function OrdersView({
                                 }}
                                 className="bg-amber-600 hover:bg-amber-700 text-white"
                               >
-                                {isPending ? "Godkänner..." : "Godkänn ändå"}
+                                {isPending ? "Beviljar..." : "Bevilja ändå"}
                               </Button>
                             </DialogFooter>
                           </DialogContent>
                         </Dialog>
 
                         {active !== "PENDING" &&
-                          ["PAID"].includes(o.status || "") && (
+                          ["PENDING_PAYMENT"].includes(o.status || "") && (
                             <Button
                               type="button"
                               size="sm"
-                              className="h-7 px-2.5 text-xs gap-1 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 shadow-none"
+                              className="h-7 w-full px-2 text-xs gap-1 bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400 shadow-none"
                               disabled={approvingOrderId === o.id || isPending}
                               onClick={() => handleApprove(o.id)}
                             >
                               <CheckIcon className="h-3.5 w-3.5" />
                               {approvingOrderId === o.id
-                                ? "Godkänner…"
-                                : "Godkänn"}
+                                ? "Beviljar…"
+                                : "Bevilja"}
                             </Button>
                           )}
 
-                        {active !== "APPROVED" &&
-                          ["PENDING_PAYMENT"].includes(o.status || "") && (
-                            <form action={onMarkPaid}>
-                              <input
-                                type="hidden"
-                                name="orderId"
-                                value={o.id}
-                              />
-                              <Button
-                                type="submit"
-                                size="sm"
-                                className="h-7 px-2.5 text-xs gap-1 bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400 shadow-none"
-                              >
-                                <DollarSignIcon className="h-3.5 w-3.5" />
-                                Betald
-                              </Button>
-                            </form>
-                          )}
-
-                        {["PENDING_PAYMENT"].includes(o.status || "") && (
-                          <form action={onCancel}>
+                        {!o.isPaid && canMarkPaid && (
+                          <form action={onMarkPaid} className="contents">
                             <input type="hidden" name="orderId" value={o.id} />
                             <Button
                               type="submit"
                               size="sm"
-                              className="h-7 px-2.5 text-xs gap-1 bg-rose-500/10 text-rose-600 hover:bg-rose-500/20 dark:text-rose-400 shadow-none"
+                              className="h-7 w-full px-2 text-xs gap-1 bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400 shadow-none"
+                            >
+                              <DollarSignIcon className="h-3.5 w-3.5" />
+                              Betald
+                            </Button>
+                          </form>
+                        )}
+
+                        {["PENDING_PAYMENT"].includes(o.status || "") && (
+                          <form action={onCancel} className="contents">
+                            <input type="hidden" name="orderId" value={o.id} />
+                            <Button
+                              type="submit"
+                              size="sm"
+                              className="h-7 w-full px-2 text-xs gap-1 bg-rose-500/10 text-rose-600 hover:bg-rose-500/20 dark:text-rose-400 shadow-none"
                             >
                               <XIcon className="h-3.5 w-3.5" />
                               Avbryt
@@ -667,9 +745,12 @@ export default function OrdersView({
                         )}
                       </div>
 
-                      <div className="w-px h-5 bg-border" />
-
-                      <DeleteOrderBtn orderId={o.id} onDelete={onDelete} />
+                      <DeleteOrderBtn
+                        orderId={o.id}
+                        onDelete={onDelete}
+                        label="Ta bort"
+                        className="w-full px-2"
+                      />
                     </div>
                   </td>
                 </tr>

--- a/src/app/(admin)/admin/orders/components/DeleteOrderBtn.tsx
+++ b/src/app/(admin)/admin/orders/components/DeleteOrderBtn.tsx
@@ -14,13 +14,18 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
 
 export default function DeleteOrderBtn({
   orderId,
   onDelete,
+  className,
+  label,
 }: {
   orderId: string;
   onDelete: (orderId: string) => boolean | Promise<boolean>;
+  className?: string;
+  label?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [confirmed, setConfirmed] = useState(false);
@@ -53,9 +58,13 @@ export default function DeleteOrderBtn({
       <DialogTrigger asChild>
         <Button
           size="sm"
-          className="h-7 px-2.5 text-xs gap-1 bg-rose-500/10 text-rose-600 hover:bg-rose-500/20 dark:text-rose-400 shadow-none"
+          className={cn(
+            "h-7 px-2.5 text-xs gap-1 bg-rose-500/10 text-rose-600 hover:bg-rose-500/20 dark:text-rose-400 shadow-none",
+            className,
+          )}
         >
           <Trash2 className="h-4.5 w-4.5" />
+          {label}
         </Button>
       </DialogTrigger>
 

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -7,23 +7,24 @@ import {
   cancelOrder,
   createPurchaseFromOrder,
   deleteOrder,
-  markOrderPaid,
+  setOrderPaid,
   updateOrderItemCourseSelections,
 } from "@/lib/actions/orders";
+import type { OrderStatus } from "@/lib/order-status";
 import prisma from "@/lib/prisma";
 import OrdersView from "./OrdersView";
 
-type StatusFilter = "ALL" | "PENDING" | "APPROVED" | "PAID" | "CANCELLED";
+type StatusFilter = "ALL" | "PENDING" | "APPROVED" | "CANCELLED";
 const PAGE_SIZE = 10;
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-type OrderStatus = "PENDING_PAYMENT" | "APPROVED" | "PAID" | "CANCELLED";
-
 type OrderLite = {
   id: string;
   userId: string;
+  isPaid: boolean;
+  paidAt?: Date | null;
   user?: {
     email?: string | null;
     details?: {
@@ -102,7 +103,6 @@ export default async function Page({
     "ALL",
     "PENDING",
     "APPROVED",
-    "PAID",
     "CANCELLED",
   ].includes(raw)
     ? (raw as StatusFilter)
@@ -119,11 +119,16 @@ export default async function Page({
     revalidatePath("/admin/orders");
   }
 
+  async function onTogglePaid(orderId: string, paid: boolean): Promise<void> {
+    "use server";
+    await setOrderPaid(orderId, paid);
+    revalidatePath("/admin/orders");
+  }
+
   async function onMarkPaid(formData: FormData) {
     "use server";
     const orderId = String(formData.get("orderId"));
-    const note = formData.get("note")?.toString();
-    await markOrderPaid(orderId, note);
+    await setOrderPaid(orderId, true);
     revalidatePath("/admin/orders");
   }
 
@@ -169,6 +174,7 @@ export default async function Page({
         pageSize={PAGE_SIZE}
         onApprove={onApprove}
         onMarkPaid={onMarkPaid}
+        onTogglePaid={onTogglePaid}
         onCancel={onCancel}
         onDelete={onDelete}
         onSavePackage={onSavePackage}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -69,7 +69,7 @@ export default async function Page() {
 
   const ordersPaid = await prisma.order.count({
     where: {
-      status: "PAID",
+      isPaid: true,
     },
   });
 
@@ -98,22 +98,22 @@ export default async function Page() {
               <InfoIcon />
             </div>
             <div>
-              <Link href="/admin/orders?status=PAID">
-                Det ligger <strong>{ordersPaid} st</strong> ordrar som behöver
-                godkännas.
+              <Link href="/admin/orders">
+                Det finns <strong>{ordersPaid} st</strong> betalda ordrar.
               </Link>
             </div>
           </div>
         )}
 
         {ordersApp > 0 && (
-          <div className="flex gap-2 text-xl text-green-500">
+          <div className="flex gap-2 text-xl text-amber-500">
             <div>
               <InfoIcon />
             </div>
             <div>
               <Link href="/admin/orders?status=PENDING">
-                Det ligger <strong>{ordersApp} st</strong> obetalda ordrar.
+                Det ligger <strong>{ordersApp} st</strong> ordrar som väntar på
+                att beviljas.
               </Link>
             </div>
           </div>

--- a/src/app/(public)/checkout/success/page.tsx
+++ b/src/app/(public)/checkout/success/page.tsx
@@ -79,7 +79,6 @@ export default async function Page({
                         PENDING_PAYMENT:
                           t.checkout.success.statusPendingPayment,
                         APPROVED: t.checkout.success.statusApproved,
-                        PAID: t.checkout.success.statusPaid,
                         CANCELLED: t.checkout.success.statusCancelled,
                       })}
                     </span>

--- a/src/app/(public)/courses/page.tsx
+++ b/src/app/(public)/courses/page.tsx
@@ -196,7 +196,7 @@ export default async function Page({ searchParams }: Props) {
         productId: { in: productIds },
         order: {
           status: {
-            in: ["PENDING_PAYMENT", "PAID", "APPROVED"],
+            in: ["PENDING_PAYMENT", "APPROVED"],
           },
         },
       },

--- a/src/app/(public)/user/components/OrderHistory.tsx
+++ b/src/app/(public)/user/components/OrderHistory.tsx
@@ -54,7 +54,6 @@ export default function OrderHistory({ orders }: OrderHistoryProps) {
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
 
   const statusLabels = {
-    PAID: t("user.orderHistory.statusPaid"),
     PENDING_PAYMENT: t("user.orderHistory.statusPendingPayment"),
     APPROVED: t("user.orderHistory.statusApproved"),
     CANCELLED: t("user.orderHistory.statusCancelled"),
@@ -64,8 +63,6 @@ export default function OrderHistory({ orders }: OrderHistoryProps) {
     const label = getOrderStatusLabel(status, statusLabels);
 
     switch (status) {
-      case "PAID":
-        return <Badge className="bg-green-500">{label}</Badge>;
       case "PENDING_PAYMENT":
         return <Badge variant="outline">{label}</Badge>;
       case "APPROVED":

--- a/src/lib/actions/admin-stats.ts
+++ b/src/lib/actions/admin-stats.ts
@@ -11,7 +11,7 @@ import {
   startOfStockholmDay,
 } from "../date-utils";
 
-const SUCCESSFUL_ORDER_STATUSES = ["APPROVED", "PAID"] as const;
+const SUCCESSFUL_ORDER_STATUSES = ["APPROVED"] as const;
 
 type SchemaDateRange = {
   customStartDate: Date | null;
@@ -188,7 +188,7 @@ function buildPotentialReservedOrderItemWhere(
   return {
     order: {
       status: {
-        in: ["PENDING_PAYMENT", "PAID", "APPROVED"],
+        in: ["PENDING_PAYMENT", "APPROVED"],
       },
       ...(dateRange && !terminId
         ? {

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -17,7 +17,7 @@ async function requireAdmin() {
 
 export async function updateOrderStatus(
   orderId: string,
-  toStatus: "PENDING_PAYMENT" | "PAID" | "APPROVED" | "CANCELLED",
+  toStatus: "PENDING_PAYMENT" | "APPROVED" | "CANCELLED",
   note?: string,
 ) {
   const adminUserId = await requireAdmin();
@@ -45,11 +45,8 @@ export async function updateOrderStatus(
 
     if (!current) throw new Error("Order not found");
     if (current.status === toStatus) return { success: true };
-    if (
-      toStatus === "CANCELLED" &&
-      ["APPROVED", "PAID"].includes(current.status)
-    ) {
-      throw new Error("Kan inte avbryta en redan godkänd eller betald order.");
+    if (toStatus === "CANCELLED" && current.status === "APPROVED") {
+      throw new Error("Kan inte avbryta en redan beviljad order.");
     }
 
     if (toStatus === "APPROVED") {
@@ -67,13 +64,13 @@ export async function updateOrderStatus(
           selectedCourseIds.length === 0
         ) {
           throw new Error(
-            `Du måste välja max ${maxCourses} olika kurser för "${item.product.name}" eeller minst 1st, innan ordern kan godkännas.`,
+            `Du måste välja max ${maxCourses} olika kurser för "${item.product.name}" eller minst 1st, innan ordern kan beviljas.`,
           );
         }
 
         if (uniqueSelectedIds.size !== selectedCourseIds.length) {
           throw new Error(
-            `Du måste välja olika kurser för "${item.product.name}" innan ordern kan godkännas.`,
+            `Du måste välja olika kurser för "${item.product.name}" innan ordern kan beviljas.`,
           );
         }
 
@@ -86,7 +83,7 @@ export async function updateOrderStatus(
 
         if (invalidCourseId) {
           throw new Error(
-            `En vald kurs i "${item.product.name}" finns inte kopplad till produkten och kan därför inte godkännas.`,
+            `En vald kurs i "${item.product.name}" finns inte kopplad till produkten och kan därför inte beviljas.`,
           );
         }
       }
@@ -119,8 +116,19 @@ export async function approveOrder(orderId: string, note?: string) {
   return updateOrderStatus(orderId, "APPROVED", note);
 }
 
-export async function markOrderPaid(orderId: string, note?: string) {
-  return updateOrderStatus(orderId, "PAID", note);
+/** Sätter betalningsstatus (isPaid) som ett separat fält, oberoende av orderns godkännandestatus. */
+export async function setOrderPaid(orderId: string, paid: boolean) {
+  await requireAdmin();
+  const now = new Date();
+  await prisma.order.update({
+    where: { id: orderId },
+    data: {
+      isPaid: paid,
+      paidAt: paid ? now : null,
+    },
+  });
+  revalidatePath("/admin/orders");
+  return { success: true };
 }
 
 export async function cancelOrder(orderId: string, note?: string) {
@@ -284,8 +292,8 @@ export async function createPurchaseFromOrder(orderId: string) {
     }
 
     // Kontrollera att ordern är i rätt status för att generera köp
-    if (!["APPROVED", "PAID"].includes(order.status)) {
-      throw new Error("Ordern är inte godkänd/betald ännu.");
+    if (order.status !== "APPROVED") {
+      throw new Error("Ordern är inte beviljad ännu.");
     }
 
     // 3. Skapa Purchases för varje OrderItem (en purchase per produkt i ordern)
@@ -394,7 +402,7 @@ export async function createPurchaseFromOrder(orderId: string) {
       const mailHTML = await generateOrderApprovedHtml(order);
       await sendMail(
         email,
-        `Din order är godkänd - Order #${order.id}`,
+        `Din plats är beviljad - Order #${order.id}`,
         mailHTML,
       );
     }

--- a/src/lib/actions/purchase-actions.ts
+++ b/src/lib/actions/purchase-actions.ts
@@ -135,7 +135,6 @@ export async function getProductStats(
           status: {
             in: [
               "PENDING_PAYMENT",
-              "PAID",
               "APPROVED", // Så inte CANCELLED räknas med.
             ],
           },

--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -167,7 +167,7 @@ export async function generateOrderConfirmationHtml(order: OrderForEmail) {
 }
 
 /**
- * Generates an HTML template for an approved order.
+ * Generates an HTML template for a spot-granted (beviljad) order email.
  * @param order The order data (with user and orderItems)
  * @returns HTML string
  */
@@ -192,11 +192,12 @@ export async function generateOrderApprovedHtml(order: OrderForEmail) {
 
   return `
     <div style="font-family: Arial, sans-serif; color: #333; max-width: 600px; margin: 0 auto; border: 1px solid #ddd; padding: 20px; border-radius: 8px;">
-      <h2 style="color: #4CAF50; text-align: center;">Din order är godkänd!</h2>
-      <p>Goda nyheter! Din order <strong>#${order.id}</strong> har blivit godkänd och produkterna är nu skapade!</p>
-      Logga in på webbsidan med kontot ${order.user.email}, och gå till profil-sidan för att hantera bokningar och se dina köpta produkter.
-     <p><strong>Varmt välkommen! 🕺💃</strong></p>
-      
+      <h2 style="color: #4CAF50; text-align: center;">Din plats är beviljad! 🎉</h2>
+      <p>Hej ${order.user.name || "Kund"},</p>
+      <p>Goda nyheter! Du har fått en plats beviljad för order <strong>#${order.id}</strong>. Vi ser fram emot att välkomna dig!</p>
+      <p>Faktura skickas ut till dig <strong>ca 2 veckor efter första lektionen</strong>.</p>
+      <p>Logga in på webbsidan med kontot ${order.user.email} för att se dina detaljer och hantera dina bokningar.</p>
+      <p><strong>Varmt välkommen! 🕺💃</strong></p>
 
       <h3 style="color: #333; border-bottom: 2px solid #eee; padding-bottom: 5px;">Ordersammanfattning</h3>
       <table style="width: 100%; border-collapse: collapse; margin-top: 15px;">

--- a/src/lib/order-status.ts
+++ b/src/lib/order-status.ts
@@ -1,8 +1,8 @@
 export const ORDER_STATUS_LABELS = {
   CREATED: "Skapad",
   AWAITING_APPROVAL: "Inväntar godkännande",
-  PENDING_PAYMENT: "Väntar betalning",
-  APPROVED: "Godkänd",
+  PENDING_PAYMENT: "Väntar på beviljande",
+  APPROVED: "Beviljad",
   PAID: "Betald",
   COMPLETED: "Slutförd",
   CANCELLED: "Avbruten",


### PR DESCRIPTION
## Beskrivning

Den lägger till isPaid som ett fält i databasen för ordrar för att separera det från statusen. PAID finns fortfarande kvar för säkrhetsskull i ENUM. Innehåller migration, som döper om alla "PAID" till "APPROVED".

Lagt in visa Betald / obetald som filter, och betald som egen kolumn med toggleknapp.

Godkänd heter nu beviljad istället enligt önskning. 

## Relaterade issues

Closes #392 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
