### PR TITLE
Lägg in dagar i schemat i getcoursename som ons tor tex

### DIFF
--- a/src/app/(admin)/admin/orders/OrdersView.tsx
+++ b/src/app/(admin)/admin/orders/OrdersView.tsx
@@ -29,7 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { Course } from "@/generated/prisma/client";
+import type { Course, Weekday } from "@/generated/prisma/client";
 import { calculateAge, formatDateToInputStr } from "@/lib/date-utils";
 import { formatPrice } from "@/lib/money";
 import { getOrderStatusLabel, type OrderStatus } from "@/lib/order-status";
@@ -37,6 +37,8 @@ import { getCourseName, getPayMethodTxt } from "@/lib/tools";
 import CancelOrderBtn from "./components/CancelOrderBtn";
 import DeleteOrderBtn from "./components/DeleteOrderBtn";
 import { OrderPackageDialog } from "./components/OrderPackageEditor";
+
+type CourseWithSchedule = Course & { schemaItems?: { weekday: Weekday }[] };
 
 type OrderLite = {
   id: string;
@@ -57,7 +59,7 @@ type OrderLite = {
         product: {
           name: string;
           maxCourses?: number | null;
-          courses?: { course: Course }[];
+          courses?: { course: CourseWithSchedule }[];
         };
         participant?: {
           id: string;
@@ -65,7 +67,7 @@ type OrderLite = {
           email: string;
           name: string;
         } | null;
-        courseSelections?: { course: Course }[] | null;
+        courseSelections?: { course: CourseWithSchedule }[] | null;
       }[]
     | null;
   totalPrice: unknown;
@@ -488,7 +490,15 @@ export default function OrdersView({
                           oi.product.courses?.map((c) => c.course) ?? [];
                         const selections =
                           oi.courseSelections?.flatMap((sel) =>
-                            sel.course ? [getCourseName(sel.course)] : [],
+                            sel.course
+                              ? [
+                                  getCourseName(
+                                    sel.course,
+                                    "sv",
+                                    sel.course.schemaItems,
+                                  ),
+                                ]
+                              : [],
                           ) ?? [];
                         const selectedIds =
                           oi.courseSelections?.flatMap((sel) =>

--- a/src/app/(admin)/admin/orders/components/OrderPackageEditor.tsx
+++ b/src/app/(admin)/admin/orders/components/OrderPackageEditor.tsx
@@ -11,13 +11,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import type { Course } from "@/generated/prisma/client";
+import type { Course, Weekday } from "@/generated/prisma/client";
 
 type OrderPackageEditorProps = {
   orderItemId: string;
   productName: string;
   maxCourses: number;
-  courses: Course[];
+  courses: (Course & { schemaItems?: { weekday: Weekday }[] })[];
   selected: string[];
   onSave: (orderItemId: string, selected: string[]) => Promise<void> | void;
   isSaving?: boolean;

--- a/src/app/(admin)/admin/orders/page.tsx
+++ b/src/app/(admin)/admin/orders/page.tsx
@@ -1,6 +1,6 @@
 import { unstable_noStore as noStore, revalidatePath } from "next/cache";
 import { notFound } from "next/navigation";
-import type { Course } from "@/generated/prisma/client";
+import type { Course, Weekday } from "@/generated/prisma/client";
 import { isAdminRole } from "@/lib/actions/admin";
 import {
   approveOrder,
@@ -20,6 +20,8 @@ const PAGE_SIZE = 10;
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+type CourseWithSchedule = Course & { schemaItems?: { weekday: Weekday }[] };
+
 type OrderLite = {
   id: string;
   userId: string;
@@ -38,7 +40,7 @@ type OrderLite = {
         product: {
           name: string;
           maxCourses?: number | null;
-          courses?: { course: Course }[];
+          courses?: { course: CourseWithSchedule }[];
         };
         participant?: {
           id: string;
@@ -48,7 +50,7 @@ type OrderLite = {
         } | null;
         courseSelections?:
           | {
-              course: Course;
+              course: CourseWithSchedule;
             }[]
           | null;
       }[]
@@ -72,13 +74,25 @@ async function getOrders(): Promise<OrderLite[]> {
           product: {
             include: {
               courses: {
-                include: { course: true },
+                include: {
+                  course: {
+                    include: {
+                      schemaItems: { select: { weekday: true } },
+                    },
+                  },
+                },
               },
             },
           },
           participant: true,
           courseSelections: {
-            include: { course: true },
+            include: {
+              course: {
+                include: {
+                  schemaItems: { select: { weekday: true } },
+                },
+              },
+            },
           },
         },
       },

--- a/src/app/(admin)/admin/orders/view/view-client.tsx
+++ b/src/app/(admin)/admin/orders/view/view-client.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState, useTransition } from "react";
 import { toast } from "sonner";
 import { OrderPackageEditor } from "@/app/(admin)/admin/orders/components/OrderPackageEditor";
-import type { Course } from "@/generated/prisma/client";
+import type { Course, Weekday } from "@/generated/prisma/client";
 import {
   adminGetOrder,
   deleteOrder,
@@ -21,6 +21,8 @@ import { formatPrice } from "@/lib/money";
 import { getOrderStatusLabel, type OrderStatus } from "@/lib/order-status";
 import { getPayMethodTxt } from "@/lib/tools";
 
+type CourseWithSchedule = Course & { schemaItems?: { weekday: Weekday }[] };
+
 export type OrderItemLite = {
   id: string;
   price: unknown;
@@ -33,7 +35,7 @@ export type OrderItemLite = {
       | {
           courseId: string;
           courseName?: string | null;
-          course?: Course;
+          course?: CourseWithSchedule;
         }[]
       | null;
   } | null;
@@ -46,7 +48,7 @@ export type OrderItemLite = {
   } | null;
   courseSelections?:
     | {
-        course: Course;
+        course: CourseWithSchedule;
       }[]
     | null;
 };
@@ -514,7 +516,7 @@ export default function OrderDetailsClient() {
                 const sum = unit * (it.count ?? 0);
                 const packCourses = (it.product?.courses ?? [])
                   .map((c) => c.course)
-                  .filter((c): c is Course => !!c);
+                  .filter((c): c is CourseWithSchedule => !!c);
                 const selectedPack = packageSelections[it.id] ?? [];
                 return (
                   <tr key={it.id} className="hover:bg-muted/30">

--- a/src/app/(admin)/admin/products/components/ProductItem.tsx
+++ b/src/app/(admin)/admin/products/components/ProductItem.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export default async function ProductItem({ product, lang }: Props) {
-  const allCourses = await getAllCourses("", true);
+  const allCourses = await getAllCourses("", true, lang);
   const productStats = await getProductStats(product.id);
   const prodCourse: ProdCourse[] = await prisma.productOnCourse.findMany({
     where: { productId: product.id },

--- a/src/app/(admin)/admin/termin/TerminItem.tsx
+++ b/src/app/(admin)/admin/termin/TerminItem.tsx
@@ -28,7 +28,7 @@ export default async function TerminItem({ termin, lang = "sv" }: Props) {
   const schemaItems: SchemaItemWithCourseStudioLessons[] = await getSchemaItems(
     termin.id,
   );
-  const allCourses = await getAllCourses("", true);
+  const allCourses = await getAllCourses("", true, lang);
   const allStudios = await getAllStudios();
 
   return (

--- a/src/app/(public)/checkout/CheckoutForm.tsx
+++ b/src/app/(public)/checkout/CheckoutForm.tsx
@@ -39,7 +39,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import type { Course, Product } from "@/generated/prisma/client";
+import type { Course, Product, Weekday } from "@/generated/prisma/client";
 import { createCheckout } from "@/lib/actions/checkout";
 import {
   getOrCreateParticipant,
@@ -56,7 +56,7 @@ export type CheckoutFormProps = {
     qty: number;
     price: number;
     /** Available courses for SelectPack (populated when maxCourses is set) */
-    courses: Course[];
+    courses: (Course & { schemaItems?: { weekday: Weekday }[] })[];
   }[];
   user: {
     id: string;

--- a/src/app/(public)/checkout/components/SelectPack.tsx
+++ b/src/app/(public)/checkout/components/SelectPack.tsx
@@ -10,12 +10,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { Course } from "@/generated/prisma/client";
+import type { Course, Weekday } from "@/generated/prisma/client";
 import { getCourseName } from "@/lib/tools";
+import { normalizeLang } from "@/locales/config-lang";
 
 interface SelectPackProps {
   maxCourses: number;
-  courses: Course[];
+  courses: (Course & { schemaItems?: { weekday: Weekday }[] })[];
   /** Array of chosen course IDs, e.g. ["id-1", "id-2"] */
   selected: string[];
   onChange: (selected: string[]) => void;
@@ -29,7 +30,8 @@ export function SelectPack({
   selected,
   onChange,
 }: SelectPackProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const lang = normalizeLang(i18n.language);
 
   const slots = Array.from({ length: maxCourses }, (_, i) => selected[i] ?? "");
 
@@ -112,7 +114,7 @@ export function SelectPack({
                         className="text-sm"
                         disabled={otherSelected.includes(c.id)}
                       >
-                        {getCourseName(c)}
+                        {getCourseName(c, lang, c.schemaItems)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/app/(public)/checkout/page.tsx
+++ b/src/app/(public)/checkout/page.tsx
@@ -42,7 +42,13 @@ export default async function Page() {
       where: { id: { in: ids }, active: true },
       include: {
         courses: {
-          include: { course: true },
+          include: {
+            course: {
+              include: {
+                schemaItems: { select: { weekday: true } },
+              },
+            },
+          },
         },
       },
     });

--- a/src/app/(public)/courses/components/CourseInfoDialog.tsx
+++ b/src/app/(public)/courses/components/CourseInfoDialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
+import type { Weekday } from "@/generated/prisma/client";
 import { pick } from "@/lib/i18n/pick";
 import { getCourseName } from "@/lib/tools";
 import type { AppLang } from "@/locales/config-lang";
@@ -29,6 +30,7 @@ type CourseForDialog = {
   description: string;
   description_en?: string | null;
   adult: boolean;
+  schemaItems?: { weekday: Weekday }[];
   teacher: {
     name: string;
     email: string;
@@ -48,7 +50,7 @@ export function CourseInfoDialog({ course }: CourseInfoDialogProps) {
   const id = useId();
   const { t, i18n } = useTranslation();
   const lang: AppLang = normalizeLang(i18n.language);
-  const title = getCourseName(course, lang);
+  const title = getCourseName(course, lang, course.schemaItems);
 
   return (
     <Dialog>

--- a/src/app/(public)/courses/page.tsx
+++ b/src/app/(public)/courses/page.tsx
@@ -319,7 +319,7 @@ export default async function Page({ searchParams }: Props) {
       seenCourseIds.add(course.id);
       courseListItems.push({
         id: course.id,
-        name: getCourseName(course, lang),
+        name: getCourseName(course, lang, course.schemaItems),
       });
     }
   }
@@ -548,7 +548,7 @@ export default async function Page({ searchParams }: Props) {
                                     >
                                       <div className="flex justify-between gap-2 mb-1 items-center">
                                         <div className="font-medium">
-                                          {`${getCourseName(c, lang)}`}
+                                          {`${getCourseName(c, lang, c.schemaItems)}`}
                                         </div>
 
                                         <CourseInfoDialog course={c} />

--- a/src/lib/actions/admin.ts
+++ b/src/lib/actions/admin.ts
@@ -20,6 +20,7 @@ import type {
   Studio,
   Termin,
   User,
+  Weekday,
 } from "@/generated/prisma/client";
 import {
   AddStudentToLessonForm,
@@ -38,6 +39,7 @@ import { generateBookingCancelledHtml, sendMail } from "../mail";
 import { sekToOre } from "../money";
 import prisma from "../prisma";
 import { dbToFormTime, formToDbDate } from "../time-convert";
+import { getCourseName } from "../tools";
 import { getProductStats, handleClips } from "./purchase-actions";
 import { calcRemainingCount, hasRemainingCount } from "./purchase-helpers";
 import { getSessionData } from "./sessiondata";
@@ -110,14 +112,17 @@ export async function getSchemaItems(
 
 /**
  * Listing courses, with filter for course name. (Notice that its not searching for the combined name only the db field name)
+ * Sorted by the full display name (name + age/level/weekday) so same-named
+ * courses land in a predictable order instead of just the raw name field.
  * @param q term for course name.
- * @returns the found courses as Course[]
+ * @returns the found courses, including schemaItems (weekday only)
  * @auth Admin
  */
 export async function getAllCourses(
   q: string = "",
   showInactive = false,
-): Promise<Course[]> {
+  lang: "sv" | "en" = "sv",
+): Promise<(Course & { schemaItems: { weekday: Weekday }[] })[]> {
   const isAdmin = await isAdminRole();
   if (!isAdmin) return [];
 
@@ -133,9 +138,22 @@ export async function getAllCourses(
         : {}),
       ...(showInactive ? {} : { active: true }),
     },
+    include: {
+      schemaItems: { select: { weekday: true } },
+    },
     orderBy: { name: "asc" },
   });
-  return courses;
+
+  // Sortera på hela visningsnamnet (namn + ålder/nivå/veckodag) på valt språk,
+  // så att kurser med samma namn men olika ålder/dag hamnar i en begriplig
+  // ordning istället för att bara sorteras på det råa name-fältet.
+  const collationLocale = lang === "en" ? "en-GB" : "sv-SE";
+  return courses.sort((a, b) =>
+    getCourseName(a, lang, a.schemaItems).localeCompare(
+      getCourseName(b, lang, b.schemaItems),
+      collationLocale,
+    ),
+  );
 }
 
 export async function getAllStudios(): Promise<Studio[]> {

--- a/src/lib/actions/orders.ts
+++ b/src/lib/actions/orders.ts
@@ -150,13 +150,25 @@ export async function adminGetOrder(orderId: string): Promise<OrderDetail> {
           product: {
             include: {
               courses: {
-                include: { course: true },
+                include: {
+                  course: {
+                    include: {
+                      schemaItems: { select: { weekday: true } },
+                    },
+                  },
+                },
               },
             },
           },
           participant: true,
           courseSelections: {
-            include: { course: true },
+            include: {
+              course: {
+                include: {
+                  schemaItems: { select: { weekday: true } },
+                },
+              },
+            },
           },
         },
       },

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,4 +1,4 @@
-import type { Weekday } from "@/generated/prisma/client";
+import type { SchemaItem, Weekday } from "@/generated/prisma/client";
 
 type CourseLike = {
   name: string;
@@ -20,13 +20,77 @@ const WEEKDAYS = [
   "SUNDAY",
 ] as const;
 
-export function getCourseName(course: CourseLike, lang: "sv" | "en" = "sv") {
+export const getWeekdayAsShort = (day: Weekday, lang: "sv" | "en" = "sv") => {
+  if (lang === "en") {
+    switch (day) {
+      case "MONDAY":
+        return "Mon";
+      case "TUESDAY":
+        return "Tue";
+      case "WEDNESDAY":
+        return "Wed";
+      case "THURSDAY":
+        return "Thu";
+      case "FRIDAY":
+        return "Fri";
+      case "SATURDAY":
+        return "Sat";
+      case "SUNDAY":
+        return "Sun";
+      default:
+        return day;
+    }
+  } else {
+    switch (day) {
+      case "MONDAY":
+        return "Mån";
+      case "TUESDAY":
+        return "Tis";
+      case "WEDNESDAY":
+        return "Ons";
+      case "THURSDAY":
+        return "Tor";
+      case "FRIDAY":
+        return "Fre";
+      case "SATURDAY":
+        return "Lör";
+      case "SUNDAY":
+        return "Sön";
+      default:
+        return day;
+    }
+  }
+};
+
+export function getCourseName(
+  course: CourseLike,
+  lang: "sv" | "en" = "sv",
+  schemaItems?: SchemaItem[],
+) {
+  // För att kunna sortera.
+  const WEEKDAY_ORDER: Weekday[] = [
+    "MONDAY",
+    "TUESDAY",
+    "WEDNESDAY",
+    "THURSDAY",
+    "FRIDAY",
+    "SATURDAY",
+    "SUNDAY",
+  ];
+
+  const siDaysStr = schemaItems
+    ? Array.from(new Set(schemaItems.map((si) => si.weekday)))
+        .sort((a, b) => WEEKDAY_ORDER.indexOf(a) - WEEKDAY_ORDER.indexOf(b))
+        .map((day) => getWeekdayAsShort(day, lang))
+        .join(", ")
+    : "";
+
   const ageRange =
     course.minAge && course.minAge > 0
       ? `${course.minAge}${
           course.maxAge && course.maxAge > 0
-            ? `–${course.maxAge} ${lang === "sv" ? ` år` : `years`}` // Använder tankstreck (–) och lägger till " år" här
-            : `+ ${lang === "sv" ? ` år` : `years`}` // Lägger till "+ år" om maxAge saknas
+            ? `–${course.maxAge} ${lang === "sv" ? `år` : `years`}` // Använder tankstreck (–) och lägger till " år" här
+            : `+ ${lang === "sv" ? `år` : `years`}` // Lägger till "+ år" om maxAge saknas
         }${course.adult ? (lang === "sv" ? ` / Vuxen` : ` / Adult`) : ""}`
       : course.adult
         ? lang === "sv"
@@ -45,7 +109,12 @@ export function getCourseName(course: CourseLike, lang: "sv" | "en" = "sv") {
   const baseName =
     lang === "sv" ? course.name : course.name_en?.trim() || course.name; // Fallback på svenskt namn.
 
-  return `${baseName} ${ageRange} ${levelInfo}`.trim();
+  const parts = [baseName, ageRange, levelInfo]
+    .filter(Boolean)
+    .map((s) => s.trim());
+  const daysPart = siDaysStr ? `(${siDaysStr})` : "";
+
+  return [...parts, daysPart].filter(Boolean).join(" ");
 }
 
 export function getWeekdays() {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -1,4 +1,4 @@
-import type { SchemaItem, Weekday } from "@/generated/prisma/client";
+import type { Weekday } from "@/generated/prisma/client";
 
 type CourseLike = {
   name: string;
@@ -65,7 +65,7 @@ export const getWeekdayAsShort = (day: Weekday, lang: "sv" | "en" = "sv") => {
 export function getCourseName(
   course: CourseLike,
   lang: "sv" | "en" = "sv",
-  schemaItems?: SchemaItem[],
+  schemaItems?: { weekday: Weekday }[],
 ) {
   // För att kunna sortera.
   const WEEKDAY_ORDER: Weekday[] = [

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -20,67 +20,51 @@ const WEEKDAYS = [
   "SUNDAY",
 ] as const;
 
-export const getWeekdayAsShort = (day: Weekday, lang: "sv" | "en" = "sv") => {
-  if (lang === "en") {
-    switch (day) {
-      case "MONDAY":
-        return "Mon";
-      case "TUESDAY":
-        return "Tue";
-      case "WEDNESDAY":
-        return "Wed";
-      case "THURSDAY":
-        return "Thu";
-      case "FRIDAY":
-        return "Fri";
-      case "SATURDAY":
-        return "Sat";
-      case "SUNDAY":
-        return "Sun";
-      default:
-        return day;
-    }
-  } else {
-    switch (day) {
-      case "MONDAY":
-        return "Mån";
-      case "TUESDAY":
-        return "Tis";
-      case "WEDNESDAY":
-        return "Ons";
-      case "THURSDAY":
-        return "Tor";
-      case "FRIDAY":
-        return "Fre";
-      case "SATURDAY":
-        return "Lör";
-      case "SUNDAY":
-        return "Sön";
-      default:
-        return day;
-    }
-  }
+const WEEKDAY_LABELS: Record<
+  Weekday,
+  Record<"sv" | "en", { full: string; short: string }>
+> = {
+  MONDAY: {
+    sv: { full: "Måndag", short: "Mån" },
+    en: { full: "Monday", short: "Mon" },
+  },
+  TUESDAY: {
+    sv: { full: "Tisdag", short: "Tis" },
+    en: { full: "Tuesday", short: "Tue" },
+  },
+  WEDNESDAY: {
+    sv: { full: "Onsdag", short: "Ons" },
+    en: { full: "Wednesday", short: "Wed" },
+  },
+  THURSDAY: {
+    sv: { full: "Torsdag", short: "Tor" },
+    en: { full: "Thursday", short: "Thu" },
+  },
+  FRIDAY: {
+    sv: { full: "Fredag", short: "Fre" },
+    en: { full: "Friday", short: "Fri" },
+  },
+  SATURDAY: {
+    sv: { full: "Lördag", short: "Lör" },
+    en: { full: "Saturday", short: "Sat" },
+  },
+  SUNDAY: {
+    sv: { full: "Söndag", short: "Sön" },
+    en: { full: "Sunday", short: "Sun" },
+  },
 };
+
+export const getWeekdayAsShort = (day: Weekday, lang: "sv" | "en" = "sv") =>
+  WEEKDAY_LABELS[day]?.[lang].short ?? day;
 
 export function getCourseName(
   course: CourseLike,
   lang: "sv" | "en" = "sv",
   schemaItems?: { weekday: Weekday }[],
 ) {
-  // För att kunna sortera.
-  const WEEKDAY_ORDER: Weekday[] = [
-    "MONDAY",
-    "TUESDAY",
-    "WEDNESDAY",
-    "THURSDAY",
-    "FRIDAY",
-    "SATURDAY",
-    "SUNDAY",
-  ];
-
   const siDaysStr = schemaItems
     ? Array.from(new Set(schemaItems.map((si) => si.weekday)))
-        .sort((a, b) => WEEKDAY_ORDER.indexOf(a) - WEEKDAY_ORDER.indexOf(b))
+        .sort((a, b) => WEEKDAYS.indexOf(a) - WEEKDAYS.indexOf(b))
         .map((day) => getWeekdayAsShort(day, lang))
         .join(", ")
     : "";
@@ -121,26 +105,8 @@ export function getWeekdays() {
   return [...WEEKDAYS];
 }
 
-export const getVeckodag = (day: Weekday, lang: "sv" | "en" = "sv") => {
-  switch (day) {
-    case "MONDAY":
-      return lang === "sv" ? "Måndag" : "Monday";
-    case "TUESDAY":
-      return lang === "sv" ? "Tisdag" : "Tuesday";
-    case "WEDNESDAY":
-      return lang === "sv" ? "Onsdag" : "Wednesday";
-    case "THURSDAY":
-      return lang === "sv" ? "Torsdag" : "Thursday";
-    case "FRIDAY":
-      return lang === "sv" ? "Fredag" : "Friday";
-    case "SATURDAY":
-      return lang === "sv" ? "Lördag" : "Saturday";
-    case "SUNDAY":
-      return lang === "sv" ? "Söndag" : "Sunday";
-    default:
-      return day; // Returnerar originalsträngen om ingen matchning hittas
-  }
-};
+export const getVeckodag = (day: Weekday, lang: "sv" | "en" = "sv") =>
+  WEEKDAY_LABELS[day]?.[lang].full ?? day;
 
 export function getPayMethodTxt(n: number, lang: "sv" | "en" = "sv") {
   if (lang === "sv")


### PR DESCRIPTION
## Beskrivning

Lägger in dagar som kurserna ligger på i det kombinerade namnet som skapas av getCourseName ifall man skickar med den infon via schemaItems. 
getAllCourses sorterar också resultatet med getCourseName så det blir lättare att hitta rätt kurser när man väljer.
Används på publika sidor och i alla paketväljare. 

## Relaterade issues

Closes #390 

## Typ av ändring

- [ ] Buggfix (icke-brytande ändring som löser ett problem)
- [x] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [x] Jag har testat mina ändringar lokalt
- [x] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [x] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
