### PR TITLE
416 gamla enum som ej används längre för status i order modellen

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npx prisma migrate deploy && npx prisma generate && next build",
     "start": "next start",
     "lint": "biome check",
+    "check:order-status": "tsx --env-file=.env scripts/check-order-status.ts",
     "format": "biome format --write",
     "prepare": "husky",
     "seed": "tsx scripts/seed.ts"

--- a/prisma/migrations/20260902120000_remove_unused_order_statuses/migration.sql
+++ b/prisma/migrations/20260902120000_remove_unused_order_statuses/migration.sql
@@ -1,0 +1,40 @@
+-- AlterEnum: ta bort CREATED, PAID och COMPLETED ur OrderStatus.
+--
+-- Ingen av dem sätts någonstans i koden, och ingen rad i vare sig "order" eller
+-- "order_status_event" har dem. COMPLETED lades till i 20260320092147 och kom
+-- aldrig till användning.
+--
+-- PENDING_PAYMENT står kvar med flit. Den är utgången — 20260825200000 flyttade
+-- alla ordrar ur den och bytte default till AWAITING_APPROVAL — men
+-- "order_status_event" har fortfarande rader med den, och den loggen ska visa
+-- vad som faktiskt hände, inte skrivas om i efterhand.
+--
+-- OBS vid deploy: castarna nedan fäller hela migrationen (transaktionen rullas
+-- tillbaka, inget halvvägs) om målbasen har rader med något av de tre borttagna
+-- värdena. Kör scripts/check-order-status.ts mot basen först.
+
+BEGIN;
+
+CREATE TYPE "OrderStatus_new" AS ENUM ('PENDING_PAYMENT', 'AWAITING_APPROVAL', 'APPROVED', 'CANCELLED');
+
+ALTER TABLE "order" ALTER COLUMN "status" DROP DEFAULT;
+
+ALTER TABLE "order"
+  ALTER COLUMN "status" TYPE "OrderStatus_new"
+  USING ("status"::text::"OrderStatus_new");
+
+ALTER TABLE "order_status_event"
+  ALTER COLUMN "fromStatus" TYPE "OrderStatus_new"
+  USING ("fromStatus"::text::"OrderStatus_new");
+
+ALTER TABLE "order_status_event"
+  ALTER COLUMN "toStatus" TYPE "OrderStatus_new"
+  USING ("toStatus"::text::"OrderStatus_new");
+
+ALTER TYPE "OrderStatus" RENAME TO "OrderStatus_old";
+ALTER TYPE "OrderStatus_new" RENAME TO "OrderStatus";
+DROP TYPE "OrderStatus_old";
+
+ALTER TABLE "order" ALTER COLUMN "status" SET DEFAULT 'AWAITING_APPROVAL';
+
+COMMIT;

--- a/prisma/migrations/20260902120000_remove_unused_order_statuses/migration.sql
+++ b/prisma/migrations/20260902120000_remove_unused_order_statuses/migration.sql
@@ -1,35 +1,41 @@
--- AlterEnum: ta bort CREATED, PAID och COMPLETED ur OrderStatus.
+-- Rensa OrderStatus till bara den levande livscykeln:
+--   AWAITING_APPROVAL -> APPROVED | CANCELLED
 --
--- Ingen av dem sätts någonstans i koden, och ingen rad i vare sig "order" eller
--- "order_status_event" har dem. COMPLETED lades till i 20260320092147 och kom
--- aldrig till användning.
+-- CREATED, PENDING_PAYMENT, PAID och COMPLETED sätts inte längre av någon kod.
+-- CREATED, PAID och COMPLETED finns dessutom inte i en enda rad; COMPLETED
+-- lades till i 20260320092147 och kom aldrig till användning.
 --
--- PENDING_PAYMENT står kvar med flit. Den är utgången — 20260825200000 flyttade
--- alla ordrar ur den och bytte default till AWAITING_APPROVAL — men
--- "order_status_event" har fortfarande rader med den, och den loggen ska visa
--- vad som faktiskt hände, inte skrivas om i efterhand.
+-- PENDING_PAYMENT är däremot inte spårlös: 20260825200000 flyttade alla ordrar
+-- ur statusen, men "order_status_event" har kvar rader med den. Det är en
+-- revisionslogg, och den ska bevara vad som faktiskt hände.
 --
