### PR TITLE
fix: add account.issuer required by better-auth 1.7 (fixes #403)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@tiptap/pm": "^3.20.0",
         "@tiptap/react": "^3.20.0",
         "@tiptap/starter-kit": "^3.20.0",
-        "better-auth": "^1.6.9",
+        "better-auth": "~1.7.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tiptap/pm": "^3.20.0",
     "@tiptap/react": "^3.20.0",
     "@tiptap/starter-kit": "^3.20.0",
-    "better-auth": "^1.6.9",
+    "better-auth": "~1.7.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.2.1",

--- a/prisma/migrations/20260820113917_add_account_issuer_for_better_auth_1_7/migration.sql
+++ b/prisma/migrations/20260820113917_add_account_issuer_for_better_auth_1_7/migration.sql
@@ -1,0 +1,21 @@
+-- better-auth 1.7 added a required `issuer` column to the account table and
+-- now resolves accounts on (issuer, accountId). Rows written before the
+-- upgrade have no issuer, so sign-in cannot match them and every existing
+-- user is locked out. Add the column nullable, backfill, then enforce.
+
+-- AlterTable
+ALTER TABLE "account" ADD COLUMN "issuer" TEXT;
+
+-- Backfill. Only email/password is configured, so every existing row is the
+-- "credential" provider and gets better-auth's synthetic local issuer
+-- ("local:" + providerId). OAuth providers would instead use
+-- "local:oauth:" + providerId -- add a branch here if a social provider is
+-- ever enabled before this migration runs.
+UPDATE "account"
+SET "issuer" = 'local:' || "providerId"
+WHERE "issuer" IS NULL;
+
+ALTER TABLE "account" ALTER COLUMN "issuer" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "account_issuer_accountId_key" ON "account"("issuer", "accountId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,9 @@ model Session {
 
 model Account {
   id                    String    @id
+  // better-auth >= 1.7 namespaces every account by its issuer and looks the
+  // account up on (issuer, accountId). Credential logins use "local:credential".
+  issuer                String
   accountId             String
   providerId            String
   userId                String
@@ -108,6 +111,7 @@ model Account {
   createdAt             DateTime  @default(now())
   updatedAt             DateTime  @updatedAt
 
+  @@unique([issuer, accountId])
   @@index([userId])
   @@map("account")
 }

--- a/scripts/report-orphaned-accounts.ts
+++ b/scripts/report-orphaned-accounts.ts
@@ -1,0 +1,60 @@
+import "dotenv/config";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../src/generated/prisma/client";
+
+const adapter = new PrismaPg({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const prisma = new PrismaClient({ adapter });
+
+/**
+ * Read-only report. Lists users that have no account row, i.e. users that can
+ * never sign in.
+ *
+ * They exist because better-auth 1.7 started writing an `issuer` column the
+ * Prisma schema did not have: sign-up created the user row, then blew up on
+ * `linkAccount`, leaving the user behind with no credentials. Retrying the
+ * same email then hits "User already exists. Use another email.".
+ *
+ * This script only reads. It deletes nothing and changes nothing -- decide
+ * per user whether to reset the password or remove the row by hand.
+ *
+ * Run with: npx tsx scripts/report-orphaned-accounts.ts
+ */
+async function main() {
+  const orphans = await prisma.user.findMany({
+    where: { accounts: { none: {} } },
+    select: { id: true, email: true, name: true, createdAt: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (orphans.length === 0) {
+    console.log("No orphaned users found.");
+    return;
+  }
+
+  console.log(`${orphans.length} user(s) without an account row:\n`);
+  console.table(
+    orphans.map((user) => ({
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      createdAt: user.createdAt.toISOString(),
+    })),
+  );
+  console.log(
+    "\nNothing was changed. These users cannot sign in until they get an" +
+      "\naccount row -- either let them sign up again on a fresh email, or" +
+      "\nremove the row manually after checking it holds no orders.",
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
Closes #403.

## Problem

The `npm update` in #401 bumped **better-auth 1.6.26 -> 1.7.1**. That release added a **required `issuer` column to the `account` table** and now resolves accounts on `(issuer, accountId)`. The Prisma schema was not updated, which broke production two ways:

- **Sign-up** threw `PrismaClientValidationError: Unknown argument ` + "`issuer`" + ` on `linkAccount`. The user row is written *before* that failure, so it left users behind with no credentials. Retrying the same email then returns "User already exists. Use another email."
- **Sign-in** matches `account.issuer === "local:credential"`. Every pre-existing row had no issuer, so the lookup failed and logged `WARN [Better Auth]: User not found`. **All existing users were locked out**, not just new sign-ups.

Diffing the full table schema between 1.6.26 and 1.7.1 confirms `issuer` is the only field added; the admin plugin schema is unchanged.

## Fix

- `Account.issuer String` + `@@unique([issuer, accountId])` to match better-auth 1.7.
- Migration adds the column nullable, backfills to `"local:" || providerId`, then sets `NOT NULL`. **No rows deleted, no column dropped.**
- `better-auth` pinned to `~1.7.1`. `^1.6.9` admitted every 1.x, which is how `npm update` crossed a minor that carried a breaking schema change.
- Read-only script listing users left without an account row. It deletes nothing.

## Verification

Rehearsed against a verified backup of the production database (67 users / 65 accounts):

| | before | after |
|---|---|---|
| users / accounts / sessions | 67 / 65 / 179 | 67 / 65 / 179 |
| password hashes intact | 65 | 65 |
| accounts matching the 1.7 sign-in lookup | 0 | 65 |

- All 65 accounts are the `credential` provider, so the backfill resolves to `local:credential`.
- Checked for `(issuer, accountId)` duplicates before adding the unique index: none.
- All migrations apply from scratch and `prisma migrate diff` reports no drift.
- `npm ci` installs devDependencies in the build, so `npx prisma migrate deploy` in the build script applies this automatically on deploy.

## Note

2 users are already orphaned by the failed sign-ups and cannot log in. They are left untouched; run `npx tsx scripts/report-orphaned-accounts.ts` to list them.