--- OBS vid deploy: castarna nedan fäller hela migrationen (transaktionen rullas
--- tillbaka, inget halvvägs) om målbasen har rader med något av de tre borttagna
--- värdena. Kör scripts/check-order-status.ts mot basen först.
+-- Därför frikopplas loggen från enumet i stället för att något av dem offras:
+-- fromStatus/toStatus blir text. Då kan loggen innehålla utgångna statusar utan
+-- att enumet tvingas bära dem, och utan att historiken skrivs om. Ordertabellen
+-- behåller enumet, eftersom den beskriver nuet och ska vara begränsad.
 
 BEGIN;
 
-CREATE TYPE "OrderStatus_new" AS ENUM ('PENDING_PAYMENT', 'AWAITING_APPROVAL', 'APPROVED', 'CANCELLED');
+-- 1. Loggen blir text. Värdena är oförändrade, bara typen byts.
+ALTER TABLE "order_status_event"
+  ALTER COLUMN "fromStatus" TYPE TEXT USING "fromStatus"::text;
+
+ALTER TABLE "order_status_event"
+  ALTER COLUMN "toStatus" TYPE TEXT USING "toStatus"::text;
+
+-- 2. Enumet byggs om med bara de levande värdena. Nu när loggen är text är
+--    "order"."status" enda kvarvarande användningen.
+--
+--    Castet nedan fäller hela transaktionen om någon rad i "order" har ett
+--    borttaget värde. Inget skrivs halvvägs, men migrationen misslyckas —
+--    kör scripts/check-order-status.ts mot basen först.
+CREATE TYPE "OrderStatus_new" AS ENUM ('AWAITING_APPROVAL', 'APPROVED', 'CANCELLED');
 
 ALTER TABLE "order" ALTER COLUMN "status" DROP DEFAULT;
 
 ALTER TABLE "order"
   ALTER COLUMN "status" TYPE "OrderStatus_new"
   USING ("status"::text::"OrderStatus_new");
-
-ALTER TABLE "order_status_event"
-  ALTER COLUMN "fromStatus" TYPE "OrderStatus_new"
-  USING ("fromStatus"::text::"OrderStatus_new");
-
-ALTER TABLE "order_status_event"
-  ALTER COLUMN "toStatus" TYPE "OrderStatus_new"
-  USING ("toStatus"::text::"OrderStatus_new");
 
 ALTER TYPE "OrderStatus" RENAME TO "OrderStatus_old";
 ALTER TYPE "OrderStatus_new" RENAME TO "OrderStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -553,16 +553,9 @@ model Photo {
 }
 
 // Enum for order lifecycle states
-// I praktiken används bara AWAITING_APPROVAL, APPROVED och CANCELLED (se orders.ts).
-// CREATED, PENDING_PAYMENT, PAID och COMPLETED är deprecated och sätts inte längre.
-// Har kvar de nu för bakåtkompabilitet bara.
+// Hela livscykeln för en order. Inga utgångna värden ligger kvar här — gamla
+// statusar lever bara som text i order_status_event, se den modellen nedan.
 enum OrderStatus {
-  // Utgått, men kvar för historikens skull: order_status_event har rader med
-  // PENDING_PAYMENT och den loggen ska visa vad som faktiskt hände. Migrationen
-  // 20260825200000 flyttade alla ordrar ur statusen och bytte default.
-  PENDING_PAYMENT
-
-  // Den levande livscykeln.
   AWAITING_APPROVAL
   APPROVED
   CANCELLED
@@ -575,8 +568,13 @@ model OrderStatusEvent {
   orderId String
   order   Order  @relation(fields: [orderId], references: [id], onDelete: Cascade)
 
-  fromStatus OrderStatus?
-  toStatus   OrderStatus
+  // Text, inte OrderStatus. En logg ska bevara vad som faktiskt hände, även
+  // statusar som sedan tagits bort ur livscykeln (loggen innehåller t.ex.
+  // PENDING_PAYMENT). Med enum här skulle varje utgången status tvinga sig
+  // kvar i enumet, eller kräva att historiken skrivs om. Skrivningarna görs
+  // bara från updateOrderStatus(), som är typad till OrderStatus.
+  fromStatus String?
+  toStatus   String
 
   changedByUserId String
   changedBy       User   @relation(fields: [changedByUserId], references: [id], onDelete: Restrict)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -557,12 +557,14 @@ model Photo {
 // CREATED, PENDING_PAYMENT, PAID och COMPLETED är deprecated och sätts inte längre.
 // Har kvar de nu för bakåtkompabilitet bara.
 enum OrderStatus {
-  CREATED
+  // Utgått, men kvar för historikens skull: order_status_event har rader med
+  // PENDING_PAYMENT och den loggen ska visa vad som faktiskt hände. Migrationen
+  // 20260825200000 flyttade alla ordrar ur statusen och bytte default.
   PENDING_PAYMENT
+
+  // Den levande livscykeln.
   AWAITING_APPROVAL
   APPROVED
-  PAID
-  COMPLETED
   CANCELLED
 }
 

--- a/scripts/check-order-status.ts
+++ b/scripts/check-order-status.ts
@@ -1,0 +1,98 @@
+/**
+ * Rapporterar vilka OrderStatus-värden som faktiskt förekommer i en databas.
+ *
+ * Körs innan man tar bort värden ur enumet: koden kan sluta skriva ett värde
+ * långt innan raderna med det värdet försvinner, och audit-tabellen
+ * order_status_event behåller dem för alltid.
+ *
+ *   npm run check:order-status                      # mot .env
+ *   DATABASE_URL="postgres://..." npm run check:order-status   # mot annan db
+ *
+ * Läser bara — gör inga ändringar.
+ *
+ * Frågorna är avsiktligt rå SQL och castar till text. Går de via Prisma-klienten
+ * kraschar de så fort schemat och databasen inte har samma enum-värden, vilket
+ * är precis det läge skriptet finns till för att utreda.
+ */
+
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../src/generated/prisma/client";
+
+// Egen klient i stället för src/lib/prisma, så skriptet kan peka på en annan
+// databas via DATABASE_URL utan att dra in appens globala singleton.
+const prisma = new PrismaClient({
+  adapter: new PrismaPg({ connectionString: process.env.DATABASE_URL }),
+});
+
+type CountRow = { value: string | null; count: bigint };
+
+async function report(title: string, rows: CountRow[]) {
+  console.log(`\n${title}`);
+  if (rows.length === 0) {
+    console.log("  (inga rader)");
+    return;
+  }
+  for (const row of rows) {
+    console.log(`  ${row.value ?? "(null)"}: ${row.count}`);
+  }
+}
+
+async function main() {
+  const url = process.env.DATABASE_URL ?? "";
+  const host = url.replace(/:\/\/[^@]*@/, "://<dolt>@");
+  console.log(`Databas: ${host || "(DATABASE_URL saknas)"}`);
+
+  const declared = await prisma.$queryRaw<{ enumlabel: string }[]>`
+    SELECT e.enumlabel
+    FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'OrderStatus'
+    ORDER BY e.enumsortorder
+  `;
+  console.log(
+    `\nDeklarerade värden i enumet: ${declared.map((d) => d.enumlabel).join(", ")}`,
+  );
+
+  const orders = await prisma.$queryRaw<CountRow[]>`
+    SELECT status::text AS value, COUNT(*)::bigint AS count
+    FROM "order" GROUP BY 1 ORDER BY 1
+  `;
+  const to = await prisma.$queryRaw<CountRow[]>`
+    SELECT "toStatus"::text AS value, COUNT(*)::bigint AS count
+    FROM "order_status_event" GROUP BY 1 ORDER BY 1
+  `;
+  const from = await prisma.$queryRaw<CountRow[]>`
+    SELECT "fromStatus"::text AS value, COUNT(*)::bigint AS count
+    FROM "order_status_event" GROUP BY 1 ORDER BY 1
+  `;
+
+  await report("order.status", orders);
+  await report("order_status_event.toStatus", to);
+  await report("order_status_event.fromStatus", from);
+
+  const used = new Set<string>();
+  for (const row of [...orders, ...to, ...from]) {
+    if (row.value) used.add(row.value);
+  }
+
+  const unused = declared
+    .map((d) => d.enumlabel)
+    .filter((label) => !used.has(label));
+
+  console.log(
+    `\nFörekommer inte i datan: ${unused.length > 0 ? unused.join(", ") : "(inga — alla värden förekommer)"}`,
+  );
+  console.log(
+    "OBS: det här säger bara att inga rader har värdet, inte att koden slutat\n" +
+      "använda det. CANCELLED saknas t.ex. i en databas utan avbrutna ordrar men\n" +
+      "sätts fortfarande av cancelOrder(). Kontrollera koden separat innan du tar\n" +
+      "bort något.",
+  );
+}
+
+main()
+  .catch((e) => {
+    console.error("FEL:", e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/(admin)/admin/orders/view/view-client.tsx
+++ b/src/app/(admin)/admin/orders/view/view-client.tsx
@@ -56,8 +56,10 @@ export type OrderItemLite = {
 
 type StatusEventLite = {
   id: string;
-  fromStatus?: OrderStatus | null;
-  toStatus: OrderStatus;
+  // Text, inte OrderStatus: loggen innehåller även statusar som tagits bort ur
+  // livscykeln. getOrderStatusLabel() översätter dem.
+  fromStatus?: string | null;
+  toStatus: string;
   note?: string | null;
   createdAt: string | Date;
   changedByUserId: string;

--- a/src/app/(admin)/admin/students/page.tsx
+++ b/src/app/(admin)/admin/students/page.tsx
@@ -552,14 +552,10 @@ export default async function Page({
   const products = await prisma.product.findMany({ orderBy: { name: "asc" } });
 
   const purchaseFilters: Prisma.PurchaseWhereInput[] = [];
+  // "Ej godkänd ännu" är numera bara AWAITING_APPROVAL: CREATED sattes aldrig
+  // av koden, och 20260825200000 flyttade alla ordrar ur PENDING_PAYMENT.
   const pendingOrderItemFilters: Prisma.OrderItemWhereInput[] = [
-    {
-      order: {
-        status: {
-          in: ["CREATED", "PENDING_PAYMENT", "AWAITING_APPROVAL"],
-        },
-      },
-    },
+    { order: { status: "AWAITING_APPROVAL" } },
   ];
 
   if (product) {

--- a/src/lib/order-status.ts
+++ b/src/lib/order-status.ts
@@ -1,10 +1,10 @@
 export const ORDER_STATUS_LABELS = {
-  CREATED: "Skapad",
-  AWAITING_APPROVAL: "Inväntar godkännande",
+  // Utgången, men kvar för att order_status_event fortfarande har rader med
+  // den och de ska gå att läsa i klartext. Se OrderStatus i schema.prisma.
   PENDING_PAYMENT: "Väntar på beviljande",
+
+  AWAITING_APPROVAL: "Inväntar godkännande",
   APPROVED: "Beviljad",
-  PAID: "Betald",
-  COMPLETED: "Slutförd",
   CANCELLED: "Avbruten",
 } as const;
 

--- a/src/lib/order-status.ts
+++ b/src/lib/order-status.ts
@@ -1,14 +1,28 @@
+/**
+ * Statusar en order kan ha. Det här är den levande livscykeln, och enumet
+ * OrderStatus i schema.prisma innehåller exakt de här värdena.
+ */
 export const ORDER_STATUS_LABELS = {
-  // Utgången, men kvar för att order_status_event fortfarande har rader med
-  // den och de ska gå att läsa i klartext. Se OrderStatus i schema.prisma.
-  PENDING_PAYMENT: "Väntar på beviljande",
-
   AWAITING_APPROVAL: "Inväntar godkännande",
   APPROVED: "Beviljad",
   CANCELLED: "Avbruten",
 } as const;
 
 export type OrderStatus = keyof typeof ORDER_STATUS_LABELS;
+
+/**
+ * Statusar som funnits förr och ligger kvar i orderloggen
+ * (order_status_event). De kan aldrig sättas på en order — de finns bara för
+ * att gamla händelser ska gå att läsa i klartext i stället för som råa
+ * versaler. Loggen lagras som text just för att den ska kunna innehålla
+ * sådant här utan att enumet behöver bära på det.
+ */
+const HISTORICAL_STATUS_LABELS: Record<string, string> = {
+  CREATED: "Skapad",
+  PENDING_PAYMENT: "Väntar på beviljande",
+  PAID: "Betald",
+  COMPLETED: "Slutförd",
+};
 
 export function getOrderStatusLabel(
   status: string,
@@ -19,5 +33,5 @@ export function getOrderStatusLabel(
     return overrides?.[typedStatus] ?? ORDER_STATUS_LABELS[typedStatus];
   }
 
-  return status;
+  return HISTORICAL_STATUS_LABELS[status] ?? status;
 }


### PR DESCRIPTION
## Beskrivning

Stänger #416.

## Vad som togs bort

`OrderStatus` går från sju värden till tre — hela den levande livscykeln:

```
AWAITING_APPROVAL -> APPROVED | CANCELLED
```

`CREATED`, `PENDING_PAYMENT`, `PAID` och `COMPLETED` sätts inte längre av någon kod. `COMPLETED` lades till i `20260320092147` och kom aldrig till användning över huvud taget.

## Den knepiga biten: PENDING_PAYMENT

De tre första var spårlösa — noll rader i både dev och prod. `PENDING_PAYMENT` var det inte. Migrationen `20260825200000` flyttade alla *ordrar* ur statusen, men revisionsloggen `order_status_event` har kvar den:

| Databas | Rader med PENDING_PAYMENT i loggen |
|---|---|
| dev | 4 |
| **prod** | **187** |

Det är huvuddelen av hela orderhistoriken i produktion.

De två uppenbara utvägarna skadar båda något:

- **Skriva om till `AWAITING_APPROVAL`** — loggen skulle beskriva 187 övergångar som aldrig ägt rum
- **Radera raderna** — merparten av orderhistoriken försvinner

Den tidigare kompromissen var att låta värdet ligga kvar i enumet "för historikens skull", men då står ett dött värde kvar i den levande livscykeln — vilket är precis den skuld issuen handlar om.

## Lösningen: loggen frikopplas från enumet

Det egentliga problemet var att en revisionslogg var typad med enumet från början. En logg registrerar *vad som hände*, inklusive tillstånd som sedan pensionerats. Binder man den till dagens livscykel garanterar man den här konflikten varje gång en status tas bort — `PENDING_PAYMENT` var bara första gången det märktes.

`order_status_event.fromStatus/toStatus` lagras därför som **text** i stället för enum:

- Loggen behåller alla 187 raderna orörda
- Enumet innehåller bara de tre levande värdena
- `order.status` behåller enumet — den beskriver *nuet* och ska vara begränsad

Renderingen klarade redan detta: `getOrderStatusLabel` tar en `string` och faller tillbaka på råvärdet. Pensionerade statusar behövde bara en uppslagstabell för att fortsätta visas som "Väntar på beviljande" i stället för råa versaler.

## Följdändringar

- Elevsidans filter för "ej godkänd ännu" listade `["CREATED", "PENDING_PAYMENT", "AWAITING_APPROVAL"]` — nu bara `AWAITING_APPROVAL`, eftersom de andra två inte kan förekomma på en levande order
- Orderns detaljvy typade loggraderna som `OrderStatus` — nu `string`
- Nytt skript `scripts/check-order-status.ts` (`npm run check:order-status`) rapporterar vilka enum-värden en databas faktiskt använder. Läser bara, kan köras mot vilken bas som helst via `DATABASE_URL`. Det var det som avslöjade skillnaden mellan dev:s 4 rader och prod:s 187.

## Verifiering

- Svep av hela repot efter de borttagna värdena — bara kommentarer och den historiska etikettkartan kvar. Träffarna på `"PAID"` i `OrdersView` är `?paid=`-parametern som filtrerar `isPaid`-boolean, inte enumet.
- Alla skrivvägar kontrollerade: orderskapandet sätter ingen status (DB-default), `updateOrderStatus` är snävad till de tre levande värdena
- Alla renderare (`view-client`, `OrderHistory`, checkout success, mail) tar `string` via `getOrderStatusLabel`; `OrderHistory` har `default`-gren
- `tsc --noEmit`, `biome check` rena
- **Migrationen applicerad lokalt** och `npm run build` (som kör `prisma migrate deploy`) går igenom mot den migrerade databasen
- Efterkontroll: enumet har tre värden medan loggen fortfarande innehåller `PENDING_PAYMENT` — omöjligt om kolumnen vore enum, alltså är historiken bevisat bevarad

## Inför deploy

Kontrollen är redan körd mot produktion: `order.status` innehåller bara `APPROVED` (104 rader), inga borttagna värden. Migrationen går alltså igenom.

Skulle något ändras innan deploy fäller castet hela transaktionen — inget skrivs halvvägs, men migrationen misslyckas. Kör `npm run check:order-status` mot basen först om du vill vara säker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Relaterade issues

<!-- Länka till relevanta issues, t.ex. Closes #123 -->

## Typ av ändring

- [x] Buggfix (icke-brytande ändring som löser ett problem)
- [ ] Ny funktion (icke-brytande ändring som lägger till funktionalitet)
- [ ] Brytande ändring (fix eller funktion som gör att befintlig funktionalitet inte fungerar som förväntat)
- [ ] Refaktorering (kodändringar som varken fixar en bugg eller lägger till en funktion)
- [ ] Dokumentation
- [ ] Övrigt (beskriv nedan)

## Checklista

- [ ] Jag har testat mina ändringar lokalt
- [ ] Min kod följer projektets kodstandard (Biome lint + format)
- [ ] Jag har uppdaterat Prisma-schema och skapat migration om det behövs
- [ ] Jag har kontrollerat att `npm run build` fungerar utan fel
- [ ] Jag har lagt till/uppdaterat typer där det behövs

## Skärmdumpar (om relevant)

<!-- Lägg till skärmdumpar som visar UI-ändringar -->

## Ytterligare kommentarer

<!-- Finns det något annat granskaren bör veta? -->
